### PR TITLE
Pin Alpine Linux version of Docker container to Alpine Linux 3.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine as openvds
+FROM golang:1.18-alpine3.16 as openvds
 RUN apk --no-cache add \
     curl \
     git \


### PR DESCRIPTION
The Go container used by the Dockerfile has been updated to use a new release of Alpine Linux (3.17). This breaks the installation procedure of OpenVDS within the container as OpenSSL v3 instead of v1 is used within the new release. Thus we pin the Alpine version to 3.16 which uses OpenSSL v1.