### PR TITLE
Openvds github action image cache

### DIFF
--- a/.github/actions/load_openvds_image/action.yaml
+++ b/.github/actions/load_openvds_image/action.yaml
@@ -1,0 +1,42 @@
+name: Load openvds image
+description: Assures openvds docker image is loaded under OPENVDS_IMAGE_TAG environment variable. Image is either built anew or loaded from cache.
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set parameters
+      shell: bash
+      id: parameters-setter
+      run: |
+        dockerfile_sha=$(sha1sum Dockerfile| head -c 40)
+        echo "DOCKERFILE_SHA=$dockerfile_sha" >> $GITHUB_ENV
+        echo "OPENVDS_CACHE_DIR=~/openvds_image" >> $GITHUB_ENV
+        echo "OPENVDS_CACHE_FILE=openvds.tar" >> $GITHUB_ENV
+        echo "OPENVDS_IMAGE_TAG=openvds:$dockerfile_sha" >> $GITHUB_ENV
+
+    - name: Make openvds directory
+      shell: bash
+      run: mkdir -p ${{ env.OPENVDS_CACHE_DIR }}
+
+    - name: Check for openvds cache
+      uses: actions/cache@v3
+      id: openvds-cache
+      with:
+        path: ${{ env.OPENVDS_CACHE_DIR }}
+        key: openvds-cache-${{ env.DOCKERFILE_SHA }}
+
+    - if: steps.openvds-cache.outputs.cache-hit != 'true'
+      name: Build openvds image
+      shell: bash
+      run: |
+        echo "openvds image from dockerfile with sha ${{ env.DOCKERFILE_SHA }} not found in cache"
+        echo "making openvds image with tag: ${{ env.OPENVDS_IMAGE_TAG }}"
+
+        docker build -f Dockerfile --target openvds -t ${{ env.OPENVDS_IMAGE_TAG }} .
+        docker save -o ${{ env.OPENVDS_CACHE_DIR }}/${{ env.OPENVDS_CACHE_FILE }} ${{ env.OPENVDS_IMAGE_TAG }}
+
+    - if: steps.openvds-cache.outputs.cache-hit == 'true'
+      name: Load openvds image
+      shell: bash
+      run: |
+        docker load -i ${{ env.OPENVDS_CACHE_DIR }}/${{ env.OPENVDS_CACHE_FILE }}

--- a/.github/workflows/analyzer.yaml
+++ b/.github/workflows/analyzer.yaml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: Run check
         run: |
           DOCKER_BUILDKIT=1 docker build -f Dockerfile --target static_analyzer .

--- a/.github/workflows/analyzer.yaml
+++ b/.github/workflows/analyzer.yaml
@@ -14,6 +14,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Load openvds image
+        uses: "./.github/actions/load_openvds_image"
+
       - name: Run check
         run: |
-          DOCKER_BUILDKIT=1 docker build -f Dockerfile --target static_analyzer .
+          DOCKER_BUILDKIT=1 docker build \
+            -f Dockerfile \
+            --build-arg OPENVDS_IMAGE=${{ env.OPENVDS_IMAGE_TAG }} \
+            --target static_analyzer \
+            .

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -12,7 +12,6 @@ jobs:
     # STORAGE_ACCOUNT_KEY : key used to access storage
     name: E2E tests with cloud
     runs-on: ubuntu-latest
-    environment: Test
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: Test
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Run E2E tests
         env:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,23 +1,43 @@
-name: E2E
+name: E2E tests
 
 on:
+  push:
+    branches: [master, e2e_tests]
   workflow_dispatch:
 
 jobs:
+  # The following secrets are required:
+  # STORAGE_ACCOUNT_NAME : name of the storage account with uploaded testdata (without blob.core.windows.net)
+  # STORAGE_ACCOUNT_KEY : key used to access storage
   e2e_tests:
-    # Required secrets:
-    #
-    # ENDPOINT : URL where server is running
-    # STORAGE_ACCOUNT_NAME : name of the storage where server is assigned to (without blob.core.windows.net)
-    # STORAGE_ACCOUNT_KEY : key used to access storage
-    name: E2E tests with cloud
+    name: Run e2e tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
+      - name: Load openvds image
+        uses: "./.github/actions/load_openvds_image"
+
+      - name: Build and Run server
+        env:
+          STORAGE_ACCOUNTS: https://${{ secrets.STORAGE_ACCOUNT_NAME }}.blob.core.windows.net
+        run: |
+          tag=server
+          DOCKER_BUILDKIT=1 docker build \
+            -f Dockerfile \
+            --build-arg OPENVDS_IMAGE=${{ env.OPENVDS_IMAGE_TAG }} \
+            --target runner \
+            --tag $tag \
+            .
+          docker run \
+            -e STORAGE_ACCOUNTS \
+            -d \
+            -p 8080:8080 \
+            $tag
+
       - name: Run E2E tests
         env:
