### PR TITLE
Add secondary environment to radix

### DIFF
--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: radix.equinor.com/v1
 kind: RadixApplication
 metadata:
@@ -8,6 +7,9 @@ spec:
     - name: dev
       build:
         from: radix
+    - name: test
+      build:
+        from: test
   components:
     - name: server
       dockerfileName: Dockerfile
@@ -29,4 +31,17 @@ spec:
               cpu: "2000m"
           horizontalScaling:
             minReplicas: 1
+            maxReplicas: 3
+        - environment: test
+          monitoring: false
+          resources:
+            requests:
+              memory: "1024Mi"
+              cpu: "200m"
+            limits:
+              memory: "2048Mi"
+              cpu: "500m"
+          horizontalScaling:
+            # Radix doesn't scale to 0, so this is just desired intention
+            minReplicas: 0
             maxReplicas: 3


### PR DESCRIPTION
Two environments in this stage are useful when we want to test a special server configuration without disrupting our main environment. Environment can always be stopped whenever it is not needed.

Though I do accept "we do not need it" in case we would forget to manually stop that after each new deploy and whenever it is not used.