### PR TITLE
Redesign the CGO / C-API and propagate C++ exceptions to Go

### DIFF
--- a/api/endpoint.go
+++ b/api/endpoint.go
@@ -14,6 +14,15 @@ import (
 	"github.com/equinor/vds-slice/internal/vds"
 )
 
+func httpStatusCode(err error) int {
+	switch err.(type){
+	case *vds.InvalidArgument: return http.StatusBadRequest
+	case *vds.InternalError:   return http.StatusInternalServerError
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
 type Endpoint struct {
 	MakeVdsConnection vds.ConnectionMaker
 	Cache             cache.Cache

--- a/api/endpoint.go
+++ b/api/endpoint.go
@@ -271,6 +271,13 @@ func parseGetRequest(ctx *gin.Context, v interface{}) error {
 	return nil
 }
 
+func parsePostRequest(ctx *gin.Context, request interface{}) error {
+	if err := ctx.ShouldBind(&request); err != nil {
+		return vds.NewInvalidArgument(err.Error())
+	}
+	return nil
+}
+
 func (e *Endpoint) Health(ctx *gin.Context) {
 	ctx.String(http.StatusOK, "I am up and running")
 }
@@ -303,10 +310,9 @@ func (e *Endpoint) MetadataGet(ctx *gin.Context) {
 // @Router   /metadata  [post]
 func (e *Endpoint) MetadataPost(ctx *gin.Context) {
 	var request MetadataRequest
-	if err := ctx.ShouldBind(&request); err != nil {
-		ctx.AbortWithError(http.StatusBadRequest, err)
-		return
-	}
+	err := parsePostRequest(ctx, &request)
+	if abortOnError(ctx, err) { return }
+
 	e.metadata(ctx, request)
 }
 
@@ -341,10 +347,9 @@ func (e *Endpoint) SliceGet(ctx *gin.Context) {
 // @Router   /slice  [post]
 func (e *Endpoint) SlicePost(ctx *gin.Context) {
 	var request SliceRequest
-	if err := ctx.ShouldBind(&request); err != nil {
-		ctx.AbortWithError(http.StatusBadRequest, err)
-		return
-	}
+	err := parsePostRequest(ctx, &request)
+	if abortOnError(ctx, err) { return }
+
 	e.slice(ctx, request)
 }
 
@@ -380,10 +385,9 @@ func (e *Endpoint) FenceGet(ctx *gin.Context) {
 // @Router   /fence  [post]
 func (e *Endpoint) FencePost(ctx *gin.Context) {
 	var request FenceRequest
-	if err := ctx.ShouldBind(&request); err != nil {
-		ctx.AbortWithError(http.StatusBadRequest, err)
-		return
-	}
+	err := parsePostRequest(ctx, &request)
+	if abortOnError(ctx, err) { return }
+
 	e.fence(ctx, request)
 }
 
@@ -400,10 +404,9 @@ func (e *Endpoint) FencePost(ctx *gin.Context) {
 // @Router   /horizon  [post]
 func (e *Endpoint) HorizonPost(ctx *gin.Context) {
 	var request HorizonRequest
-	if err := ctx.ShouldBind(&request); err != nil {
-		ctx.AbortWithError(http.StatusBadRequest, err)
-		return
-	}
+	err := parsePostRequest(ctx, &request)
+	if abortOnError(ctx, err) { return }
+
 	e.horizon(ctx, request)
 }
 
@@ -417,9 +420,8 @@ func (e *Endpoint) HorizonPost(ctx *gin.Context) {
 // @Router   /horizon/attributes  [post]
 func (e *Endpoint) AttributesPost(ctx *gin.Context) {
 	var request AttributeRequest
-	if err := ctx.ShouldBind(&request); err != nil {
-		ctx.AbortWithError(http.StatusBadRequest, err)
-		return
-	}
+	err := parsePostRequest(ctx, &request)
+	if abortOnError(ctx, err) { return }
+
 	e.attributes(ctx, request)
 }

--- a/api/endpoint.go
+++ b/api/endpoint.go
@@ -261,10 +261,14 @@ func (e *Endpoint) attributes(ctx *gin.Context, request AttributeRequest) {
 
 func parseGetRequest(ctx *gin.Context, v interface{}) error {
 	if err := json.Unmarshal([]byte(ctx.Query("query")), v); err != nil {
-		return err
+		return vds.NewInvalidArgument(err.Error())
 	}
 
-	return binding.Validator.ValidateStruct(v)
+	if err := binding.Validator.ValidateStruct(v); err != nil {
+		return vds.NewInvalidArgument(err.Error())
+	}
+
+	return nil
 }
 
 func (e *Endpoint) Health(ctx *gin.Context) {
@@ -282,10 +286,9 @@ func (e *Endpoint) Health(ctx *gin.Context) {
 // @Router   /metadata  [get]
 func (e *Endpoint) MetadataGet(ctx *gin.Context) {
 	var request MetadataRequest
-	if err := parseGetRequest(ctx, &request); err != nil {
-		ctx.AbortWithError(http.StatusBadRequest, err)
-		return
-	}
+	err := parseGetRequest(ctx, &request)
+	if abortOnError(ctx, err) { return }
+
 	e.metadata(ctx, request)
 }
 
@@ -319,10 +322,9 @@ func (e *Endpoint) MetadataPost(ctx *gin.Context) {
 // @Router   /slice  [get]
 func (e *Endpoint) SliceGet(ctx *gin.Context) {
 	var request SliceRequest
-	if err := parseGetRequest(ctx, &request); err != nil {
-		ctx.AbortWithError(http.StatusBadRequest, err)
-		return
-	}
+	err := parseGetRequest(ctx, &request)
+	if abortOnError(ctx, err) { return }
+
 	e.slice(ctx, request)
 }
 
@@ -359,10 +361,9 @@ func (e *Endpoint) SlicePost(ctx *gin.Context) {
 // @Router   /fence  [get]
 func (e *Endpoint) FenceGet(ctx *gin.Context) {
 	var request FenceRequest
-	if err := parseGetRequest(ctx, &request); err != nil {
-		ctx.AbortWithError(http.StatusBadRequest, err)
-		return
-	}
+	err := parseGetRequest(ctx, &request)
+	if abortOnError(ctx, err) { return }
+
 	e.fence(ctx, request)
 }
 

--- a/api/endpoint.go
+++ b/api/endpoint.go
@@ -200,20 +200,18 @@ func validateVerticalWindow(above float32, below float32,) error {
 	if lower <= above && above < upper { return nil }
 	if lower <= below && below < upper { return nil }
 	
-	return fmt.Errorf(
+	return vds.NewInvalidArgument(fmt.Sprintf(
 		"'above'/'below' out of range! Must be within [%d, %d]",
 		lower,
 		upper,
-	)
+	))
 }
 
 func (e *Endpoint) attributes(ctx *gin.Context, request AttributeRequest) {
 	prepareRequestLogging(ctx, request)
 
-	if err := validateVerticalWindow(*request.Above, *request.Below); err != nil {
-		ctx.AbortWithError(http.StatusBadRequest, err)
-		return
-	}
+	err := validateVerticalWindow(*request.Above, *request.Below)
+	if abortOnError(ctx, err) { return }
 
 	conn, err := e.MakeVdsConnection(request.Vds, request.Sas)
 	if abortOnError(ctx, err) { return }

--- a/api/endpoint.go
+++ b/api/endpoint.go
@@ -23,6 +23,34 @@ func httpStatusCode(err error) int {
 	}
 }
 
+/* Call abortOnError on the context in case of an error
+ *
+ * This function is designed specifically for our endpoint handler functions
+ * and aims at making the errorhandling as short and concise as possible.
+ *
+ * If err != nil the error will be mapped to an appropriate http status code
+ * through the httpStatusCode mapper, and ctx.AbortWithError will be called
+ * with this status and the error itself. It then returns true to indicate that
+ * the context have been aborted.
+ *
+ * If err == nil the ctx is left untouched and this function returns false,
+ * indicating that the context was not aborted.
+ *
+ * The result is a oneline error handling:
+ *
+ *     err, _ := func()
+ *     if abortOnError(ctx, err) { return }
+ */
+func abortOnError(ctx *gin.Context, err error) bool {
+	if err == nil {
+		return false
+	}
+
+	ctx.AbortWithError(httpStatusCode(err), err)
+
+	return true
+}
+
 type Endpoint struct {
 	MakeVdsConnection vds.ConnectionMaker
 	Cache             cache.Cache

--- a/internal/vds/connection.go
+++ b/internal/vds/connection.go
@@ -39,11 +39,11 @@ func srtContainsContainer(srt string) bool {
 func validateSasSrt(connection *AzureConnection) error {
 	query, err := url.ParseQuery(connection.sas)
 	if err != nil {
-		return fmt.Errorf(
+		return NewInvalidArgument(fmt.Sprintf(
 			"illegal sas-token, was: '%s',  err: %v",
 			connection.sas,
 			err,
-		)
+		))
 	}
 
 	if !query.Has("srt") {
@@ -54,10 +54,10 @@ func validateSasSrt(connection *AzureConnection) error {
 	if srtContainsObject(srt) && srtContainsContainer(srt) {
 		return nil
 	}
-	return fmt.Errorf(
+	return NewInvalidArgument(fmt.Sprintf(
 		"invalid sas-token, expected 'c' and 'o' in 'srt', found: '%s'",
 		srt,
-	)
+	))
 }
 
 type Connection interface {
@@ -183,7 +183,7 @@ func isAllowed(allowlist []*url.URL, requested *url.URL) error {
 	msg := "unsupported storage account: %s. This API is configured to work "  +
 		"with a pre-defined set of storage accounts. Contact the system admin " +
 		"to get your storage account on the allowlist"
-	return fmt.Errorf(msg, requested.Host)
+	return NewInvalidArgument(fmt.Sprintf(msg, requested.Host))
 }
 /*
  * Strip leading ? if present from the input SAS token
@@ -218,7 +218,7 @@ func MakeAzureConnection(accounts []string) ConnectionMaker {
 	return func(blob string, sas string) (Connection, error) {
 		blobUrl, err := makeUrl(blob)
 		if err != nil {
-			return nil, err
+			return nil, NewInvalidArgument(err.Error())
 		}
 
 		if err := isAllowed(allowlist, blobUrl); err != nil {

--- a/internal/vds/datahandle.cpp
+++ b/internal/vds/datahandle.cpp
@@ -26,22 +26,14 @@ OpenVDS::InterpolationMethod to_interpolation(interpolation_method interpolation
 
 } /* namespace */
 
-DataHandle::DataHandle(std::string const url, std::string const credentials) {
-    OpenVDS::Error error;
-    auto handle = OpenVDS::Open(url, credentials, error);
-    if(error.code != 0) {
-        throw std::runtime_error("Could not open VDS: " + error.string);
-    }
-
-    this->m_file_handle = handle;
-    this->m_access_manager = OpenVDS::GetAccessManager(this->m_file_handle);
-    this->m_metadata = std::unique_ptr<MetadataHandle>(
-        new MetadataHandle(this->m_access_manager.GetVolumeDataLayout())
-    );
-}
+DataHandle::DataHandle(OpenVDS::VDSHandle handle)
+    : m_file_handle(handle)
+    , m_access_manager(OpenVDS::GetAccessManager(handle))
+    , m_metadata(m_access_manager.GetVolumeDataLayout())
+{}
 
 MetadataHandle const& DataHandle::get_metadata() const noexcept (true) {
-    return *(this->m_metadata);
+    return this->m_metadata;
 }
 
 OpenVDS::VolumeDataFormat DataHandle::format() noexcept (true) {

--- a/internal/vds/datahandle.hpp
+++ b/internal/vds/datahandle.hpp
@@ -13,7 +13,7 @@ using voxel = float[OpenVDS::Dimensionality_Max];
 
 class DataHandle {
 public:
-    DataHandle(std::string const url, std::string const credentials);
+    DataHandle(OpenVDS::VDSHandle handle);
 
     MetadataHandle const& get_metadata() const noexcept (true);
 
@@ -51,8 +51,7 @@ public:
 private:
     OpenVDS::ScopedVDSHandle m_file_handle;
     OpenVDS::VolumeDataAccessManager m_access_manager;
-    // Must be pointer due to delayed initialization.
-    std::unique_ptr<MetadataHandle> m_metadata;
+    MetadataHandle m_metadata;
 
     static int constexpr lod_level = 0;
     static int constexpr channel = 0;

--- a/internal/vds/errors.go
+++ b/internal/vds/errors.go
@@ -13,3 +13,15 @@ func NewInvalidArgument(msg string) *InvalidArgument {
 		message: msg,
 	}
 }
+
+type InternalError struct {
+	message string
+}
+
+func (e *InternalError) Error() string {
+	return e.message
+}
+
+func NewInternalError(msg string) *InternalError {
+	return &InternalError{ message: msg }
+}

--- a/internal/vds/exceptions.hpp
+++ b/internal/vds/exceptions.hpp
@@ -1,0 +1,14 @@
+#ifndef VDS_SLICE_EXCEPTIONS_H
+#define VDS_SLICE_EXCEPTIONS_H
+
+#include <stdexcept>
+
+namespace detail {
+
+struct nullptr_error : public std::runtime_error {
+    using std::runtime_error::runtime_error;
+};
+
+} // namespace detail
+
+#endif // VDS_SLICE_EXCEPTIONS_H

--- a/internal/vds/vds.cpp
+++ b/internal/vds/vds.cpp
@@ -530,6 +530,26 @@ struct response fetch_horizon_metadata(
     return to_response(meta);
 }
 
+struct Context {
+    std::string errmsg;
+};
+
+Context* context_new() {
+    return new Context{};
+}
+
+int context_free(Context* ctx) {
+    if (not ctx) return STATUS_OK;
+
+    delete ctx;
+    return STATUS_OK;
+}
+
+const char* errmsg(Context* ctx) {
+    if (not ctx) return nullptr;
+    return ctx->errmsg.c_str();
+}
+
 struct response slice(
     const char* vds,
     const char* credentials,

--- a/internal/vds/vds.cpp
+++ b/internal/vds/vds.cpp
@@ -567,7 +567,7 @@ const char* errmsg(Context* ctx) {
     return ctx->errmsg.c_str();
 }
 
-void slice(
+int slice(
     const char* vds,
     const char* credentials,
     int lineno,
@@ -582,14 +582,17 @@ void slice(
         if (not out) throw detail::nullptr_error("Invalid out pointer");
 
         fetch_slice(cube, cred, direction, lineno, out);
+        return STATUS_OK;
     } catch (const detail::nullptr_error& e) {
         to_response(e, out);
+        return STATUS_NULLPTR_ERROR;
     } catch (const std::exception& e) {
         to_response(e, out);
+        return STATUS_RUNTIME_ERROR;
     }
 }
 
-void slice_metadata(
+int slice_metadata(
     const char* vds,
     const char* credentials,
     axis_name ax,
@@ -603,14 +606,17 @@ void slice_metadata(
         if (not out) throw detail::nullptr_error("Invalid out pointer");
 
         fetch_slice_metadata(cube, cred, direction, out);
+        return STATUS_OK;
     } catch (const detail::nullptr_error& e) {
         to_response(e, out);
+        return STATUS_NULLPTR_ERROR;
     } catch (const std::exception& e) {
         to_response(e, out);
+        return STATUS_RUNTIME_ERROR;
     }
 }
 
-void fence(
+int fence(
     const char* vds,
     const char* credentials,
     enum coordinate_system coordinate_system,
@@ -634,14 +640,17 @@ void fence(
             interpolation_method,
             out
         );
+        return STATUS_OK;
     } catch (const detail::nullptr_error& e) {
         to_response(e, out);
+        return STATUS_NULLPTR_ERROR;
     } catch (const std::exception& e) {
         to_response(e, out);
+        return STATUS_RUNTIME_ERROR;
     }
 }
 
-void fence_metadata(
+int fence_metadata(
     const char* vds,
     const char* credentials,
     size_t npoints,
@@ -654,14 +663,17 @@ void fence_metadata(
         if (not out) throw detail::nullptr_error("Invalid out pointer");
 
         fetch_fence_metadata(cube, cred, npoints, out);
+        return STATUS_OK;
     } catch (const detail::nullptr_error& e) {
         to_response(e, out);
+        return STATUS_NULLPTR_ERROR;
     } catch (const std::exception& e) {
         to_response(e, out);
+        return STATUS_RUNTIME_ERROR;
     }
 }
 
-void metadata(
+int metadata(
     const char* vds,
     const char* credentials,
     response* out
@@ -672,14 +684,17 @@ void metadata(
         std::string cube(vds);
         std::string cred(credentials);
         metadata(cube, cred, out);
+        return STATUS_OK;
     } catch (const detail::nullptr_error& e) {
         to_response(e, out);
+        return STATUS_NULLPTR_ERROR;
     } catch (const std::exception& e) {
         to_response(e, out);
+        return STATUS_RUNTIME_ERROR;
     }
 }
 
-void horizon(
+int horizon(
     const char*  vdspath,
     const char* credentials,
     const float* data,
@@ -714,14 +729,17 @@ void horizon(
             interpolation,
             out
         );
+        return STATUS_OK;
     } catch (const detail::nullptr_error& e) {
         to_response(e, out);
+        return STATUS_NULLPTR_ERROR;
     } catch (const std::exception& e) {
         to_response(e, out);
+        return STATUS_RUNTIME_ERROR;
     }
 }
 
-void horizon_metadata(
+int horizon_metadata(
     const char*  vdspath,
     const char* credentials,
     size_t nrows,
@@ -735,14 +753,17 @@ void horizon_metadata(
         std::string cred(credentials);
 
         fetch_horizon_metadata(cube, cred, nrows, ncols, out);
+        return STATUS_OK;
     } catch (const detail::nullptr_error& e) {
         to_response(e, out);
+        return STATUS_NULLPTR_ERROR;
     } catch (const std::exception& e) {
         to_response(e, out);
+        return STATUS_RUNTIME_ERROR;
     }
 }
 
-void attribute(
+int attribute(
     const char* data,
     size_t size,
     size_t vertical_window,
@@ -755,10 +776,14 @@ void attribute(
         if (not out) throw detail::nullptr_error("Invalid out pointer");
 
         Horizon horizon((float*)data, size, vertical_window, fillvalue);
+
         calculate_attribute(horizon, attributes, nattributes, out);
+        return STATUS_OK;
     } catch (const detail::nullptr_error& e) {
         to_response(e, out);
+        return STATUS_NULLPTR_ERROR;
     } catch (const std::exception& e) {
         to_response(e, out);
+        return STATUS_RUNTIME_ERROR;
     }
 }

--- a/internal/vds/vds.cpp
+++ b/internal/vds/vds.cpp
@@ -548,7 +548,14 @@ int datahandle_new(
 ) {
     try {
         if (not out) throw detail::nullptr_error("Invalid out pointer");
-        *out = new DataHandle(url, credentials);
+
+        OpenVDS::Error error;
+        auto handle = OpenVDS::Open(url, credentials, error);
+        if(error.code != 0) {
+            throw std::runtime_error("Could not open VDS: " + error.string);
+        }
+
+        *out = new DataHandle(std::move(handle));
         return STATUS_OK;
     } catch (const detail::nullptr_error& e) {
         if (ctx) ctx->errmsg = e.what();

--- a/internal/vds/vds.cpp
+++ b/internal/vds/vds.cpp
@@ -557,6 +557,38 @@ const char* errmsg(Context* ctx) {
     return ctx->errmsg.c_str();
 }
 
+int datahandle_new(
+    Context* ctx,
+    const char* url,
+    const char* credentials,
+    DataHandle** out
+) {
+    try {
+        if (not out) throw detail::nullptr_error("Invalid out pointer");
+        *out = new DataHandle(url, credentials);
+        return STATUS_OK;
+    } catch (const detail::nullptr_error& e) {
+        if (ctx) ctx->errmsg = e.what();
+        return STATUS_NULLPTR_ERROR;
+    } catch (const std::exception& e) {
+        if (ctx) ctx->errmsg = e.what();
+        return STATUS_RUNTIME_ERROR;
+    }
+}
+
+int datahandle_free(Context* ctx, DataHandle* f) {
+    try {
+        if (not f) return STATUS_OK;
+
+        delete f;
+
+        return STATUS_OK;
+    } catch (const std::exception& e) {
+        if (ctx) ctx->errmsg = e.what();
+        return STATUS_RUNTIME_ERROR;
+    }
+}
+
 int slice(
     Context* ctx,
     const char* vds,

--- a/internal/vds/vds.cpp
+++ b/internal/vds/vds.cpp
@@ -579,6 +579,20 @@ int datahandle_free(Context* ctx, DataHandle* f) {
     }
 }
 
+int handle_exception(Context* ctx, std::exception_ptr eptr) {
+    try {
+        if (eptr) std::rethrow_exception(eptr);
+    } catch (const detail::nullptr_error& e) {
+        if (ctx) ctx->errmsg = e.what();
+        return STATUS_NULLPTR_ERROR;
+    } catch (const std::exception& e) {
+        if (ctx) ctx->errmsg = e.what();
+        return STATUS_RUNTIME_ERROR;
+    }
+
+    return STATUS_OK;
+}
+
 int slice(
     Context* ctx,
     DataHandle* handle,
@@ -593,12 +607,8 @@ int slice(
         Direction const direction(ax);
         fetch_slice(*handle, direction, lineno, out);
         return STATUS_OK;
-    } catch (const detail::nullptr_error& e) {
-        if (ctx) ctx->errmsg = e.what();
-        return STATUS_NULLPTR_ERROR;
-    } catch (const std::exception& e) {
-        if (ctx) ctx->errmsg = e.what();
-        return STATUS_RUNTIME_ERROR;
+    } catch (...) {
+        return handle_exception(ctx, std::current_exception());
     }
 }
 
@@ -615,12 +625,8 @@ int slice_metadata(
         Direction const direction(ax);
         fetch_slice_metadata(*handle, direction, out);
         return STATUS_OK;
-    } catch (const detail::nullptr_error& e) {
-        if (ctx) ctx->errmsg = e.what();
-        return STATUS_NULLPTR_ERROR;
-    } catch (const std::exception& e) {
-        if (ctx) ctx->errmsg = e.what();
-        return STATUS_RUNTIME_ERROR;
+    } catch (...) {
+        return handle_exception(ctx, std::current_exception());
     }
 }
 
@@ -646,12 +652,8 @@ int fence(
             out
         );
         return STATUS_OK;
-    } catch (const detail::nullptr_error& e) {
-        if (ctx) ctx->errmsg = e.what();
-        return STATUS_NULLPTR_ERROR;
-    } catch (const std::exception& e) {
-        if (ctx) ctx->errmsg = e.what();
-        return STATUS_RUNTIME_ERROR;
+    } catch (...) {
+        return handle_exception(ctx, std::current_exception());
     }
 }
 
@@ -667,12 +669,8 @@ int fence_metadata(
 
         fetch_fence_metadata(*handle, npoints, out);
         return STATUS_OK;
-    } catch (const detail::nullptr_error& e) {
-        if (ctx) ctx->errmsg = e.what();
-        return STATUS_NULLPTR_ERROR;
-    } catch (const std::exception& e) {
-        if (ctx) ctx->errmsg = e.what();
-        return STATUS_RUNTIME_ERROR;
+    } catch (...) {
+        return handle_exception(ctx, std::current_exception());
     }
 }
 
@@ -687,12 +685,8 @@ int metadata(
 
         metadata(*handle, out);
         return STATUS_OK;
-    } catch (const detail::nullptr_error& e) {
-        if (ctx) ctx->errmsg = e.what();
-        return STATUS_NULLPTR_ERROR;
-    } catch (const std::exception& e) {
-        if (ctx) ctx->errmsg = e.what();
-        return STATUS_RUNTIME_ERROR;
+    } catch (...) {
+        return handle_exception(ctx, std::current_exception());
     }
 }
 
@@ -729,12 +723,8 @@ int horizon(
             out
         );
         return STATUS_OK;
-    } catch (const detail::nullptr_error& e) {
-        if (ctx) ctx->errmsg = e.what();
-        return STATUS_NULLPTR_ERROR;
-    } catch (const std::exception& e) {
-        if (ctx) ctx->errmsg = e.what();
-        return STATUS_RUNTIME_ERROR;
+    } catch (...) {
+        return handle_exception(ctx, std::current_exception());
     }
 }
 
@@ -751,12 +741,8 @@ int horizon_metadata(
 
         fetch_horizon_metadata(*handle, nrows, ncols, out);
         return STATUS_OK;
-    } catch (const detail::nullptr_error& e) {
-        if (ctx) ctx->errmsg = e.what();
-        return STATUS_NULLPTR_ERROR;
-    } catch (const std::exception& e) {
-        if (ctx) ctx->errmsg = e.what();
-        return STATUS_RUNTIME_ERROR;
+    } catch (...) {
+        return handle_exception(ctx, std::current_exception());
     }
 }
 
@@ -777,11 +763,7 @@ int attribute(
 
         calculate_attribute(horizon, attributes, nattributes, out);
         return STATUS_OK;
-    } catch (const detail::nullptr_error& e) {
-        if (ctx) ctx->errmsg = e.what();
-        return STATUS_NULLPTR_ERROR;
-    } catch (const std::exception& e) {
-        if (ctx) ctx->errmsg = e.what();
-        return STATUS_RUNTIME_ERROR;
+    } catch (...) {
+        return handle_exception(ctx, std::current_exception());
     }
 }

--- a/internal/vds/vds.go
+++ b/internal/vds/vds.go
@@ -189,7 +189,13 @@ func (v VDSHandle) Error(status C.int) error {
 	}
 
 	msg := C.GoString(C.errmsg(v.context()))
-	return errors.New(msg)
+
+	switch status {
+	case C.STATUS_NULLPTR_ERROR: fallthrough
+	case C.STATUS_RUNTIME_ERROR: return NewInternalError(msg)
+	default:
+		return errors.New(msg)
+	}
 }
 
 func (v VDSHandle) Close() error {

--- a/internal/vds/vds.go
+++ b/internal/vds/vds.go
@@ -178,11 +178,11 @@ func GetMetadata(conn Connection) ([]byte, error) {
 	defer C.free(unsafe.Pointer(ccred))
 
 	var result C.struct_response
-	C.metadata(curl, ccred, &result)
+	cerr := C.metadata(curl, ccred, &result)
 
 	defer C.response_delete(&result)
 
-	if result.err != nil {
+	if cerr != C.STATUS_OK {
 		err := C.GoString(result.err)
 		return nil, errors.New(err)
 	}
@@ -199,7 +199,7 @@ func GetSlice(conn Connection, lineno, direction int) ([]byte, error) {
 	defer C.free(unsafe.Pointer(ccred))
 
 	var result C.struct_response
-	C.slice(
+	cerr := C.slice(
 		curl,
 		ccred,
 		C.int(lineno),
@@ -208,8 +208,7 @@ func GetSlice(conn Connection, lineno, direction int) ([]byte, error) {
 	)
 
 	defer C.response_delete(&result)
-
-	if result.err != nil {
+	if cerr != C.STATUS_OK {
 		err := C.GoString(result.err)
 		return nil, errors.New(err)
 	}
@@ -226,7 +225,7 @@ func GetSliceMetadata(conn Connection, direction int) ([]byte, error) {
 	defer C.free(unsafe.Pointer(ccred))
 
 	var result C.struct_response
-	C.slice_metadata(
+	cerr := C.slice_metadata(
 		curl,
 		ccred,
 		C.enum_axis_name(direction),
@@ -235,7 +234,7 @@ func GetSliceMetadata(conn Connection, direction int) ([]byte, error) {
 
 	defer C.response_delete(&result)
 
-	if result.err != nil {
+	if cerr != C.STATUS_OK {
 		err := C.GoString(result.err)
 		return nil, errors.New(err)
 	}
@@ -275,7 +274,7 @@ func GetFence(
 	}
 
 	var result C.struct_response
-	C.fence(
+	cerr := C.fence(
 		cvds,
 		ccred,
 		C.enum_coordinate_system(coordinateSystem),
@@ -287,7 +286,7 @@ func GetFence(
 
 	defer C.response_delete(&result)
 
-	if result.err != nil {
+	if cerr != C.STATUS_OK {
 		err := C.GoString(result.err)
 		return nil, errors.New(err)
 	}
@@ -304,7 +303,7 @@ func GetFenceMetadata(conn Connection, coordinates [][]float32) ([]byte, error) 
 	defer C.free(unsafe.Pointer(ccred))
 
 	var result C.struct_response
-	C.fence_metadata(
+	cerr := C.fence_metadata(
 		curl,
 		ccred,
 		C.size_t(len(coordinates)),
@@ -313,7 +312,7 @@ func GetFenceMetadata(conn Connection, coordinates [][]float32) ([]byte, error) 
 
 	defer C.response_delete(&result)
 
-	if result.err != nil {
+	if cerr != C.STATUS_OK {
 		err := C.GoString(result.err)
 		return nil, errors.New(err)
 	}
@@ -361,7 +360,7 @@ func getHorizon(
 	}
 
 	var result C.struct_response
-	C.horizon(
+	cerr := C.horizon(
 		curl,
 		ccred,
 		&cdata[0],
@@ -379,7 +378,7 @@ func getHorizon(
 		&result,
 	)
 
-	if result.err != nil {
+	if cerr != C.STATUS_OK {
 		err := C.GoString(result.err)
 		C.response_delete(&result)
 		return nil, errors.New(err)
@@ -433,7 +432,7 @@ func GetHorizonMetadata(conn Connection, data [][]float32) ([]byte, error) {
 	defer C.free(unsafe.Pointer(ccred))
 
 	var result C.struct_response
-	C.horizon_metadata(
+	cerr := C.horizon_metadata(
 		curl,
 		ccred,
 		C.size_t(len(data)),
@@ -443,7 +442,7 @@ func GetHorizonMetadata(conn Connection, data [][]float32) ([]byte, error) {
 
 	defer C.response_delete(&result)
 
-	if result.err != nil {
+	if cerr != C.STATUS_OK {
 		err := C.GoString(result.err)
 		return nil, errors.New(err)
 	}
@@ -505,7 +504,7 @@ func GetAttributes(
 	}
 
 	var buffer C.struct_response
-	C.attribute(
+	cerr := C.attribute(
 		horizon.data,
 		C.size_t(hsize),
 		C.size_t(vsize),
@@ -516,7 +515,7 @@ func GetAttributes(
 	)
 	defer C.response_delete(&buffer)
 
-	if buffer.err != nil {
+	if cerr != C.STATUS_OK {
 		err := C.GoString(buffer.err)
 		return nil, errors.New(err)
 	}

--- a/internal/vds/vds.go
+++ b/internal/vds/vds.go
@@ -115,7 +115,7 @@ func GetAxis(direction string) (int, error) {
 	default:
 		options := "i, j, k, inline, crossline or depth/time/sample"
 		msg := "invalid direction '%s', valid options are: %s"
-		return -1, fmt.Errorf(msg, direction, options)
+		return -1, NewInvalidArgument(fmt.Sprintf(msg, direction, options))
 	}
 }
 
@@ -130,7 +130,7 @@ func GetCoordinateSystem(coordinateSystem string) (int, error) {
 	default:
 		options := "ij, ilxl, cdp"
 		msg := "coordinate system not recognized: '%s', valid options are: %s"
-		return -1, fmt.Errorf(msg, coordinateSystem, options)
+		return -1, NewInvalidArgument(fmt.Sprintf(msg, coordinateSystem, options))
 	}
 }
 
@@ -151,7 +151,7 @@ func GetInterpolationMethod(interpolation string) (int, error) {
 	default:
 		options := "nearest, linear, cubic, angular or triangular"
 		msg := "invalid interpolation method '%s', valid options are: %s"
-		return -1, fmt.Errorf(msg, interpolation, options)
+		return -1, NewInvalidArgument(fmt.Sprintf(msg, interpolation, options))
 	}
 }
 
@@ -166,7 +166,7 @@ func GetAttributeType(attribute string) (int, error) {
 	default:
 		options := "min, max, mean, rms, sd"
 		msg := "invalid attribute '%s', valid options are: %s"
-		return -1, fmt.Errorf(msg, attribute, options)
+		return -1, NewInvalidArgument(fmt.Sprintf(msg, attribute, options))
 	}
 }
 

--- a/internal/vds/vds.go
+++ b/internal/vds/vds.go
@@ -177,13 +177,16 @@ func GetMetadata(conn Connection) ([]byte, error) {
 	ccred := C.CString(conn.ConnectionString())
 	defer C.free(unsafe.Pointer(ccred))
 
+	cctx := C.context_new()
+	defer C.context_free(cctx)
+
 	var result C.struct_response
-	cerr := C.metadata(curl, ccred, &result)
+	cerr := C.metadata(cctx, curl, ccred, &result)
 
 	defer C.response_delete(&result)
 
 	if cerr != C.STATUS_OK {
-		err := C.GoString(result.err)
+		err := C.GoString(C.errmsg(cctx))
 		return nil, errors.New(err)
 	}
 
@@ -198,8 +201,12 @@ func GetSlice(conn Connection, lineno, direction int) ([]byte, error) {
 	ccred := C.CString(conn.ConnectionString())
 	defer C.free(unsafe.Pointer(ccred))
 
+	cctx := C.context_new()
+	defer C.context_free(cctx)
+
 	var result C.struct_response
 	cerr := C.slice(
+		cctx,
 		curl,
 		ccred,
 		C.int(lineno),
@@ -209,7 +216,7 @@ func GetSlice(conn Connection, lineno, direction int) ([]byte, error) {
 
 	defer C.response_delete(&result)
 	if cerr != C.STATUS_OK {
-		err := C.GoString(result.err)
+		err := C.GoString(C.errmsg(cctx))
 		return nil, errors.New(err)
 	}
 
@@ -224,8 +231,12 @@ func GetSliceMetadata(conn Connection, direction int) ([]byte, error) {
 	ccred := C.CString(conn.ConnectionString())
 	defer C.free(unsafe.Pointer(ccred))
 
+	cctx := C.context_new()
+	defer C.context_free(cctx)
+
 	var result C.struct_response
 	cerr := C.slice_metadata(
+		cctx,
 		curl,
 		ccred,
 		C.enum_axis_name(direction),
@@ -235,7 +246,7 @@ func GetSliceMetadata(conn Connection, direction int) ([]byte, error) {
 	defer C.response_delete(&result)
 
 	if cerr != C.STATUS_OK {
-		err := C.GoString(result.err)
+		err := C.GoString(C.errmsg(cctx))
 		return nil, errors.New(err)
 	}
 
@@ -273,8 +284,12 @@ func GetFence(
 		}
 	}
 
+	cctx := C.context_new()
+	defer C.context_free(cctx)
+
 	var result C.struct_response
 	cerr := C.fence(
+		cctx,
 		cvds,
 		ccred,
 		C.enum_coordinate_system(coordinateSystem),
@@ -287,7 +302,7 @@ func GetFence(
 	defer C.response_delete(&result)
 
 	if cerr != C.STATUS_OK {
-		err := C.GoString(result.err)
+		err := C.GoString(C.errmsg(cctx))
 		return nil, errors.New(err)
 	}
 
@@ -302,8 +317,12 @@ func GetFenceMetadata(conn Connection, coordinates [][]float32) ([]byte, error) 
 	ccred := C.CString(conn.ConnectionString())
 	defer C.free(unsafe.Pointer(ccred))
 
+	cctx := C.context_new()
+	defer C.context_free(cctx)
+
 	var result C.struct_response
 	cerr := C.fence_metadata(
+		cctx,
 		curl,
 		ccred,
 		C.size_t(len(coordinates)),
@@ -313,7 +332,7 @@ func GetFenceMetadata(conn Connection, coordinates [][]float32) ([]byte, error) 
 	defer C.response_delete(&result)
 
 	if cerr != C.STATUS_OK {
-		err := C.GoString(result.err)
+		err := C.GoString(C.errmsg(cctx))
 		return nil, errors.New(err)
 	}
 
@@ -359,8 +378,12 @@ func getHorizon(
 		}
 	}
 
+	cctx := C.context_new()
+	defer C.context_free(cctx)
+
 	var result C.struct_response
 	cerr := C.horizon(
+		cctx,
 		curl,
 		ccred,
 		&cdata[0],
@@ -379,7 +402,7 @@ func getHorizon(
 	)
 
 	if cerr != C.STATUS_OK {
-		err := C.GoString(result.err)
+		err := C.GoString(C.errmsg(cctx))
 		C.response_delete(&result)
 		return nil, errors.New(err)
 	}
@@ -431,8 +454,12 @@ func GetHorizonMetadata(conn Connection, data [][]float32) ([]byte, error) {
 	ccred := C.CString(conn.ConnectionString())
 	defer C.free(unsafe.Pointer(ccred))
 
+	cctx := C.context_new()
+	defer C.context_free(cctx)
+
 	var result C.struct_response
 	cerr := C.horizon_metadata(
+		cctx,
 		curl,
 		ccred,
 		C.size_t(len(data)),
@@ -443,7 +470,7 @@ func GetHorizonMetadata(conn Connection, data [][]float32) ([]byte, error) {
 	defer C.response_delete(&result)
 
 	if cerr != C.STATUS_OK {
-		err := C.GoString(result.err)
+		err := C.GoString(C.errmsg(cctx))
 		return nil, errors.New(err)
 	}
 
@@ -498,6 +525,9 @@ func GetAttributes(
 	var mapsize = hsize * 4
 	var vsize   = int(horizon.size) / mapsize
 
+	cctx := C.context_new()
+	defer C.context_free(cctx)
+
 	cattributes := make([]C.enum_attribute, len(targetAttributes))
 	for i := range targetAttributes {
 		cattributes[i] = C.enum_attribute(targetAttributes[i])
@@ -505,6 +535,7 @@ func GetAttributes(
 
 	var buffer C.struct_response
 	cerr := C.attribute(
+		cctx,
 		horizon.data,
 		C.size_t(hsize),
 		C.size_t(vsize),
@@ -516,7 +547,7 @@ func GetAttributes(
 	defer C.response_delete(&buffer)
 
 	if cerr != C.STATUS_OK {
-		err := C.GoString(buffer.err)
+		err := C.GoString(C.errmsg(cctx))
 		return nil, errors.New(err)
 	}
 

--- a/internal/vds/vds.go
+++ b/internal/vds/vds.go
@@ -183,6 +183,15 @@ func (v VDSHandle) context() *C.struct_Context{
 	return v.ctx
 }
 
+func (v VDSHandle) Error(status C.int) error {
+	if status == C.STATUS_OK {
+		return nil
+	}
+
+	msg := C.GoString(C.errmsg(v.context()))
+	return errors.New(msg)
+}
+
 func (v VDSHandle) Close() error {
 	defer C.context_free(v.ctx)
 
@@ -222,9 +231,8 @@ func (v VDSHandle) GetMetadata() ([]byte, error) {
 
 	defer C.response_delete(&result)
 
-	if cerr != C.STATUS_OK {
-		err := C.GoString(C.errmsg(v.context()))
-		return nil, errors.New(err)
+	if err := v.Error(cerr); err != nil {
+		return nil, err
 	}
 
 	buf := C.GoBytes(unsafe.Pointer(result.data), C.int(result.size))
@@ -242,9 +250,8 @@ func (v VDSHandle) GetSlice(lineno, direction int) ([]byte, error) {
 	)
 
 	defer C.response_delete(&result)
-	if cerr != C.STATUS_OK {
-		err := C.GoString(C.errmsg(v.context()))
-		return nil, errors.New(err)
+	if err := v.Error(cerr); err != nil {
+		return nil, err
 	}
 
 	buf := C.GoBytes(unsafe.Pointer(result.data), C.int(result.size))
@@ -262,9 +269,8 @@ func (v VDSHandle) GetSliceMetadata(direction int) ([]byte, error) {
 
 	defer C.response_delete(&result)
 
-	if cerr != C.STATUS_OK {
-		err := C.GoString(C.errmsg(v.context()))
-		return nil, errors.New(err)
+	if err := v.Error(cerr); err != nil {
+		return nil, err
 	}
 
 	buf := C.GoBytes(unsafe.Pointer(result.data), C.int(result.size))
@@ -307,9 +313,8 @@ func (v VDSHandle) GetFence(
 
 	defer C.response_delete(&result)
 
-	if cerr != C.STATUS_OK {
-		err := C.GoString(C.errmsg(v.context()))
-		return nil, errors.New(err)
+	if err := v.Error(cerr); err != nil {
+		return nil, err
 	}
 
 	buf := C.GoBytes(unsafe.Pointer(result.data), C.int(result.size))
@@ -327,9 +332,8 @@ func (v VDSHandle) GetFenceMetadata(coordinates [][]float32) ([]byte, error) {
 
 	defer C.response_delete(&result)
 
-	if cerr != C.STATUS_OK {
-		err := C.GoString(C.errmsg(v.context()))
-		return nil, errors.New(err)
+	if err := v.Error(cerr); err != nil {
+		return nil, err
 	}
 
 	buf := C.GoBytes(unsafe.Pointer(result.data), C.int(result.size))
@@ -386,10 +390,8 @@ func (v VDSHandle) getHorizon(
 		&result,
 	)
 
-	if cerr != C.STATUS_OK {
-		err := C.GoString(C.errmsg(v.context()))
-		C.response_delete(&result)
-		return nil, errors.New(err)
+	if err := v.Error(cerr); err != nil {
+		return nil, err
 	}
 
 	return &result, nil
@@ -442,9 +444,8 @@ func (v VDSHandle) GetHorizonMetadata(data [][]float32) ([]byte, error) {
 
 	defer C.response_delete(&result)
 
-	if cerr != C.STATUS_OK {
-		err := C.GoString(C.errmsg(v.context()))
-		return nil, errors.New(err)
+	if err := v.Error(cerr); err != nil {
+		return nil, err
 	}
 
 	buf := C.GoBytes(unsafe.Pointer(result.data), C.int(result.size))
@@ -514,9 +515,8 @@ func (v VDSHandle) GetAttributes(
 	)
 	defer C.response_delete(&buffer)
 
-	if cerr != C.STATUS_OK {
-		err := C.GoString(C.errmsg(v.context()))
-		return nil, errors.New(err)
+	if err := v.Error(cerr); err != nil {
+		return nil, err
 	}
 
 	out := make([][]byte, len(targetAttributes))

--- a/internal/vds/vds.go
+++ b/internal/vds/vds.go
@@ -177,7 +177,8 @@ func GetMetadata(conn Connection) ([]byte, error) {
 	ccred := C.CString(conn.ConnectionString())
 	defer C.free(unsafe.Pointer(ccred))
 
-	result := C.metadata(curl, ccred)
+	var result C.struct_response
+	C.metadata(curl, ccred, &result)
 
 	defer C.response_delete(&result)
 
@@ -197,11 +198,13 @@ func GetSlice(conn Connection, lineno, direction int) ([]byte, error) {
 	ccred := C.CString(conn.ConnectionString())
 	defer C.free(unsafe.Pointer(ccred))
 
-	result := C.slice(
+	var result C.struct_response
+	C.slice(
 		curl,
 		ccred,
 		C.int(lineno),
 		C.enum_axis_name(direction),
+		&result,
 	)
 
 	defer C.response_delete(&result)
@@ -222,10 +225,12 @@ func GetSliceMetadata(conn Connection, direction int) ([]byte, error) {
 	ccred := C.CString(conn.ConnectionString())
 	defer C.free(unsafe.Pointer(ccred))
 
-	result := C.slice_metadata(
+	var result C.struct_response
+	C.slice_metadata(
 		curl,
 		ccred,
 		C.enum_axis_name(direction),
+		&result,
 	)
 
 	defer C.response_delete(&result)
@@ -269,13 +274,15 @@ func GetFence(
 		}
 	}
 
-	result := C.fence(
+	var result C.struct_response
+	C.fence(
 		cvds,
 		ccred,
 		C.enum_coordinate_system(coordinateSystem),
 		&ccoordinates[0],
 		C.size_t(len(coordinates)),
 		C.enum_interpolation_method(interpolation),
+		&result,
 	)
 
 	defer C.response_delete(&result)
@@ -296,10 +303,12 @@ func GetFenceMetadata(conn Connection, coordinates [][]float32) ([]byte, error) 
 	ccred := C.CString(conn.ConnectionString())
 	defer C.free(unsafe.Pointer(ccred))
 
-	result := C.fence_metadata(
+	var result C.struct_response
+	C.fence_metadata(
 		curl,
 		ccred,
 		C.size_t(len(coordinates)),
+		&result,
 	)
 
 	defer C.response_delete(&result)
@@ -351,7 +360,8 @@ func getHorizon(
 		}
 	}
 
-	result := C.horizon(
+	var result C.struct_response
+	C.horizon(
 		curl,
 		ccred,
 		&cdata[0],
@@ -366,6 +376,7 @@ func getHorizon(
 		C.float(above),
 		C.float(below),
 		C.enum_interpolation_method(interpolation),
+		&result,
 	)
 
 	if result.err != nil {
@@ -421,11 +432,13 @@ func GetHorizonMetadata(conn Connection, data [][]float32) ([]byte, error) {
 	ccred := C.CString(conn.ConnectionString())
 	defer C.free(unsafe.Pointer(ccred))
 
-	result := C.horizon_metadata(
+	var result C.struct_response
+	C.horizon_metadata(
 		curl,
 		ccred,
 		C.size_t(len(data)),
 		C.size_t(len(data[0])),
+		&result,
 	)
 
 	defer C.response_delete(&result)
@@ -491,13 +504,15 @@ func GetAttributes(
 		cattributes[i] = C.enum_attribute(targetAttributes[i])
 	}
 
-	buffer := C.attribute(
+	var buffer C.struct_response
+	C.attribute(
 		horizon.data,
 		C.size_t(hsize),
 		C.size_t(vsize),
 		C.float(fillValue),
 		&cattributes[0],
 		C.size_t(len(targetAttributes)),
+		&buffer,
 	)
 	defer C.response_delete(&buffer)
 

--- a/internal/vds/vds.h
+++ b/internal/vds/vds.h
@@ -98,15 +98,13 @@ enum attribute {
 
 int metadata(
     Context* ctx,
-    const char* vds,
-    const char* credentials,
+    DataHandle* handle,
     response* out
 );
 
 int slice(
     Context* ctx,
-    const char* vds,
-    const char* credentials,
+    DataHandle* handle,
     int lineno,
     enum axis_name direction,
     response* out
@@ -114,16 +112,14 @@ int slice(
 
 int slice_metadata(
     Context* ctx,
-    const char* vds,
-    const char* credentials,
+    DataHandle* handle,
     enum axis_name direction,
     response* out
 );
 
 int fence(
     Context* ctx,
-    const char* vds,
-    const char* credentials,
+    DataHandle* handle,
     enum coordinate_system coordinate_system,
     const float* points,
     size_t npoints,
@@ -133,16 +129,14 @@ int fence(
 
 int fence_metadata(
     Context* ctx,
-    const char* vds,
-    const char* credentials,
+    DataHandle* handle,
     size_t npoints,
     response* out
 );
 
 int horizon(
     Context* ctx,
-    const char* vds,
-    const char* credentials,
+    DataHandle* handle,
     const float* data,
     size_t nrows,
     size_t ncols,
@@ -160,8 +154,7 @@ int horizon(
 
 int horizon_metadata(
     Context* ctx,
-    const char*  vdspath,
-    const char* credentials,
+    DataHandle* handle,
     size_t nrows,
     size_t ncols,
     response* out

--- a/internal/vds/vds.h
+++ b/internal/vds/vds.h
@@ -11,6 +11,30 @@ enum status_code {
     STATUS_OK = 0
 };
 
+/** Carry additional context between caller and functions
+ *
+ * Any function that accepts a context as one of its input parameters can use
+ * it to write additional information that might be of use to the caller. This
+ * includes, but is not limited, to writting error messages into the context if
+ * the function should fail. In that case the caller can call errmsg(Context*
+ * ctx) to retrieve the error message.
+ */
+struct Context;
+typedef struct Context Context;
+
+/** Create a new context instance
+ *
+ * The returned instance must always be explicitly free'd by a
+ * call to context_free().
+ */
+Context* context_new();
+
+/** Free up the resources managed internally by the context */
+int context_free(Context* ctx);
+
+/** Read out the last error msg set on the context */
+const char* errmsg(Context* ctx);
+
 struct response {
     char*         data;
     char*         err;

--- a/internal/vds/vds.h
+++ b/internal/vds/vds.h
@@ -39,7 +39,6 @@ const char* errmsg(Context* ctx);
 
 struct response {
     char*         data;
-    char*         err;
     unsigned long size;
 };
 typedef struct response response;
@@ -80,12 +79,14 @@ enum attribute {
 };
 
 int metadata(
+    Context* ctx,
     const char* vds,
     const char* credentials,
     response* out
 );
 
 int slice(
+    Context* ctx,
     const char* vds,
     const char* credentials,
     int lineno,
@@ -94,6 +95,7 @@ int slice(
 );
 
 int slice_metadata(
+    Context* ctx,
     const char* vds,
     const char* credentials,
     enum axis_name direction,
@@ -101,6 +103,7 @@ int slice_metadata(
 );
 
 int fence(
+    Context* ctx,
     const char* vds,
     const char* credentials,
     enum coordinate_system coordinate_system,
@@ -111,6 +114,7 @@ int fence(
 );
 
 int fence_metadata(
+    Context* ctx,
     const char* vds,
     const char* credentials,
     size_t npoints,
@@ -118,6 +122,7 @@ int fence_metadata(
 );
 
 int horizon(
+    Context* ctx,
     const char* vds,
     const char* credentials,
     const float* data,
@@ -136,6 +141,7 @@ int horizon(
 );
 
 int horizon_metadata(
+    Context* ctx,
     const char*  vdspath,
     const char* credentials,
     size_t nrows,
@@ -144,6 +150,7 @@ int horizon_metadata(
 );
 
 int attribute(
+    Context* ctx,
     const char* data,
     size_t size,
     size_t vertical_window,

--- a/internal/vds/vds.h
+++ b/internal/vds/vds.h
@@ -45,6 +45,24 @@ typedef struct response response;
 
 void response_delete(struct response*);
 
+struct DataHandle;
+typedef struct DataHandle DataHandle;
+
+/** Create a new (VDS) DataHandle instance */
+int datahandle_new(
+    Context* ctx,
+    const char* url,
+    const char* credentials,
+    DataHandle** f
+);
+
+/** Free up the handle
+ *
+ * Closes the attached OpenVDS handle and frees the handle instance
+ * itself.
+ */
+int datahandle_free(Context* ctx, DataHandle* f);
+
 enum axis_name {
     I         = 0,
     J         = 1,

--- a/internal/vds/vds.h
+++ b/internal/vds/vds.h
@@ -40,6 +40,7 @@ struct response {
     char*         err;
     unsigned long size;
 };
+typedef struct response response;
 
 void response_delete(struct response*);
 

--- a/internal/vds/vds.h
+++ b/internal/vds/vds.h
@@ -12,6 +12,8 @@ struct response {
     unsigned long size;
 };
 
+void response_delete(struct response*);
+
 enum axis_name {
     I         = 0,
     J         = 1,
@@ -110,9 +112,6 @@ struct response attribute(
     enum attribute* attributes,
     size_t nattributes
 );
-
-void response_delete(struct response*);
-
 
 #ifdef __cplusplus
 }

--- a/internal/vds/vds.h
+++ b/internal/vds/vds.h
@@ -8,7 +8,9 @@ extern "C" {
 
 /** Return value status codes */
 enum status_code {
-    STATUS_OK = 0
+    STATUS_OK = 0,
+    STATUS_NULLPTR_ERROR,
+    STATUS_RUNTIME_ERROR
 };
 
 /** Carry additional context between caller and functions
@@ -77,13 +79,13 @@ enum attribute {
     SD
 };
 
-void metadata(
+int metadata(
     const char* vds,
     const char* credentials,
     response* out
 );
 
-void slice(
+int slice(
     const char* vds,
     const char* credentials,
     int lineno,
@@ -91,14 +93,14 @@ void slice(
     response* out
 );
 
-void slice_metadata(
+int slice_metadata(
     const char* vds,
     const char* credentials,
     enum axis_name direction,
     response* out
 );
 
-void fence(
+int fence(
     const char* vds,
     const char* credentials,
     enum coordinate_system coordinate_system,
@@ -108,14 +110,14 @@ void fence(
     response* out
 );
 
-void fence_metadata(
+int fence_metadata(
     const char* vds,
     const char* credentials,
     size_t npoints,
     response* out
 );
 
-void horizon(
+int horizon(
     const char* vds,
     const char* credentials,
     const float* data,
@@ -133,7 +135,7 @@ void horizon(
     response* out
 );
 
-void horizon_metadata(
+int horizon_metadata(
     const char*  vdspath,
     const char* credentials,
     size_t nrows,
@@ -141,7 +143,7 @@ void horizon_metadata(
     response* out
 );
 
-void attribute(
+int attribute(
     const char* data,
     size_t size,
     size_t vertical_window,

--- a/internal/vds/vds.h
+++ b/internal/vds/vds.h
@@ -77,40 +77,45 @@ enum attribute {
     SD
 };
 
-struct response metadata(
+void metadata(
     const char* vds,
-    const char* credentials
+    const char* credentials,
+    response* out
 );
 
-struct response slice(
+void slice(
     const char* vds,
     const char* credentials,
     int lineno,
-    enum axis_name direction
+    enum axis_name direction,
+    response* out
 );
 
-struct response slice_metadata(
+void slice_metadata(
     const char* vds,
     const char* credentials,
-    enum axis_name direction
+    enum axis_name direction,
+    response* out
 );
 
-struct response fence(
+void fence(
     const char* vds,
     const char* credentials,
     enum coordinate_system coordinate_system,
     const float* points,
     size_t npoints,
-    enum interpolation_method interpolation_method
+    enum interpolation_method interpolation_method,
+    response* out
 );
 
-struct response fence_metadata(
+void fence_metadata(
     const char* vds,
     const char* credentials,
-    size_t npoints
+    size_t npoints,
+    response* out
 );
 
-struct response horizon(
+void horizon(
     const char* vds,
     const char* credentials,
     const float* data,
@@ -124,23 +129,26 @@ struct response horizon(
     float fillvalue,
     float above,
     float below,
-    enum interpolation_method interpolation_method
+    enum interpolation_method interpolation_method,
+    response* out
 );
 
-struct response horizon_metadata(
+void horizon_metadata(
     const char*  vdspath,
     const char* credentials,
     size_t nrows,
-    size_t ncols
+    size_t ncols,
+    response* out
 );
 
-struct response attribute(
+void attribute(
     const char* data,
     size_t size,
     size_t vertical_window,
     float  fillvalue,
     enum attribute* attributes,
-    size_t nattributes
+    size_t nattributes,
+    response* out
 );
 
 #ifdef __cplusplus

--- a/internal/vds/vds.h
+++ b/internal/vds/vds.h
@@ -6,6 +6,11 @@
 extern "C" {
 #endif
 
+/** Return value status codes */
+enum status_code {
+    STATUS_OK = 0
+};
+
 struct response {
     char*         data;
     char*         err;


### PR DESCRIPTION

## Motivation

This PR implement a new design of the CGO / CAPI. There are several motivations for this new design:

1. Give more control to Go
By exposing open openvds handles to Go, they can be kept alive between function calls which will allow us to drive more of the workflow directly from GO. 

2. Performance
Avoiding the need to re-open the same vds handle multiple times also has a positive outcome on performance

3. Better errorhandling
The new error codes means that we can map C++ exceptions to C error-codes, which are them mapped to Go Errors and finally to appropriate HTTP status codes which are passed to the callers. This will enable us to return more accurate status codes.


The new design also opens other doors, that are not part of this PR:

The most noteworthy is to allocate data buffers that OpenVDS writes into directly in go (as opposed to allocating in c++ and passing a pointer to that memory to GO, which then makes it's own copy). Opening a new handle can also be used as authentication for requests that hit the cache, meaning we can get rid of our custom auth here.

## The new API

The API changes can be summarised by taking a look at the new slice signature:

```
int slice(
    Context* ctx
    DataHandle* f,
    int lineno,
    enum axis_name direction,
    response* response
);
```

1. Return value is reserved for error codes
All functions (with a couple of exceptions) implements typical C error handling through return value error codes. Status codes will allow us to better distinguish different types of errors, which means we can set more correct http errors in the response from go. E.g. user input validations that happens in C++

2. The context object
 The first parameter to every function is a context object. The main use of that is for functions to have a place to write error messages when they fail (and return a none zero return value). The caller can then call a new function `const char* errmsg(context* ctx)` to retrieve a textual message.

2. reuses already open OpenVDS handle (`DataHandle*`)
Opening a new vds handle is expensive (as it will download the metadata entries). By keeping an open instance alive, and letting Go manage its lifetime we can do more roundtrips to C++ without paying huge costs. This will again enable us to drive more of the workflow from GO directly. 

4. The result is written into an output parameter (`response`)
The response struct is relieved of its responsibly of carrying error messages. That is now handled by the return value and the context. It's also been moved from a return value to an output parameter - in order to free up the return value for status codes.


