### PR TITLE
Return geospacial information in slice metadata

### DIFF
--- a/api/endpoint.go
+++ b/api/endpoint.go
@@ -98,7 +98,7 @@ func (e *Endpoint) slice(ctx *gin.Context, request SliceRequest) {
 	axis, err := vds.GetAxis(strings.ToLower(request.Direction))
 	if abortOnError(ctx, err) { return }
 
-	metadata, err := handle.GetSliceMetadata(axis)
+	metadata, err := handle.GetSliceMetadata(*request.Lineno, axis)
 	if abortOnError(ctx, err) { return }
 
 	data, err := handle.GetSlice(*request.Lineno, axis)

--- a/internal/vds/vds.go
+++ b/internal/vds/vds.go
@@ -61,7 +61,6 @@ type BoundingBox struct {
 	Ij   [][]float64 `json:"ij"`
 } //@name BoundingBox
 
-
 // @Description Slice metadata
 type SliceMetadata struct {
 	// Data format is represented by a numpy-style formatcodes. E.g. f4 is 4
@@ -74,6 +73,11 @@ type SliceMetadata struct {
 
 	// Y-axis information
 	Y Axis `json:"y"`
+
+	// Horizontal bounding box of the slice. For inline/crossline slices this
+	// is a linestring, while for time/depth slices this is essentially the
+	// bounding box of the volume.
+	Geospatial [][]float64 `json:"geospatial"`
 } // @name SliceMetadata
 
 // @Description Metadata
@@ -340,11 +344,12 @@ func (v VDSHandle) GetSlice(lineno, direction int) ([]byte, error) {
 	return buf, nil
 }
 
-func (v VDSHandle) GetSliceMetadata(direction int) ([]byte, error) {
+func (v VDSHandle) GetSliceMetadata(lineno, direction int) ([]byte, error) {
 	var result C.struct_response
 	cerr := C.slice_metadata(
 		v.context(),
 		v.Handle(),
+		C.int(lineno),
 		C.enum_axis_name(direction),
 		&result,
 	)

--- a/internal/vds/vds.h
+++ b/internal/vds/vds.h
@@ -137,6 +137,7 @@ int slice(
 int slice_metadata(
     Context* ctx,
     DataHandle* handle,
+    int lineno,
     enum axis_name direction,
     response* out
 );

--- a/tests/e2e/test_requests.py
+++ b/tests/e2e/test_requests.py
@@ -99,7 +99,8 @@ def test_slice(method):
     {
         "x": {"annotation": "Sample", "max": 16.0, "min": 4.0, "samples" : 4, "unit": "ms"},
         "y": {"annotation": "Crossline", "max": 11.0, "min": 10.0, "samples" : 2, "unit": "unitless"},
-        "format": "<f4"
+        "format": "<f4",
+        "geospatial": [[14.0, 8.0], [12.0, 11.0]]
     }
     """)
     assert meta == expected_meta


### PR DESCRIPTION
Geospacial information is often integral in order to relate seismic to other data sources. Currently we provide the bounding box of the entire cube through /metadata. However, when fetching a (vertical) slice the user would have to manually do coordinate mapping to get the geospacial position of the slice. This commit adds this information to the slice metadata. For horizontal slices, this is just the bounding box, while for vertical slices this is essentially a linestring.

There are many ways to implement this, and I landed on basing it on the SubVolume bounds. This has 2 benefits. Firstly, it ensures consistency between fetch_slice and fetch_slice_metadata, and secondly, it is future proof if we ever deside to implement sub-slicing.