### PR TITLE
Remove "vds." prefix from swag annotations

### DIFF
--- a/api/query.go
+++ b/api/query.go
@@ -178,7 +178,7 @@ func (e *Endpoint) Health(ctx *gin.Context) {
 // @Tags     metadata
 // @Param    query  query  string  True  "Urlencoded/escaped MetadataRequest"
 // @Produce  json
-// @Success  200 {object} vds.Metadata
+// @Success  200 {object} Metadata
 // @Failure  400 {object} ErrorResponse "Request is invalid"
 // @Failure  500 {object} ErrorResponse "openvds failed to process the request"
 // @Router   /metadata  [get]
@@ -196,7 +196,7 @@ func (e *Endpoint) MetadataGet(ctx *gin.Context) {
 // @Tags     metadata
 // @Param    body  body  MetadataRequest  True  "Request parameters"
 // @Produce  json
-// @Success  200 {object} vds.Metadata
+// @Success  200 {object} Metadata
 // @Failure  400 {object} ErrorResponse "Request is invalid"
 // @Failure  500 {object} ErrorResponse "openvds failed to process the request"
 // @Router   /metadata  [post]
@@ -215,7 +215,7 @@ func (e *Endpoint) MetadataPost(ctx *gin.Context) {
 // @Tags     slice
 // @Param    query  query  string  True  "Urlencoded/escaped SliceRequest"
 // @Produce  multipart/mixed
-// @Success  200 {object} vds.SliceMetadata "(Example below only for metadata part)"
+// @Success  200 {object} SliceMetadata "(Example below only for metadata part)"
 // @Failure  400 {object} ErrorResponse "Request is invalid"
 // @Failure  500 {object} ErrorResponse "openvds failed to process the request"
 // @Router   /slice  [get]
@@ -235,7 +235,7 @@ func (e *Endpoint) SliceGet(ctx *gin.Context) {
 // @Param    body  body  SliceRequest  True  "Query Parameters"
 // @Accept   application/json
 // @Produce  multipart/mixed
-// @Success  200 {object} vds.SliceMetadata "(Example below only for metadata part)"
+// @Success  200 {object} SliceMetadata "(Example below only for metadata part)"
 // @Failure  400 {object} ErrorResponse "Request is invalid"
 // @Failure  500 {object} ErrorResponse "openvds failed to process the request"
 // @Router   /slice  [post]
@@ -255,7 +255,7 @@ func (e *Endpoint) SlicePost(ctx *gin.Context) {
 // @Param    query  query  string  True  "Urlencoded/escaped FenceResponse"
 // @Accept   application/json
 // @Produce  multipart/mixed
-// @Success  200 {object} vds.FenceMetadata "(Example below only for metadata part)"
+// @Success  200 {object} FenceMetadata "(Example below only for metadata part)"
 // @Failure  400 {object} ErrorResponse "Request is invalid"
 // @Failure  500 {object} ErrorResponse "openvds failed to process the request"
 // @Router   /fence  [get]
@@ -275,7 +275,7 @@ func (e *Endpoint) FenceGet(ctx *gin.Context) {
 // @Param    body  body  FenceRequest  True  "Request Parameters"
 // @Accept   application/json
 // @Produce  multipart/mixed
-// @Success  200 {object} vds.FenceMetadata "(Example below only for metadata part)"
+// @Success  200 {object} FenceMetadata "(Example below only for metadata part)"
 // @Failure  400 {object} ErrorResponse "Request is invalid"
 // @Failure  500 {object} ErrorResponse "openvds failed to process the request"
 // @Router   /fence  [post]


### PR DESCRIPTION
Since swag 1.8.8 the usage of the "swagger names" inside the documentation is enforced. This forbids the use of the "vds." prefix from swag annotations.

Closes #59 