### PR TITLE
Golang static checker

### DIFF
--- a/.github/workflows/analyzer.yaml
+++ b/.github/workflows/analyzer.yaml
@@ -1,0 +1,18 @@
+name: "Code analyzers"
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  go:
+    name: "Run golang Staticcheck"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run check
+        run: |
+          DOCKER_BUILDKIT=1 docker build -f Dockerfile --target static_analyzer .

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ COPY . .
 ARG CGO_CPPFLAGS="-I/open-vds/Dist/OpenVDS/include"
 ARG CGO_LDFLAGS="-L/open-vds/Dist/OpenVDS/lib"
 RUN go build -a ./...
-RUN GOBIN=/tools go install github.com/swaggo/swag/cmd/swag@latest
+RUN GOBIN=/tools go install github.com/swaggo/swag/cmd/swag@v1.8.4
 RUN /tools/swag init -g cmd/query/main.go --md docs
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM golang:1.18-alpine as openvds
 RUN apk --no-cache add \
+    curl \
     git \
     g++ \
     gcc \
@@ -50,6 +51,17 @@ ARG CGO_LDFLAGS="-L/open-vds/Dist/OpenVDS/lib"
 ARG LD_LIBRARY_PATH=/open-vds/Dist/OpenVDS/lib:$LD_LIBRARY_PATH
 ARG OPENVDS_AZURESDKFORCPP=1
 RUN go test -race ./...
+
+
+FROM builder as static_analyzer
+ARG CGO_CPPFLAGS="-I/open-vds/Dist/OpenVDS/include"
+ARG CGO_LDFLAGS="-L/open-vds/Dist/OpenVDS/lib"
+ARG LD_LIBRARY_PATH=/open-vds/Dist/OpenVDS/lib:$LD_LIBRARY_PATH
+RUN curl \
+    -L https://github.com/dominikh/go-tools/releases/download/v0.3.3/staticcheck_linux_amd64.tar.gz \
+    -o staticcheck-0.3.3.tar.gz
+RUN tar xf staticcheck-0.3.3.tar.gz
+RUN ./staticcheck/staticcheck ./...
 
 
 FROM builder as installer


### PR DESCRIPTION
closes #64 

Repeating args becomes annoying, but I think I failed to find a better solution.
There was something about declaring them at the very top of the docker file, but that seemed too far away from the context.

Not sure if we can do that any faster. The other PR introduces option to run E2E tests using a built image stored in azure, but as far as I recall that approach can't be used for unit tests mostly because secrets are unavailable in github PRs and publicly org-hosting someone else's image is strange.

Feel free to do with this PR whatever you want to :smile:  Submitting it now in case fixes would fit nice into your planned refactoring.