### PR TITLE
Introduce axis class  (part 2 of refactoring)

### DIFF
--- a/internal/vds/axis.cpp
+++ b/internal/vds/axis.cpp
@@ -1,0 +1,38 @@
+#include "axis.h"
+
+#include <stdexcept>
+
+#include <OpenVDS/IJKCoordinateTransformer.h>
+#include <OpenVDS/KnownMetadata.h>
+
+
+Axis::Axis(
+    OpenVDS::VolumeDataLayout const * const layout,
+    int const                               dimension
+) : m_dimension(dimension),
+    m_axis_descriptor(layout->GetAxisDescriptor(dimension))
+{}
+
+int Axis::min() const noexcept(true) {
+    return this->m_axis_descriptor.GetCoordinateMin();
+}
+
+int Axis::max() const noexcept(true) {
+    return this->m_axis_descriptor.GetCoordinateMax();
+}
+
+int Axis::nsamples() const noexcept(true) {
+    return this->m_axis_descriptor.GetNumSamples();
+}
+
+std::string Axis::unit() const noexcept(true) {
+    return this->m_axis_descriptor.GetUnit();
+}
+
+int Axis::dimension() const noexcept(true) {
+    return this->m_dimension;
+}
+
+std::string Axis::name() const noexcept(true) {
+    return this->m_axis_descriptor.GetName();
+}

--- a/internal/vds/axis.h
+++ b/internal/vds/axis.h
@@ -1,0 +1,32 @@
+#ifndef AXIS_H
+#define AXIS_H
+
+#include <memory>
+#include <string>
+
+#include <OpenVDS/OpenVDS.h>
+
+#include "vds.h"
+
+class Axis {
+public:
+    Axis(
+        OpenVDS::VolumeDataLayout const * const layout,
+        int const dimension
+    );
+
+    int nsamples() const noexcept(true);
+
+    int min() const noexcept(true);
+    int max() const noexcept(true);
+
+    std::string unit() const noexcept(true);
+    int dimension() const noexcept(true);
+
+    std::string name() const noexcept(true);
+private:
+    int const m_dimension;
+    OpenVDS::VolumeDataAxisDescriptor m_axis_descriptor;
+};
+
+#endif /* AXIS_H */

--- a/internal/vds/vds.cpp
+++ b/internal/vds/vds.cpp
@@ -170,7 +170,7 @@ bool unit_validation(axis_name ax, const char* zunit) {
  *
  * This function will return 0 if that's not the case
  */
-bool axis_order_validation(axis_name ax, const OpenVDS::VolumeDataLayout *layout) {
+bool axis_order_validation(const OpenVDS::VolumeDataLayout *layout) {
     if (std::strcmp(layout->GetDimensionName(2), OpenVDS::KnownAxisNames::Inline())) {
         return false;
     }
@@ -197,7 +197,7 @@ bool axis_order_validation(axis_name ax, const OpenVDS::VolumeDataLayout *layout
 
 
 void axis_validation(axis_name ax, const OpenVDS::VolumeDataLayout* layout) {
-    if (not axis_order_validation(ax, layout)) {
+    if (not axis_order_validation(layout)) {
         std::string msg = "Unsupported axis ordering in VDS, expected ";
         msg += "Depth/Time/Sample, Crossline, Inline";
         throw std::runtime_error(msg);

--- a/internal/vds/vds.cpp
+++ b/internal/vds/vds.cpp
@@ -59,13 +59,13 @@ coordinate_system axis_tosystem(axis_name ax) {
         case I:
         case J:
         case K:
-            return INDEX;
+            return coordinate_system::INDEX;
         case INLINE:
         case CROSSLINE:
         case DEPTH:
         case TIME:
         case SAMPLE:
-            return ANNOTATION;
+            return coordinate_system::ANNOTATION;
         default: {
             throw std::runtime_error("Unhandled axis");
         }
@@ -290,7 +290,7 @@ void set_voxels(
     auto vdim   = axis.dimension();
     auto system = axis_tosystem(ax);
     switch (system) {
-        case ANNOTATION: {
+        case coordinate_system::ANNOTATION: {
             auto transformer = OpenVDS::IJKCoordinateTransformer(layout);
             if (not transformer.AnnotationsDefined()) {
                 throw std::runtime_error("VDS doesn't define annotations");
@@ -298,11 +298,11 @@ void set_voxels(
             voxelline = lineno_annotation_to_voxel(lineno, vdim, layout);
             break;
         }
-        case INDEX: {
+        case coordinate_system::INDEX: {
             voxelline = lineno_index_to_voxel(lineno, vdim, layout);
             break;
         }
-        case CDP: {
+        case coordinate_system::CDP: {
             break;
         }
         default: {
@@ -472,11 +472,11 @@ struct response fetch_fence(
     auto coordinate_transformer = OpenVDS::IJKCoordinateTransformer(layout);
     auto transform_coordinate = [&] (const float x, const float y) {
         switch (coordinate_system) {
-            case INDEX:
+            case coordinate_system::INDEX:
                 return OpenVDS::Vector<double, 3> {x, y, 0};
-            case ANNOTATION:
+            case coordinate_system::ANNOTATION:
                 return coordinate_transformer.AnnotationToIJKPosition({x, y, 0});
-            case CDP:
+            case coordinate_system::CDP:
                 return coordinate_transformer.WorldToIJKPosition({x, y, 0});
             default: {
                 throw std::runtime_error("Unhandled coordinate system");


### PR DESCRIPTION
Adds a class to represent any of the three axis available in a VDS. The class also maps between the API view on axis and the VDS view were the order/indices differ and also the names may differ.

I considered to move the validation of the axis order into the `class Axis`, but dropped this for the moment to have consistent behavior with the current state of the code. Checking the axis order during the creation of an object of type Axis seems to be too strict under our current tests. At the moment the axis order is only checked for slice and slice metadata requests.

**DONE** ~~Must be rebased and reviewed **after** https://github.com/equinor/vds-slice/pull/99 has been merged.~~
Previous PR https://github.com/equinor/vds-slice/pull/99. Next PR #101.