### PR TITLE
Log requests

### DIFF
--- a/api/endpoint.go
+++ b/api/endpoint.go
@@ -18,7 +18,14 @@ type Endpoint struct {
 	Cache             cache.Cache
 }
 
+func prepareRequestLogging(ctx *gin.Context, request Request) {
+	// ignore possible errors as they should not change outcome for the user
+	requestString, _ := request.toString()
+	ctx.Set("request", requestString)
+}
+
 func (e *Endpoint) metadata(ctx *gin.Context, request MetadataRequest) {
+	prepareRequestLogging(ctx, request)
 	conn, err := e.MakeVdsConnection(request.Vds, request.Sas)
 	if err != nil {
 		ctx.AbortWithError(http.StatusBadRequest, err)
@@ -35,6 +42,7 @@ func (e *Endpoint) metadata(ctx *gin.Context, request MetadataRequest) {
 }
 
 func (e *Endpoint) slice(ctx *gin.Context, request SliceRequest) {
+	prepareRequestLogging(ctx, request)
 	conn, err := e.MakeVdsConnection(request.Vds, request.Sas)
 	if err != nil {
 		ctx.AbortWithError(http.StatusBadRequest, err)
@@ -78,6 +86,7 @@ func (e *Endpoint) slice(ctx *gin.Context, request SliceRequest) {
 }
 
 func (e *Endpoint) fence(ctx *gin.Context, request FenceRequest) {
+	prepareRequestLogging(ctx, request)
 	conn, err := e.MakeVdsConnection(request.Vds, request.Sas)
 	if err != nil {
 		ctx.AbortWithError(http.StatusBadRequest, err)

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -27,13 +27,21 @@ func FormattedLogger() gin.HandlerFunc {
 		 */
 		path := strings.Split(param.Path, "?")[0]
 
-		return fmt.Sprintf("[GIN] %v |%s %3d %s| %13v | %15s |%s %-7s %s %#v\n%s",
+		request := param.Keys["request"]
+		if request == nil {
+			request = ""
+		} else {
+			request = fmt.Sprintf("%s\n", request)
+		}
+
+		return fmt.Sprintf("[GIN] %v |%s %3d %s| %13v | %15s |%s %-7s %s %#v\n%s%s",
 			param.TimeStamp.Format(time.RFC1123),
 			statusColor, param.StatusCode, resetColor,
 			param.Latency,
 			param.ClientIP,
 			methodColor, param.Method, resetColor,
 			path,
+			request,
 			param.ErrorMessage,
 		)
 	})


### PR DESCRIPTION
Log only successfully parsed requests. Goal of Requests logging is to assist in future debugging of server behavior (which we got burned on recently).
For malformed requests enough information is returned to the user. So it is their responsibility to fix the request. Us logging it won't help anything.

While information can be tied to the user's ip, it is not stored anywhere for further processing.
SAS are not logged. Any other relevant information (aka vds) while isn't public, shouldn't do any harm if known to anyone with access to the server logs.

closes #87 