### PR TITLE
Add custom gin logger

### DIFF
--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/equinor/vds-slice/api"
 	"github.com/equinor/vds-slice/internal/vds"
 	"github.com/equinor/vds-slice/internal/cache"
+	"github.com/equinor/vds-slice/internal/logging"
 )
 
 type opts struct {
@@ -98,7 +99,9 @@ func main() {
 		Cache:             cache.NewCache(opts.cacheSize),
 	}
 
-	app := gin.Default()
+	app := gin.New()
+	app.Use(logging.FormattedLogger())
+	app.Use(gin.Recovery())
 	app.Use(gzip.Gzip(gzip.BestSpeed))
 
 	app.GET("/", endpoint.Health)

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,32 @@
+package logging
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+func FormattedLogger() gin.HandlerFunc {
+	return gin.LoggerWithFormatter(func (param gin.LogFormatterParams) string {
+		var statusColor, methodColor, resetColor string
+		if param.IsOutputColor() {
+			statusColor = param.StatusCodeColor()
+			methodColor = param.MethodColor()
+			resetColor  = param.ResetColor()
+		}
+
+		if param.Latency > time.Minute {
+			param.Latency = param.Latency.Truncate(time.Second)
+		}
+		return fmt.Sprintf("[GIN] %v |%s %3d %s| %13v | %15s |%s %-7s %s %#v\n%s",
+			param.TimeStamp.Format("2006/01/02 - 15:04:05"),
+			statusColor, param.StatusCode, resetColor,
+			param.Latency,
+			param.ClientIP,
+			methodColor, param.Method, resetColor,
+			param.Path,
+			param.ErrorMessage,
+		)
+	})
+}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -3,6 +3,7 @@ package logging
 import (
 	"fmt"
 	"time"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 )
@@ -19,13 +20,20 @@ func FormattedLogger() gin.HandlerFunc {
 		if param.Latency > time.Minute {
 			param.Latency = param.Latency.Truncate(time.Second)
 		}
+
+		/*
+		 * Strip off the query parameters from the path. In particular we don't want
+		 * the clients sas token to be logged on our server.
+		 */
+		path := strings.Split(param.Path, "?")[0]
+
 		return fmt.Sprintf("[GIN] %v |%s %3d %s| %13v | %15s |%s %-7s %s %#v\n%s",
 			param.TimeStamp.Format(time.RFC1123),
 			statusColor, param.StatusCode, resetColor,
 			param.Latency,
 			param.ClientIP,
 			methodColor, param.Method, resetColor,
-			param.Path,
+			path,
 			param.ErrorMessage,
 		)
 	})

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -20,7 +20,7 @@ func FormattedLogger() gin.HandlerFunc {
 			param.Latency = param.Latency.Truncate(time.Second)
 		}
 		return fmt.Sprintf("[GIN] %v |%s %3d %s| %13v | %15s |%s %-7s %s %#v\n%s",
-			param.TimeStamp.Format("2006/01/02 - 15:04:05"),
+			param.TimeStamp.Format(time.RFC1123),
 			statusColor, param.StatusCode, resetColor,
 			param.Latency,
 			param.ClientIP,


### PR DESCRIPTION
This commit slightly changes the request log format to include timezone, and excludes query-parameters from the path. The later solves the sas-token logging described in #87. It does not log requests at all. This is for a later PR