-          ENDPOINT: ${{ secrets.ENDPOINT }}
+          ENDPOINT: http://localhost:8080
           STORAGE_ACCOUNT_NAME: ${{ secrets.STORAGE_ACCOUNT_NAME }}
           STORAGE_ACCOUNT_KEY: ${{ secrets.STORAGE_ACCOUNT_KEY }}
         run: |
@@ -27,4 +47,5 @@ jobs:
             -e ENDPOINT \
             -e STORAGE_ACCOUNT_NAME \
             -e STORAGE_ACCOUNT_KEY \
+            --network="host" \
             $tag

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -8,18 +8,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: ./tests/performance/Dockerfile
           tags: performance_tests:latest
           outputs: type=docker,dest=/tmp/performance_tests.tar
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: performance_tests
           path: /tmp/performance_tests.tar
@@ -82,9 +82,9 @@ jobs:
 
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Download artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: performance_tests
           path: /tmp
@@ -93,7 +93,7 @@ jobs:
           docker load --input /tmp/performance_tests.tar
           docker image ls -a
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Run "${{ matrix.name }}" test
         env:

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -33,7 +33,6 @@ jobs:
     name: Pattern
     runs-on: ubuntu-latest
     if: always()
-    environment: Test
     needs: prepare_env
 
     strategy:

--- a/.github/workflows/performance_user_input.yaml
+++ b/.github/workflows/performance_user_input.yaml
@@ -29,7 +29,7 @@ jobs:
     name: Run performance check for a chosen file
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run performance tests
         env:
           VDS: ${{ github.event.inputs.vds }}

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Run go tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Run server tests
         run: |

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -14,6 +14,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Load openvds image
+        uses: "./.github/actions/load_openvds_image"
+
       - name: Run server tests
         run: |
-          DOCKER_BUILDKIT=1 docker build -f Dockerfile --target tester .
+          DOCKER_BUILDKIT=1 docker build \
+            -f Dockerfile \
+            --build-arg OPENVDS_IMAGE=${{ env.OPENVDS_IMAGE_TAG }} \
+            --target tester \
+            .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+ARG OPENVDS_IMAGE=openvds
 FROM golang:1.18-alpine3.16 as openvds
 RUN apk --no-cache add \
     curl \
@@ -33,7 +34,7 @@ RUN cmake -S . \
 RUN cmake --build build   --config Release  --target install  -j 8 --verbose
 
 
-FROM openvds as builder
+FROM $OPENVDS_IMAGE as builder
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download && go mod verify

--- a/README.md
+++ b/README.md
@@ -27,3 +27,15 @@ resource use when fetching small amounts of data, such as slices or fences.
 However, if your use-case involve reading larger amounts of data, such as
 in a ML pipeline or other seismic processing you are better of using OpenVDS
 directly.
+
+# Development
+
+## CI
+
+E2E tests use secrets to access Azure environment and due to security reasons
+secrets are not accessible in pull requests. Thus e2e tests can't run on PRs,
+but are set up to run on merge to master.
+
+If one wants to run e2e tests oneself, one must set up own fork with required
+secrets to dedicated test storage account. Then e2e tests run can be triggered
+either manually or by pushing code to a dedicated e2e_tests branch.

--- a/tests/e2e/test_requests.py
+++ b/tests/e2e/test_requests.py
@@ -56,8 +56,8 @@ def test_slice(method):
 
     expected_meta = json.loads("""
     {
-        "x": {"annotation": "Crossline", "max": 11.0, "min": 10.0, "samples" : 2, "unit": "unitless"},
-        "y": {"annotation": "Sample", "max": 16.0, "min": 4.0, "samples" : 4, "unit": "ms"},
+        "x": {"annotation": "Sample", "max": 16.0, "min": 4.0, "samples" : 4, "unit": "ms"},
+        "y": {"annotation": "Crossline", "max": 11.0, "min": 10.0, "samples" : 2, "unit": "unitless"},
         "format": "<f4"
     }
     """)
@@ -147,7 +147,7 @@ def test_assure_only_allowed_storage_accounts(path, payload):
                        params={"query": json.dumps(payload)})
     assert res.status_code == http.HTTPStatus.BAD_REQUEST
     body = json.loads(res.content)
-    assert "Unsupported storage account" in body['error']
+    assert "unsupported storage account" in body['error']
 
 
 @pytest.mark.parametrize("path, payload, error_code, error", [
@@ -222,8 +222,8 @@ def request_slice(method, lineno, direction):
     data = multipart_data.parts[1].content
 
     shape = (
-        metadata['x']['samples'],
-        metadata['y']['samples']
+        metadata['y']['samples'],
+        metadata['x']['samples']
     )
 
     data = np.ndarray(shape, metadata['format'], data)


### PR DESCRIPTION
1. To see if main assumption of cache from master being accessible in PR holds, we need to merge first, but at least it holds for stuff pushed to other branches.

2. When openvds must be updated, cache with new version name shouldn't exist anywhere and all the jobs would have to build it on their own. So everything should be fine.

3. Need to push to Radix to make sure dockerfile still builds, but think it should be fine.