### PR TITLE
Add gzip support to endpoints

### DIFF
--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pborman/getopt/v2"
 	"github.com/swaggo/gin-swagger"
 	"github.com/swaggo/files"
+	"github.com/gin-contrib/gzip"
 
 	_ "github.com/equinor/vds-slice/docs"
 	"github.com/equinor/vds-slice/api"
@@ -66,7 +67,9 @@ func main() {
 	}
 
 	app := gin.Default()
+	app.Use(gzip.Gzip(gzip.BestSpeed))
 	app.Use(api.ErrorHandler)
+
 	app.GET("/", endpoint.Health)
 
 	app.GET( "metadata", endpoint.MetadataGet)

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/gin-contrib/gzip v0.0.6 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.6 // indirect


### PR DESCRIPTION
This commits add support for clients to ask for their response to be
gzip'd by specifying 'gzip' as part of the 'Accept-Encoding' header.

At the moment we priorities compression performance over compression
ratio. Compressing to aggressivly will have a negative impact on
cloud-to-cloud. This might change if we do more benchmarking.

The current compression ratio is about 2 for a farily dense binary
fence.