### PR TITLE
Add go unit tests to github actions

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -1,0 +1,19 @@
+name: Unit tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  go_tests:
+    name: Run go tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run server tests
+        run: |
+          DOCKER_BUILDKIT=1 docker build -f Dockerfile --target tester .


### PR DESCRIPTION
As we still build openvds from scratch, it takes a long time and might
not be very efficient to run on every PR.