### PR TITLE
Make sas-token a part of payload in /slice & /slice/metadata

### DIFF
--- a/api/query.go
+++ b/api/query.go
@@ -39,7 +39,7 @@ func (e *Endpoint) sliceMetadata(ctx *gin.Context, query SliceQuery) {
 		return
 	}
 
-	buffer, err := vds.SliceMetadata(conn.Url, conn.Credential, *query.Lineno, axis)
+	buffer, err := vds.SliceMetadata(*conn, *query.Lineno, axis)
 	if err != nil {
 		log.Println(err)
 		ctx.AbortWithStatus(http.StatusInternalServerError)
@@ -63,7 +63,7 @@ func (e *Endpoint) slice(ctx *gin.Context, query SliceQuery) {
 		return
 	}
 
-	buffer, err := vds.Slice(conn.Url, conn.Credential, *query.Lineno, axis)
+	buffer, err := vds.Slice(*conn, *query.Lineno, axis)
 	if err != nil {
 		log.Println(err)
 		ctx.AbortWithStatus(http.StatusInternalServerError)

--- a/api/query.go
+++ b/api/query.go
@@ -33,7 +33,6 @@ func (e *Endpoint) sliceMetadata(ctx *gin.Context, query SliceQuery) {
 	}
 
 	axis, err := vds.GetAxis(strings.ToLower(query.Direction))
-
 	if err != nil {
 		ctx.AbortWithError(http.StatusBadRequest, err)
 		return
@@ -57,7 +56,6 @@ func (e *Endpoint) slice(ctx *gin.Context, query SliceQuery) {
 	}
 
 	axis, err := vds.GetAxis(strings.ToLower(query.Direction))
-
 	if err != nil {
 		ctx.AbortWithError(http.StatusBadRequest, err)
 		return

--- a/api/query.go
+++ b/api/query.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -16,23 +15,6 @@ type SliceQuery struct {
 	Vds       string `form:"vds"       json:"vds"       binding:"required"`
 	Direction string `form:"direction" json:"direction" binding:"required"`
 	Lineno    *int   `form:"lineno"    json:"lineno"    binding:"required"`
-}
-
-func getAxis(direction string) (int, error) {
-	switch direction {
-		case "i":         return vds.AxisI,         nil
-		case "j":         return vds.AxisJ,         nil
-		case "k":         return vds.AxisK,         nil
-		case "inline":    return vds.AxisInline,    nil
-		case "crossline": return vds.AxisCrossline, nil
-		case "depth":     return vds.AxisDepth,     nil
-		case "time":      return vds.AxisTime,      nil
-		case "sample":    return vds.AxisSample,    nil
-		default:
-			options := "i, j, k, inline, crossline or depth/time/sample"
-			msg := "Invalid direction '%s', valid options are: %s"
-			return 0, errors.New(fmt.Sprintf(msg, direction, options))
-	}
 }
 
 type Endpoint struct {
@@ -69,7 +51,7 @@ func (e *Endpoint) sliceMetadata(ctx *gin.Context) {
 		querystr.Encode(),
 	)
 
-	axis, err := getAxis(strings.ToLower(query.Direction))
+	axis, err := vds.GetAxis(strings.ToLower(query.Direction))
 
 	if err != nil {
 		ctx.AbortWithError(http.StatusBadRequest, err)
@@ -112,7 +94,7 @@ func (e *Endpoint) slice(ctx *gin.Context) {
 		querystr.Encode(),
 	)
 
-	axis, err := getAxis(strings.ToLower(query.Direction))
+	axis, err := vds.GetAxis(strings.ToLower(query.Direction))
 
 	if err != nil {
 		ctx.AbortWithError(http.StatusBadRequest, err)

--- a/api/query.go
+++ b/api/query.go
@@ -43,7 +43,7 @@ func (e *Endpoint) Health(ctx *gin.Context) {
 	ctx.String(http.StatusOK, "I am up and running")
 }
 
-func (e *Endpoint) SliceMetadata(ctx *gin.Context) {
+func (e *Endpoint) sliceMetadata(ctx *gin.Context) {
 	var query SliceQuery
 
 	if err := ctx.ShouldBind(&query); err != nil {
@@ -86,7 +86,7 @@ func (e *Endpoint) SliceMetadata(ctx *gin.Context) {
 	ctx.Data(http.StatusOK, "application/json", buffer)
 }
 
-func (e *Endpoint) Slice(ctx *gin.Context) {
+func (e *Endpoint) slice(ctx *gin.Context) {
 	var query SliceQuery
 
 	if err := ctx.ShouldBind(&query); err != nil {
@@ -127,4 +127,20 @@ func (e *Endpoint) Slice(ctx *gin.Context) {
 	}
 
 	ctx.Data(http.StatusOK, "application/octet-stream", buffer)
+}
+
+func (e *Endpoint) SliceMetadataGet(ctx *gin.Context) {
+	e.sliceMetadata(ctx)
+}
+
+func (e *Endpoint) SliceMetadataPost(ctx *gin.Context) {
+	e.sliceMetadata(ctx)
+}
+
+func (e *Endpoint) SliceGet(ctx *gin.Context) {
+	e.slice(ctx)
+}
+
+func (e *Endpoint) SlicePost(ctx *gin.Context) {
+	e.slice(ctx)
 }

--- a/api/query.go
+++ b/api/query.go
@@ -23,10 +23,11 @@ type SliceQuery struct {
 
 type Endpoint struct {
 	StorageURL string
+	Protocol   string
 }
 
 func (e *Endpoint) sliceMetadata(ctx *gin.Context, query SliceQuery) {
-	conn, err := vds.MakeConnection("azure://",  e.StorageURL, query.Vds, query.Sas)
+	conn, err := vds.MakeConnection(e.Protocol,  e.StorageURL, query.Vds, query.Sas)
 	if err != nil {
 		ctx.AbortWithError(http.StatusBadRequest, err)
 		return
@@ -49,7 +50,7 @@ func (e *Endpoint) sliceMetadata(ctx *gin.Context, query SliceQuery) {
 }
 
 func (e *Endpoint) slice(ctx *gin.Context, query SliceQuery) {
-	conn, err := vds.MakeConnection("azure://",  e.StorageURL, query.Vds, query.Sas)
+	conn, err := vds.MakeConnection(e.Protocol, e.StorageURL, query.Vds, query.Sas)
 	if err != nil {
 		ctx.AbortWithError(http.StatusBadRequest, err)
 		return

--- a/api/query.go
+++ b/api/query.go
@@ -21,10 +21,6 @@ type Endpoint struct {
 	StorageURL string
 }
 
-func (e *Endpoint) Health(ctx *gin.Context) {
-	ctx.String(http.StatusOK, "I am up and running")
-}
-
 func (e *Endpoint) sliceMetadata(ctx *gin.Context) {
 	var query SliceQuery
 
@@ -109,6 +105,10 @@ func (e *Endpoint) slice(ctx *gin.Context) {
 	}
 
 	ctx.Data(http.StatusOK, "application/octet-stream", buffer)
+}
+
+func (e *Endpoint) Health(ctx *gin.Context) {
+	ctx.String(http.StatusOK, "I am up and running")
 }
 
 func (e *Endpoint) SliceMetadataGet(ctx *gin.Context) {

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -55,10 +55,10 @@ func main() {
 
 	app := gin.Default()
 	app.GET("/", endpoint.Health)
-	app.GET("slice", endpoint.Slice)
-	app.POST("slice", endpoint.Slice)
-	app.GET("slice/metadata", endpoint.SliceMetadata)
-	app.POST("slice/metadata", endpoint.SliceMetadata)
+	app.GET( "slice", endpoint.SliceGet)
+	app.POST("slice", endpoint.SlicePost)
+	app.GET( "slice/metadata", endpoint.SliceMetadataGet)
+	app.POST("slice/metadata", endpoint.SliceMetadataPost)
 
 	app.Run(fmt.Sprintf(":%s", opts.port))
 }

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -51,6 +51,7 @@ func main() {
 
 	endpoint := api.Endpoint{
 		StorageURL: opts.storageURL,
+		Protocol:   "azure://",
 	}
 
 	app := gin.Default()

--- a/internal/vds/vds.go
+++ b/internal/vds/vds.go
@@ -42,6 +42,34 @@ func GetAxis(direction string) (int, error) {
 	}
 }
 
+type Connection struct {
+	Url        string
+	Credential string
+}
+
+func MakeConnection(
+	protocol,
+	storageURL,
+	vds,
+	sas string,
+) (*Connection, error) {
+	var url  string
+	var cred string
+
+	switch protocol {
+		case "azure://": {
+			cred = fmt.Sprintf("BlobEndpoint=%v;SharedAccessSignature=?%v", storageURL, sas)
+			url  = protocol + vds
+		}
+		default: {
+			msg := fmt.Sprintf("Unknown protocol: %v", protocol)
+			return nil, errors.New(msg)
+		}
+	}
+
+	return &Connection{ Url: url, Credential: cred }, nil
+}
+
 func Slice(vds, credentials string, lineno, direction int) ([]byte, error) {
 	cvds := C.CString(vds)
 	defer C.free(unsafe.Pointer(cvds))

--- a/internal/vds/vds.go
+++ b/internal/vds/vds.go
@@ -11,6 +11,7 @@ import "unsafe"
 
 import (
 	"errors"
+	"fmt"
 )
 
 const (
@@ -23,6 +24,23 @@ const (
 	AxisTime      = C.TIME
 	AxisSample    = C.SAMPLE
 )
+
+func GetAxis(direction string) (int, error) {
+	switch direction {
+		case "i":         return AxisI,         nil
+		case "j":         return AxisJ,         nil
+		case "k":         return AxisK,         nil
+		case "inline":    return AxisInline,    nil
+		case "crossline": return AxisCrossline, nil
+		case "depth":     return AxisDepth,     nil
+		case "time":      return AxisTime,      nil
+		case "sample":    return AxisSample,    nil
+		default:
+			options := "i, j, k, inline, crossline or depth/time/sample"
+			msg := "Invalid direction '%s', valid options are: %s"
+			return 0, errors.New(fmt.Sprintf(msg, direction, options))
+	}
+}
 
 func Slice(vds, credentials string, lineno, direction int) ([]byte, error) {
 	cvds := C.CString(vds)

--- a/internal/vds/vds.go
+++ b/internal/vds/vds.go
@@ -61,6 +61,10 @@ func MakeConnection(
 			cred = fmt.Sprintf("BlobEndpoint=%v;SharedAccessSignature=?%v", storageURL, sas)
 			url  = protocol + vds
 		}
+		case "file://": {
+			cred = ""
+			url  = protocol + vds
+		}
 		default: {
 			msg := fmt.Sprintf("Unknown protocol: %v", protocol)
 			return nil, errors.New(msg)

--- a/internal/vds/vds.go
+++ b/internal/vds/vds.go
@@ -74,15 +74,15 @@ func MakeConnection(
 	return &Connection{ Url: url, Credential: cred }, nil
 }
 
-func Slice(vds, credentials string, lineno, direction int) ([]byte, error) {
-	cvds := C.CString(vds)
-	defer C.free(unsafe.Pointer(cvds))
+func Slice(conn Connection, lineno, direction int) ([]byte, error) {
+	curl := C.CString(conn.Url)
+	defer C.free(unsafe.Pointer(curl))
 
-	ccred := C.CString(credentials)
+	ccred := C.CString(conn.Credential)
 	defer C.free(unsafe.Pointer(ccred))
 
 	result := C.slice(
-		cvds,
+		curl,
 		ccred,
 		C.int(lineno),
 		C.enum_axis(direction),
@@ -99,15 +99,15 @@ func Slice(vds, credentials string, lineno, direction int) ([]byte, error) {
 	return buf, nil
 }
 
-func SliceMetadata(vds, credentials string, lineno, direction int) ([]byte, error) {
-	cvds := C.CString(vds)
-	defer C.free(unsafe.Pointer(cvds))
+func SliceMetadata(conn Connection, lineno, direction int) ([]byte, error) {
+	curl := C.CString(conn.Url)
+	defer C.free(unsafe.Pointer(curl))
 
-	ccred := C.CString(credentials)
+	ccred := C.CString(conn.Credential)
 	defer C.free(unsafe.Pointer(ccred))
 
 	result := C.slice_metadata(
-		cvds,
+		curl,
 		ccred,
 		C.int(lineno),
 		C.enum_axis(direction),

--- a/internal/vds/vds.go
+++ b/internal/vds/vds.go
@@ -12,6 +12,7 @@ import "unsafe"
 import (
 	"errors"
 	"fmt"
+	"strings"
 )
 
 const (
@@ -55,6 +56,14 @@ func MakeConnection(
 ) (*Connection, error) {
 	var url  string
 	var cred string
+
+	if strings.HasPrefix(sas, "?") {
+		sas = sas[1:]
+	}
+
+	if strings.HasSuffix(vds, "/") {
+		vds = vds[:len(vds)-1]
+	}
 
 	switch protocol {
 		case "azure://": {

--- a/internal/vds/vds_test.go
+++ b/internal/vds/vds_test.go
@@ -9,9 +9,18 @@ import (
 	"testing"
 )
 
-const (
-	well_known = "file://../../testdata/wellknown/well_known_default.vds"
-)
+
+func make_well_known() Connection {
+	well_known, _ := MakeConnection(
+		"file://",
+		"",
+		"../../testdata/wellknown/well_known_default.vds",
+		"",
+	)
+	return *well_known
+}
+
+var well_known = make_well_known()
 
 type Axis struct {
 	Annotation string  `json:"annotation"`
@@ -77,7 +86,7 @@ func TestSliceData(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		buf, err := Slice(well_known, "", testcase.lineno, testcase.direction)
+		buf, err := Slice(well_known, testcase.lineno, testcase.direction)
 		if err != nil {
 			t.Errorf(
 				"[case: %v] Failed to fetch slice, err: %v",
@@ -128,7 +137,7 @@ func TestSliceOutOfBounds(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		_, err := Slice(well_known, "", testcase.lineno, testcase.direction)
+		_, err := Slice(well_known, testcase.lineno, testcase.direction)
 		if err == nil {
 			t.Errorf(
 				"[case: %v] Expected slice to fail",
@@ -158,7 +167,7 @@ func TestSliceStridedLineno(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		_, err := Slice(well_known, "", testcase.lineno, testcase.direction)
+		_, err := Slice(well_known, testcase.lineno, testcase.direction)
 		if err == nil {
 			t.Errorf(
 				"[case: %v] Expected slice to fail",
@@ -186,7 +195,7 @@ func TestSliceInvalidAxis(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		_, err := Slice(well_known, "", 0, testcase.direction)
+		_, err := Slice(well_known, 0, testcase.direction)
 
 		if err == nil {
 			t.Errorf(
@@ -224,7 +233,7 @@ func TestDepthAxis(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		_, err := Slice(well_known, "", 0, testcase.direction)
+		_, err := Slice(well_known, 0, testcase.direction)
 
 		if err == nil {
 			t.Errorf(
@@ -290,7 +299,7 @@ func TestSliceMetadataAxisOrdering(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		buf, err := SliceMetadata(well_known, "", testcase.lineno, testcase.direction)
+		buf, err := SliceMetadata(well_known, testcase.lineno, testcase.direction)
 
 		var meta Metadata
 		err = json.Unmarshal(buf, &meta)

--- a/tests/e2e/test_slice.py
+++ b/tests/e2e/test_slice.py
@@ -13,16 +13,16 @@ def getslice(lineno, direction):
     payload = {
         "direction": direction,
         "lineno": lineno,
-        "vds": "{}/{}".format(CONTAINER, VDS)
+        "vds": "{}/{}".format(CONTAINER, VDS),
+        # container sas is not enough?
+        # sas = generate_container_signature(STORAGE_ACCOUNT_NAME, CONTAINER, STORAGE_ACCOUNT_KEY)
+        "sas": generate_account_signature(STORAGE_ACCOUNT_NAME, STORAGE_ACCOUNT_KEY)
     }
 
     print(payload)
 
-    # container sas is not enough?
-    # sas = generate_container_signature(STORAGE_ACCOUNT_NAME, CONTAINER, STORAGE_ACCOUNT_KEY)
-    sas = generate_account_signature(STORAGE_ACCOUNT_NAME, STORAGE_ACCOUNT_KEY)
-    rmeta = requests.post(f'{ENDPOINT}/slice/metadata?{sas}', data = payload)
-    rdata = requests.post(f'{ENDPOINT}/slice?{sas}', data = payload)
+    rmeta = requests.post(f'{ENDPOINT}/slice/metadata', data = payload)
+    rdata = requests.post(f'{ENDPOINT}/slice', data = payload)
     rmeta.raise_for_status()
 
     meta = rmeta.json()


### PR DESCRIPTION
The main work of this PR makes changes to how the slice endpoints accepts parameters. Additionally it does a bit of refactoring and misc work to facilitate these changes, as well as making the code more testable. Tests are left for the next PR

Endpoint /slice and /slice/metadata now expects the following payload:

```
{
    "direction": "inline",
    "lineno": 9961,
    "vds": "container/subpath",
    "sas": "sv=..."
}
```
Both endpoints still support GET and POST methods. The GET methods
expects the payload to be URLescaped and passed as query parameter
'query'. I.e. ?query=urlescape(payload.json). The POST methods expect
the json to be passed in the request body.

Examples
--------

Get:
```
curl -G --data-urlencode query@body.json "http://localhost:8080/slice/metadata"
```
Post:
```
curl -H "Content-Type: application/json" -d @body.json "http://localhost:8080/slice/metadata"
```
where the content of query.json equals the above example payload. This is similar to how GraphQL does POST and GET