### PR TITLE
Trust no proxies

### DIFF
--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -171,6 +171,7 @@ func main() {
 	}
 
 	app := gin.New()
+	app.SetTrustedProxies(nil)
 
 	var metric *metrics.Metrics
 	if opts.metrics {
@@ -182,6 +183,8 @@ func main() {
 		 * are continually scarping the /metrics endpoint. I.e. graphana.
 		 */
 		metricsApp := gin.New()
+		metricsApp.SetTrustedProxies(nil)
+
 		metricsApp.Use(gin.Recovery())
 		metricsApp.GET("metrics", metrics.NewGinHandler(metric))
 


### PR DESCRIPTION
As our server is not expected to be used by anyone and company proxies are usually sophisticated enough to bypass default proxy checks, trusting no proxy shouldn't affect us in any way and will make gin happy.

closes #106 