### PR TITLE
Add metadata handle (part 3 of refactoring) 

### DIFF
--- a/api/endpoint.go
+++ b/api/endpoint.go
@@ -67,7 +67,7 @@ func (e *Endpoint) slice(ctx *gin.Context, request SliceRequest) {
 		return
 	}
 
-	metadata, err := vds.GetSliceMetadata(conn, *request.Lineno, axis)
+	metadata, err := vds.GetSliceMetadata(conn, axis)
 	if err != nil {
 		ctx.AbortWithError(http.StatusInternalServerError, err)
 		return

--- a/internal/vds/axis.cpp
+++ b/internal/vds/axis.cpp
@@ -1,0 +1,106 @@
+#include "axis.h"
+
+#include <stdexcept>
+
+#include <OpenVDS/IJKCoordinateTransformer.h>
+#include <OpenVDS/KnownMetadata.h>
+
+Axis::Axis(
+    const enum api_axis_name api_name,
+    OpenVDS::VolumeDataLayout const * layout
+) : api_name(api_name) {
+    switch (this->api_name) {
+        case I:
+        case INLINE:
+            this->api_index = 0;
+            this->vds_index = 2;
+            break;
+        case J:
+        case CROSSLINE:
+            this->api_index = 1;
+            this->vds_index = 1;
+            break;
+        case K:
+        case DEPTH:
+        case TIME:
+        case SAMPLE:
+            this->api_index = 2;
+            this->vds_index = 0;
+            break;
+        default: {
+            throw std::runtime_error("Unhandled axis");
+        }
+    }
+
+    this->vds_axis_descriptor = layout->GetAxisDescriptor(this->vds_index);
+}
+
+int Axis::get_min() const noexcept(true) {
+    return this->vds_axis_descriptor.GetCoordinateMin();
+}
+
+int Axis::get_max() const noexcept(true) {
+    return this->vds_axis_descriptor.GetCoordinateMax();
+}
+
+int Axis::get_number_of_points() const noexcept(true) {
+    return this->vds_axis_descriptor.GetNumSamples();
+}
+
+std::string Axis::get_unit() const noexcept(true) {
+    return this->vds_axis_descriptor.GetUnit();
+}
+
+int Axis::get_vds_index() const noexcept(true) {
+    return this->vds_index;
+}
+
+int Axis::get_api_index() const noexcept(true) {
+    return this->api_index;
+}
+
+std::string Axis::get_vds_name() const noexcept(true) {
+    return this->vds_axis_descriptor.GetName();
+}
+
+std::string Axis::get_api_name() const {
+    switch (this->api_name) {
+        case I:
+            return OpenVDS::KnownAxisNames::I();
+        case INLINE:
+            return OpenVDS::KnownAxisNames::Inline();
+        case J:
+            return OpenVDS::KnownAxisNames::J();
+        case CROSSLINE:
+            return OpenVDS::KnownAxisNames::Crossline();
+        case K:
+            return OpenVDS::KnownAxisNames::K();
+        case DEPTH:
+            return OpenVDS::KnownAxisNames::Depth();
+        case TIME:
+            return OpenVDS::KnownAxisNames::Time();
+        case SAMPLE:
+            return OpenVDS::KnownAxisNames::Sample();
+        default: {
+            throw std::runtime_error("Unhandled axis");
+        }
+    }
+}
+
+coordinate_system Axis::get_coordinate_system() const {
+    switch (this->api_name) {
+        case I:
+        case J:
+        case K:
+            return coordinate_system::INDEX;
+        case INLINE:
+        case CROSSLINE:
+        case DEPTH:
+        case TIME:
+        case SAMPLE:
+            return coordinate_system::ANNOTATION;
+        default: {
+            throw std::runtime_error("Unhandled coordinate system");
+        }
+    }
+}

--- a/internal/vds/axis.h
+++ b/internal/vds/axis.h
@@ -1,0 +1,39 @@
+#ifndef AXIS_H
+#define AXIS_H
+
+#include <memory>
+#include <string>
+
+#include <OpenVDS/OpenVDS.h>
+
+#include "vds.h"
+
+class Axis {
+public:
+    Axis(
+        const api_axis_name               api_name,
+        OpenVDS::VolumeDataLayout const * layout
+    );
+
+    int get_number_of_points() const noexcept(true);
+
+    int get_min() const noexcept(true);
+    int get_max() const noexcept(true);
+
+    std::string get_unit() const noexcept(true);
+
+    int get_vds_index() const noexcept(true);
+    int get_api_index() const noexcept(true);
+
+    std::string get_vds_name() const noexcept(true);
+    std::string get_api_name() const;
+
+    coordinate_system get_coordinate_system() const;
+private:
+    const api_axis_name api_name;
+    int vds_index;
+    int api_index;
+    OpenVDS::VolumeDataAxisDescriptor vds_axis_descriptor;
+};
+
+#endif /* AXIS_H */

--- a/internal/vds/boundingbox.cpp
+++ b/internal/vds/boundingbox.cpp
@@ -1,0 +1,40 @@
+#include "boundingbox.h"
+
+std::vector< std::pair<int, int> > BoundingBox::index() noexcept (true) {
+    auto ils = layout->GetDimensionNumSamples(2) - 1;
+    auto xls = layout->GetDimensionNumSamples(1) - 1;
+
+    return { {0, 0}, {ils, 0}, {ils, xls}, {0, xls} };
+}
+
+std::vector< std::pair<double, double> > BoundingBox::world() noexcept (true) {
+    std::vector< std::pair<double, double> > world_points;
+
+    auto points = this->index();
+    std::for_each(points.begin(), points.end(),
+        [&](const std::pair<int, int>& point) {
+            auto p = this->transformer.IJKIndexToWorld(
+                { point.first, point.second, 0 }
+            );
+            world_points.emplace_back(p[0], p[1]);
+        }
+    );
+
+    return world_points;
+};
+
+std::vector< std::pair<int, int> > BoundingBox::annotation() noexcept (true) {
+    auto points = this->index();
+    std::transform(points.begin(), points.end(), points.begin(),
+        [this](std::pair<int, int>& point) {
+            auto anno = this->transformer.IJKIndexToAnnotation({
+                point.first,
+                point.second,
+                0
+            });
+            return std::pair<int, int>{anno[0], anno[1]};
+        }
+    );
+
+    return points;
+};

--- a/internal/vds/boundingbox.cpp
+++ b/internal/vds/boundingbox.cpp
@@ -1,10 +1,7 @@
 #include "boundingbox.h"
 
 std::vector< std::pair<int, int> > BoundingBox::index() noexcept (true) {
-    auto ils = layout->GetDimensionNumSamples(2) - 1;
-    auto xls = layout->GetDimensionNumSamples(1) - 1;
-
-    return { {0, 0}, {ils, 0}, {ils, xls}, {0, xls} };
+    return { {0, 0}, {this->ils, 0}, {this->ils, this->xls}, {0, this->xls} };
 }
 
 std::vector< std::pair<double, double> > BoundingBox::world() noexcept (true) {

--- a/internal/vds/boundingbox.h
+++ b/internal/vds/boundingbox.h
@@ -1,0 +1,27 @@
+#ifndef BOUNDINGBOX_H
+#define BOUNDINGBOX_H
+
+#include <utility>
+#include <vector>
+
+#include <OpenVDS/OpenVDS.h>
+#include <OpenVDS/IJKCoordinateTransformer.h>
+
+class BoundingBox {
+public:
+    explicit BoundingBox(
+        const OpenVDS::VolumeDataLayout *layout
+    ) : layout(layout)
+    {
+        transformer = OpenVDS::IJKCoordinateTransformer(layout);
+    }
+
+    std::vector< std::pair<int, int> >       index()      noexcept (true);
+    std::vector< std::pair<int, int> >       annotation() noexcept (true);
+    std::vector< std::pair<double, double> > world()      noexcept (true);
+private:
+    OpenVDS::IJKCoordinateTransformer transformer;
+    const OpenVDS::VolumeDataLayout*  layout;
+};
+
+#endif /* BOUNDINGBOX_H */

--- a/internal/vds/boundingbox.h
+++ b/internal/vds/boundingbox.h
@@ -7,11 +7,16 @@
 #include <OpenVDS/OpenVDS.h>
 #include <OpenVDS/IJKCoordinateTransformer.h>
 
+#include "axis.h"
+
 class BoundingBox {
 public:
     explicit BoundingBox(
-        const OpenVDS::VolumeDataLayout *layout
-    ) : layout(layout)
+        OpenVDS::VolumeDataLayout const * const layout,
+        Axis const& inline_axis,
+        Axis const& crossline_axis
+    ) : ils(inline_axis.get_number_of_points()-1),
+        xls(crossline_axis.get_number_of_points()-1)
     {
         transformer = OpenVDS::IJKCoordinateTransformer(layout);
     }
@@ -21,7 +26,11 @@ public:
     std::vector< std::pair<double, double> > world()      noexcept (true);
 private:
     OpenVDS::IJKCoordinateTransformer transformer;
-    const OpenVDS::VolumeDataLayout*  layout;
+
+    // Maximum index of inline axis
+    int const ils;
+    // Maximum index of crossline axis
+    int const xls;
 };
 
 #endif /* BOUNDINGBOX_H */

--- a/internal/vds/metadatahandle.cpp
+++ b/internal/vds/metadatahandle.cpp
@@ -1,0 +1,75 @@
+#include "metadatahandle.h"
+
+#include <stdexcept>
+#include <list>
+#include <utility>
+
+#include <OpenVDS/KnownMetadata.h>
+
+void MetadataHandle::validate_dimensionality() const {
+    constexpr int expected_dimensionality = 3;
+    if (this->layout->GetDimensionality() != expected_dimensionality) {
+        throw std::runtime_error(
+            "Unsupported VDS, expected 3 dimensions, got " +
+            std::to_string(this->layout->GetDimensionality())
+        );
+    }
+}
+
+/*
+ * We're gonna assume that all VDS' are ordered like so:
+ *
+ *     voxel[0] -> depth/time/sample
+ *     voxel[1] -> crossline
+ *     voxel[2] -> inline
+ */
+void MetadataHandle::validate_axes_order() const {
+    std::list<std::pair<int, char const *>> expected_axis_index_and_name = {
+        {0, OpenVDS::KnownAxisNames::Sample()},
+        {1, OpenVDS::KnownAxisNames::Crossline()},
+        {2, OpenVDS::KnownAxisNames::Inline()}
+    };
+
+    for (const auto& index_and_name: expected_axis_index_and_name) {
+        int const expected_axis_index = index_and_name.first;
+        char const * expected_axis_name = index_and_name.second;
+        char const * actual_axis_name = this->layout->GetDimensionName(
+                                          expected_axis_index
+                                      );
+
+        if (strcmp(expected_axis_name, actual_axis_name) != 0) {
+            std::string msg = "Unsupported axis ordering. Expected axis "
+                              + std::string(expected_axis_name)
+                              + " (axis index: "
+                              + std::to_string(expected_axis_index)
+                              + "), got "
+                              + std::string(actual_axis_name);
+            throw std::runtime_error(msg);
+        }
+    }
+}
+
+Axis const& MetadataHandle::get_inline() const noexcept (true) {
+    return this->inline_axis;
+}
+
+Axis const& MetadataHandle::get_crossline() const noexcept (true) {
+    return this->crossline_axis;
+}
+
+Axis const& MetadataHandle::get_sample() const noexcept (true) {
+    return this->sample_axis;
+}
+
+BoundingBox const& MetadataHandle::get_bounding_box() const noexcept (true) {
+    return this->bounding_box;
+}
+
+std::string MetadataHandle::get_format() const noexcept (true) {
+    return "<f4";
+}
+
+std::string MetadataHandle::get_crs() const noexcept (true) {
+    auto const crs = OpenVDS::KnownMetadata::SurveyCoordinateSystemCRSWkt();
+    return this->layout->GetMetadataString(crs.GetCategory(), crs.GetName());
+}

--- a/internal/vds/metadatahandle.h
+++ b/internal/vds/metadatahandle.h
@@ -1,0 +1,44 @@
+#ifndef METADATAHANDLE_H
+#define METADATAHANDLE_H
+
+#include <string>
+
+#include <OpenVDS/OpenVDS.h>
+
+#include "axis.h"
+#include "boundingbox.h"
+
+class MetadataHandle {
+public:
+    MetadataHandle(OpenVDS::VolumeDataLayout const * const layout) :
+        layout(layout),
+        inline_axis(Axis(api_axis_name::INLINE, layout)),
+        crossline_axis(Axis(api_axis_name::CROSSLINE, layout)),
+        sample_axis(Axis(api_axis_name::SAMPLE, layout)),
+        bounding_box(BoundingBox(layout, inline_axis, crossline_axis))
+    {
+        this->validate_dimensionality();
+        this->validate_axes_order();
+    }
+
+    Axis const& get_inline()    const noexcept (true);
+    Axis const& get_crossline() const noexcept (true);
+    Axis const& get_sample()    const noexcept (true);
+
+    BoundingBox const& get_bounding_box() const noexcept (true);
+    std::string        get_format()       const noexcept (true);
+    std::string        get_crs()          const noexcept (true);
+private:
+    OpenVDS::VolumeDataLayout const * const layout;
+
+    Axis const inline_axis;
+    Axis const crossline_axis;
+    Axis const sample_axis;
+
+    BoundingBox bounding_box;
+
+    void validate_dimensionality() const;
+    void validate_axes_order() const;
+};
+
+#endif /* METADATAHANDLE_H */

--- a/internal/vds/vds.cpp
+++ b/internal/vds/vds.cpp
@@ -421,8 +421,7 @@ struct vdsbuffer fetch_slice(
 struct vdsbuffer fetch_slice_metadata(
     std::string url,
     std::string credentials,
-    api_axis_name ax,
-    int lineno
+    api_axis_name ax
 ) {
     auto handle = open_vds(url, credentials);
 
@@ -664,14 +663,13 @@ struct vdsbuffer slice(
 struct vdsbuffer slice_metadata(
     const char* vds,
     const char* credentials,
-    int lineno,
     api_axis_name ax
 ) {
     std::string cube(vds);
     std::string cred(credentials);
 
     try {
-        return fetch_slice_metadata(cube, cred, ax, lineno);
+        return fetch_slice_metadata(cube, cred, ax);
     } catch (const std::exception& e) {
         return handle_error(e);
     }

--- a/internal/vds/vds.cpp
+++ b/internal/vds/vds.cpp
@@ -18,6 +18,8 @@
 #include <OpenVDS/KnownMetadata.h>
 #include <OpenVDS/IJKCoordinateTransformer.h>
 
+#include "boundingbox.h"
+
 using namespace std;
 
 void vdsbuffer_delete(struct vdsbuffer* buf) {
@@ -342,64 +344,6 @@ void set_voxels(
         voxelmax[i] = vmax[i];
     }
 }
-
-
-class BoundingBox {
-public:
-    explicit BoundingBox(
-        const OpenVDS::VolumeDataLayout *layout
-    ) : layout(layout)
-    {
-        transformer = OpenVDS::IJKCoordinateTransformer(layout);
-    }
-
-    std::vector< std::pair<int, int> >       index()      noexcept (true);
-    std::vector< std::pair<int, int> >       annotation() noexcept (true);
-    std::vector< std::pair<double, double> > world()      noexcept (true);
-private:
-    OpenVDS::IJKCoordinateTransformer transformer;
-    const OpenVDS::VolumeDataLayout*  layout;
-};
-
-
-std::vector< std::pair<int, int> > BoundingBox::index() noexcept (true) {
-    auto ils = layout->GetDimensionNumSamples(2) - 1;
-    auto xls = layout->GetDimensionNumSamples(1) - 1;
-
-    return { {0, 0}, {ils, 0}, {ils, xls}, {0, xls} };
-}
-
-std::vector< std::pair<double, double> > BoundingBox::world() noexcept (true) {
-    std::vector< std::pair<double, double> > world_points;
-
-    auto points = this->index();
-    std::for_each(points.begin(), points.end(),
-        [&](const std::pair<int, int>& point) {
-            auto p = this->transformer.IJKIndexToWorld(
-                { point.first, point.second, 0 }
-            );
-            world_points.emplace_back(p[0], p[1]);
-        }
-    );
-
-    return world_points;
-};
-
-std::vector< std::pair<int, int> > BoundingBox::annotation() noexcept (true) {
-    auto points = this->index();
-    std::transform(points.begin(), points.end(), points.begin(),
-        [this](std::pair<int, int>& point) {
-            auto anno = this->transformer.IJKIndexToAnnotation({
-                point.first,
-                point.second,
-                0
-            });
-            return std::pair<int, int>{anno[0], anno[1]};
-        }
-    );
-
-    return points;
-};
 
 nlohmann::json json_axis(
     int voxel_dim,

--- a/internal/vds/vds.cpp
+++ b/internal/vds/vds.cpp
@@ -29,7 +29,7 @@ void vdsbuffer_delete(struct vdsbuffer* buf) {
     *buf = vdsbuffer {};
 }
 
-int axis_todim(axis ax) {
+int axis_todim(api_axis_name ax) {
     switch (ax) {
         case I:
         case INLINE:
@@ -48,7 +48,7 @@ int axis_todim(axis ax) {
     }
 }
 
-coordinate_system axis_tosystem(axis ax) {
+coordinate_system axis_tosystem(api_axis_name ax) {
     switch (ax) {
         case I:
         case J:
@@ -66,7 +66,7 @@ coordinate_system axis_tosystem(axis ax) {
     }
 }
 
-const std::string axis_tostring(axis ax) {
+const std::string axis_tostring(api_axis_name ax) {
     switch (ax) {
         case I:         return std::string( OpenVDS::KnownAxisNames::I()         );
         case J:         return std::string( OpenVDS::KnownAxisNames::J()         );
@@ -114,7 +114,7 @@ std::string vdsformat_tostring(OpenVDS::VolumeDataFormat format) {
  * E.g. a Time slice is only valid if the units of the Z-axis in the VDS is
  * "Seconds" or "Milliseconds"
  */
-bool unit_validation(axis ax, const char* zunit) {
+bool unit_validation(api_axis_name ax, const char* zunit) {
     /* Define some convenient lookup tables for units */
     static const std::array< const char*, 3 > depthunits = {
         OpenVDS::KnownUnitNames::Meter(),
@@ -164,7 +164,7 @@ bool unit_validation(axis ax, const char* zunit) {
  *
  * This function will return 0 if that's not the case
  */
-bool axis_order_validation(axis ax, const OpenVDS::VolumeDataLayout *layout) {
+bool axis_order_validation(api_axis_name ax, const OpenVDS::VolumeDataLayout *layout) {
     if (std::strcmp(layout->GetDimensionName(2), OpenVDS::KnownAxisNames::Inline())) {
         return false;
     }
@@ -190,7 +190,7 @@ bool axis_order_validation(axis ax, const OpenVDS::VolumeDataLayout *layout) {
 }
 
 
-void axis_validation(axis ax, const OpenVDS::VolumeDataLayout* layout) {
+void axis_validation(api_axis_name ax, const OpenVDS::VolumeDataLayout* layout) {
     if (not axis_order_validation(ax, layout)) {
         std::string msg = "Unsupported axis ordering in VDS, expected ";
         msg += "Depth/Time/Sample, Crossline, Inline";
@@ -295,7 +295,7 @@ int lineno_index_to_voxel(
  * Convert target dimension/axis + lineno to VDS voxel coordinates.
  */
 void set_voxels(
-    axis ax,
+    api_axis_name ax,
     int dimension,
     int lineno,
     const OpenVDS::VolumeDataLayout *layout,
@@ -432,7 +432,7 @@ OpenVDS::ScopedVDSHandle open_vds(
 struct vdsbuffer fetch_slice(
     std::string url,
     std::string credentials,
-    axis ax,
+    api_axis_name ax,
     int lineno
 ) {
     auto handle = open_vds(url, credentials);
@@ -477,7 +477,7 @@ struct vdsbuffer fetch_slice(
 struct vdsbuffer fetch_slice_metadata(
     std::string url,
     std::string credentials,
-    axis ax,
+    api_axis_name ax,
     int lineno
 ) {
     auto handle = open_vds(url, credentials);
@@ -705,7 +705,7 @@ struct vdsbuffer slice(
     const char* vds,
     const char* credentials,
     int lineno,
-    axis ax
+    api_axis_name ax
 ) {
     std::string cube(vds);
     std::string cred(credentials);
@@ -721,7 +721,7 @@ struct vdsbuffer slice_metadata(
     const char* vds,
     const char* credentials,
     int lineno,
-    axis ax
+    api_axis_name ax
 ) {
     std::string cube(vds);
     std::string cred(credentials);

--- a/internal/vds/vds.cpp
+++ b/internal/vds/vds.cpp
@@ -22,13 +22,13 @@
 
 using namespace std;
 
-void vdsbuffer_delete(struct vdsbuffer* buf) {
+void response_delete(struct response* buf) {
     if (!buf)
         return;
 
     delete[] buf->data;
     delete[] buf->err;
-    *buf = vdsbuffer {};
+    *buf = response {};
 }
 
 int axis_todim(api_axis_name ax) {
@@ -373,7 +373,7 @@ OpenVDS::ScopedVDSHandle open_vds(
     return handle;
 }
 
-struct vdsbuffer fetch_slice(
+struct response fetch_slice(
     std::string url,
     std::string credentials,
     api_axis_name ax,
@@ -409,7 +409,7 @@ struct vdsbuffer fetch_slice(
 
     request.get()->WaitForCompletion();
 
-    vdsbuffer buffer{};
+    response buffer{};
     buffer.size = size;
     buffer.data = data.get();
 
@@ -418,7 +418,7 @@ struct vdsbuffer fetch_slice(
     return buffer;
 }
 
-struct vdsbuffer fetch_slice_metadata(
+struct response fetch_slice_metadata(
     std::string url,
     std::string credentials,
     api_axis_name ax
@@ -462,14 +462,14 @@ struct vdsbuffer fetch_slice_metadata(
     auto *data = new char[str.size()];
     std::copy(str.begin(), str.end(), data);
 
-    vdsbuffer buffer{};
+    response buffer{};
     buffer.size = str.size();
     buffer.data = data;
 
     return buffer;
 }
 
-struct vdsbuffer fetch_fence(
+struct response fetch_fence(
     const std::string& url,
     const std::string& credentials,
     enum coordinate_system coordinate_system,
@@ -563,7 +563,7 @@ struct vdsbuffer fetch_fence(
         throw std::runtime_error(msg);
     }
 
-    vdsbuffer buffer{};
+    response buffer{};
     buffer.size = size;
     buffer.data = data.get();
 
@@ -572,7 +572,7 @@ struct vdsbuffer fetch_fence(
     return buffer;
 }
 
-struct vdsbuffer fetch_fence_metadata(
+struct response fetch_fence_metadata(
     std::string url,
     std::string credentials,
     size_t npoints
@@ -592,14 +592,14 @@ struct vdsbuffer fetch_fence_metadata(
     auto *data = new char[str.size()];
     std::copy(str.begin(), str.end(), data);
 
-    vdsbuffer buffer{};
+    response buffer{};
     buffer.size = str.size();
     buffer.data = data;
 
     return buffer;
 }
 
-struct vdsbuffer metadata(
+struct response metadata(
     const std::string& url,
     const std::string& credentials
 ) {
@@ -628,23 +628,23 @@ struct vdsbuffer metadata(
     auto *data = new char[str.size()];
     std::copy(str.begin(), str.end(), data);
 
-    vdsbuffer buffer{};
+    response buffer{};
     buffer.size = str.size();
     buffer.data = data;
 
     return buffer;
 }
 
-struct vdsbuffer handle_error(
+struct response handle_error(
     const std::exception& e
 ) {
-    vdsbuffer buf {};
+    response buf {};
     buf.err = new char[std::strlen(e.what()) + 1];
     std::strcpy(buf.err, e.what());
     return buf;
 }
 
-struct vdsbuffer slice(
+struct response slice(
     const char* vds,
     const char* credentials,
     int lineno,
@@ -660,7 +660,7 @@ struct vdsbuffer slice(
     }
 }
 
-struct vdsbuffer slice_metadata(
+struct response slice_metadata(
     const char* vds,
     const char* credentials,
     api_axis_name ax
@@ -675,7 +675,7 @@ struct vdsbuffer slice_metadata(
     }
 }
 
-struct vdsbuffer fence(
+struct response fence(
     const char* vds,
     const char* credentials,
     enum coordinate_system coordinate_system,
@@ -695,7 +695,7 @@ struct vdsbuffer fence(
     }
 }
 
-struct vdsbuffer fence_metadata(
+struct response fence_metadata(
     const char* vds,
     const char* credentials,
     size_t npoints
@@ -710,7 +710,7 @@ struct vdsbuffer fence_metadata(
     }
 }
 
-struct vdsbuffer metadata(
+struct response metadata(
     const char* vds,
     const char* credentials
 ) {

--- a/internal/vds/vds.go
+++ b/internal/vds/vds.go
@@ -164,7 +164,7 @@ func GetMetadata(conn Connection) ([]byte, error) {
 	defer C.free(unsafe.Pointer(ccred))
 
 	result := C.metadata(curl, ccred)
-	
+
 	defer C.vdsbuffer_delete(&result)
 
 	if result.err != nil {
@@ -187,7 +187,7 @@ func GetSlice(conn Connection, lineno, direction int) ([]byte, error) {
 		curl,
 		ccred,
 		C.int(lineno),
-		C.enum_axis(direction),
+		C.enum_api_axis_name(direction),
 	)
 
 	defer C.vdsbuffer_delete(&result)
@@ -212,7 +212,7 @@ func GetSliceMetadata(conn Connection, lineno, direction int) ([]byte, error) {
 		curl,
 		ccred,
 		C.int(lineno),
-		C.enum_axis(direction),
+		C.enum_api_axis_name(direction),
 	)
 
 	defer C.vdsbuffer_delete(&result)

--- a/internal/vds/vds.go
+++ b/internal/vds/vds.go
@@ -165,7 +165,7 @@ func GetMetadata(conn Connection) ([]byte, error) {
 
 	result := C.metadata(curl, ccred)
 
-	defer C.vdsbuffer_delete(&result)
+	defer C.response_delete(&result)
 
 	if result.err != nil {
 		err := C.GoString(result.err)
@@ -190,7 +190,7 @@ func GetSlice(conn Connection, lineno, direction int) ([]byte, error) {
 		C.enum_api_axis_name(direction),
 	)
 
-	defer C.vdsbuffer_delete(&result)
+	defer C.response_delete(&result)
 
 	if result.err != nil {
 		err := C.GoString(result.err)
@@ -214,7 +214,7 @@ func GetSliceMetadata(conn Connection, direction int) ([]byte, error) {
 		C.enum_api_axis_name(direction),
 	)
 
-	defer C.vdsbuffer_delete(&result)
+	defer C.response_delete(&result)
 
 	if result.err != nil {
 		err := C.GoString(result.err)
@@ -264,7 +264,7 @@ func GetFence(
 		C.enum_interpolation_method(interpolation),
 	)
 
-	defer C.vdsbuffer_delete(&result)
+	defer C.response_delete(&result)
 
 	if result.err != nil {
 		err := C.GoString(result.err)
@@ -288,7 +288,7 @@ func GetFenceMetadata(conn Connection, coordinates [][]float32) ([]byte, error) 
 		C.size_t(len(coordinates)),
 	)
 
-	defer C.vdsbuffer_delete(&result)
+	defer C.response_delete(&result)
 
 	if result.err != nil {
 		err := C.GoString(result.err)

--- a/internal/vds/vds.go
+++ b/internal/vds/vds.go
@@ -201,7 +201,7 @@ func GetSlice(conn Connection, lineno, direction int) ([]byte, error) {
 	return buf, nil
 }
 
-func GetSliceMetadata(conn Connection, lineno, direction int) ([]byte, error) {
+func GetSliceMetadata(conn Connection, direction int) ([]byte, error) {
 	curl := C.CString(conn.Url())
 	defer C.free(unsafe.Pointer(curl))
 
@@ -211,7 +211,6 @@ func GetSliceMetadata(conn Connection, lineno, direction int) ([]byte, error) {
 	result := C.slice_metadata(
 		curl,
 		ccred,
-		C.int(lineno),
 		C.enum_api_axis_name(direction),
 	)
 

--- a/internal/vds/vds.h
+++ b/internal/vds/vds.h
@@ -12,7 +12,7 @@ struct vdsbuffer {
     unsigned long size;
 };
 
-enum axis {
+enum api_axis_name {
     I         = 0,
     J         = 1,
     K         = 2,
@@ -46,14 +46,14 @@ struct vdsbuffer slice(
     const char* vds,
     const char* credentials,
     int lineno,
-    enum axis direction
+    enum api_axis_name direction
 );
 
 struct vdsbuffer slice_metadata(
     const char* vds,
     const char* credentials,
     int lineno,
-    enum axis direction
+    enum api_axis_name direction
 );
 
 struct vdsbuffer fence(

--- a/internal/vds/vds.h
+++ b/internal/vds/vds.h
@@ -6,7 +6,7 @@
 extern "C" {
 #endif
 
-struct vdsbuffer {
+struct response {
     char*         data;
     char*         err;
     unsigned long size;
@@ -37,25 +37,25 @@ enum interpolation_method {
     TRIANGULAR
 };
 
-struct vdsbuffer metadata(
+struct response metadata(
     const char* vds,
     const char* credentials
 );
 
-struct vdsbuffer slice(
+struct response slice(
     const char* vds,
     const char* credentials,
     int lineno,
     enum api_axis_name direction
 );
 
-struct vdsbuffer slice_metadata(
+struct response slice_metadata(
     const char* vds,
     const char* credentials,
     enum api_axis_name direction
 );
 
-struct vdsbuffer fence(
+struct response fence(
     const char* vds,
     const char* credentials,
     enum coordinate_system coordinate_system,
@@ -64,13 +64,13 @@ struct vdsbuffer fence(
     enum interpolation_method interpolation_method
 );
 
-struct vdsbuffer fence_metadata(
+struct response fence_metadata(
     const char* vds,
     const char* credentials,
     size_t npoints
 );
 
-void vdsbuffer_delete(struct vdsbuffer*);
+void response_delete(struct response*);
 
 
 #ifdef __cplusplus

--- a/internal/vds/vds.h
+++ b/internal/vds/vds.h
@@ -52,7 +52,6 @@ struct vdsbuffer slice(
 struct vdsbuffer slice_metadata(
     const char* vds,
     const char* credentials,
-    int lineno,
     enum api_axis_name direction
 );
 

--- a/internal/vds/vds_test.go
+++ b/internal/vds/vds_test.go
@@ -123,7 +123,7 @@ func TestSliceData(t *testing.T) {
 		}
 
 		for i, x := range(*slice) {
-			if (x == testcase.expected[i]) { 
+			if (x == testcase.expected[i]) {
 				continue
 			}
 
@@ -316,7 +316,7 @@ func TestSliceMetadataAxisOrdering(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		buf, err := GetSliceMetadata(well_known, testcase.lineno, testcase.direction)
+		buf, err := GetSliceMetadata(well_known, testcase.direction)
 		if err != nil {
 			t.Fatalf(
 				"[case: %v] Failed to get slice metadata, err: %v",
@@ -334,7 +334,7 @@ func TestSliceMetadataAxisOrdering(t *testing.T) {
 				err,
 			)
 		}
-		
+
 		axis := []string{ meta.X.Annotation, meta.Y.Annotation }
 		for i, ax := range(testcase.expectedAxis) {
 			if ax != axis[i] {
@@ -693,7 +693,7 @@ func TestOnly3DSupported(t *testing.T) {
 		},
 		{
 			name:     "SliceMetadata",
-			function: func() ([]byte, error) { return GetSliceMetadata(prestack, 0, 0) },
+			function: func() ([]byte, error) { return GetSliceMetadata(prestack, 0) },
 		},
 		{
 			name:     "Fence",


### PR DESCRIPTION
Adds handle that exposesmetadata information from VDS including axes that we expect in a VDS (Time/Depth/Sample, Crossline, Inline) and the bounding box.

Must be rebased and reviewed **after** #100 has been merged.
Previous PR #100. Next PR #102.