### PR TITLE
Swap axis order in slice metadata

### DIFF
--- a/api/query_test.go
+++ b/api/query_test.go
@@ -156,13 +156,13 @@ func TestSliceHappyHTTPResponse(t *testing.T) {
 		switch testcase.slice.Direction {
 		case "i":
 			expectedMetadata = &testSliceMetadata{
-				X:      crosslineAxis,
-				Y:      sampleAxis,
+				X:      sampleAxis,
+				Y:      crosslineAxis,
 				Format: expectedFormat}
 		case "crossline":
 			expectedMetadata = &testSliceMetadata{
-				X:      inlineAxis,
-				Y:      sampleAxis,
+				X:      sampleAxis,
+				Y:      inlineAxis,
 				Format: expectedFormat}
 		default:
 			t.Fatalf("Unhandled direction %s in case %s", testcase.slice.Direction, testcase.name)

--- a/internal/vds/vds.cpp
+++ b/internal/vds/vds.cpp
@@ -508,7 +508,7 @@ struct vdsbuffer fetch_slice_metadata(
      * with the OpenVDS library.
      */
     std::vector< int > dims;
-    for (int i = 2; i >= 0; --i) {
+    for (int i = 0; i < 3; ++i) {
         if (i == vdim) continue;
         dims.push_back(i);
     }

--- a/internal/vds/vds_test.go
+++ b/internal/vds/vds_test.go
@@ -281,37 +281,37 @@ func TestSliceMetadataAxisOrdering(t *testing.T) {
 			name: "Inline",
 			direction: AxisInline,
 			lineno: 3,
-			expectedAxis: []string{"Crossline", "Sample"},
+			expectedAxis: []string{"Sample", "Crossline"},
 		},
 		{
 			name: "I",
 			lineno: 0,
 			direction: AxisI,
-			expectedAxis: []string{"Crossline", "Sample"},
+			expectedAxis: []string{"Sample", "Crossline"},
 		},
 		{
 			name: "Crossline",
 			direction: AxisCrossline,
 			lineno: 10,
-			expectedAxis: []string{"Inline", "Sample"},
+			expectedAxis: []string{"Sample", "Inline"},
 		},
 		{
 			name: "J",
 			lineno: 0,
 			direction: AxisJ,
-			expectedAxis: []string{"Inline", "Sample"},
+			expectedAxis: []string{"Sample", "Inline"},
 		},
 		{
 			name: "Time",
 			direction: AxisTime,
 			lineno: 4,
-			expectedAxis: []string{"Inline", "Crossline"},
+			expectedAxis: []string{"Crossline", "Inline"},
 		},
 		{
 			name: "K",
 			lineno: 0,
 			direction: AxisK,
-			expectedAxis: []string{"Inline", "Crossline"},
+			expectedAxis: []string{"Crossline", "Inline"},
 		},
 	}
 


### PR DESCRIPTION
The axis information does not match the way the data is ordered. One can argue that it's the data that should be transposed, not the axis as that seams to be the most natural orientation for e.g. plotting. However, I'm unsure if we should transpose data server side as that imposed additional compute on us.

Hence this commit reorders the metadata rather than the data, to make sure they correspond. This descision might be revisited before we do a proper versioned release of the API.