### PR TITLE
Consistently use Go module "require" for testing

### DIFF
--- a/api/request_test.go
+++ b/api/request_test.go
@@ -65,9 +65,7 @@ func TestSasIsOmmitedFromSliceHash(t *testing.T) {
 		"Failed to compute hash, err: %v", err,
 	)
 
-	if hash1 != hash2 {
-		t.Fatalf("Expected hashes to be equal, was %v and %v", hash1, hash2)
-	}
+	require.Equalf(t, hash1, hash2, "Expected hashes to be equal")
 }
 
 func TestSasIsOmmitedFromFenceHash(t *testing.T) {
@@ -96,9 +94,7 @@ func TestSasIsOmmitedFromFenceHash(t *testing.T) {
 		"Failed to compute hash, err: %v", err,
 	)
 
-	if hash1 != hash2 {
-		t.Fatalf("Expected hashes to be equal, was %v and %v", hash1, hash2)
-	}
+	require.Equalf(t, hash1, hash2, "Expected hashes to be equal")
 }
 
 func TestSliceGivesUniqueHash(t *testing.T) {

--- a/api/request_test.go
+++ b/api/request_test.go
@@ -130,14 +130,10 @@ func TestSliceGivesUniqueHash(t *testing.T) {
 			"[%s] Failed to compute hash, err: %v", testCase.name, err,
 		)
 
-		if hash1 == hash2 {
-			t.Fatalf(
-				"[%s] Expected unique hashes, got: %v == %v",
-				testCase.name,
-				hash1,
-				hash2,
-			)
-		}
+		require.NotEqualf(t, hash1, hash2,
+			"[%s] Expected unique hashes",
+			testCase.name,
+		)
 	}
 }
 
@@ -183,14 +179,10 @@ func TestFenceGivesUniqueHash(t *testing.T) {
 			"[%s] Failed to compute hash, err: %v", testCase.name, err,
 		)
 
-		if hash1 == hash2 {
-			t.Fatalf(
-				"[%s] Expected unique hashes, got: %v == %v",
-				testCase.name,
-				hash1,
-				hash2,
-			)
-		}
+		require.NotEqualf(t, hash1, hash2,
+			"[%s] Expected unique hashes",
+			testCase.name,
+		)
 	}
 }
 

--- a/api/request_test.go
+++ b/api/request_test.go
@@ -3,7 +3,6 @@ package api
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -239,10 +238,10 @@ func TestExtractSasFromUrl(t *testing.T) {
 	for _, testCase := range testCases {
 		err := testCase.request.NormalizeConnection()
 		if testCase.shouldError {
-			assert.ErrorContains(t, err, testCase.expected)
+			require.ErrorContains(t, err, testCase.expected)
 		} else {
-			assert.NoError(t, err)
-			assert.Equal(t, testCase.expected, testCase.request.Sas)
+			require.NoError(t, err)
+			require.Equal(t, testCase.expected, testCase.request.Sas)
 		}
 	}
 }

--- a/api/request_test.go
+++ b/api/request_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func newSliceRequest(
@@ -55,14 +56,14 @@ func TestSasIsOmmitedFromSliceHash(t *testing.T) {
 	request2 := newSliceRequest("some-path", "different-sas", "inline", 9961)
 
 	hash1, err := request1.Hash()
-	if err != nil {
-		t.Fatalf("Failed to compute hash, err: %v", err)
-	}
+	require.NoErrorf(t, err,
+		"Failed to compute hash, err: %v", err,
+	)
 
 	hash2, err := request2.Hash()
-	if err != nil {
-		t.Fatalf("Failed to compute hash, err: %v", err)
-	}
+	require.NoErrorf(t, err,
+		"Failed to compute hash, err: %v", err,
+	)
 
 	if hash1 != hash2 {
 		t.Fatalf("Expected hashes to be equal, was %v and %v", hash1, hash2)
@@ -86,14 +87,14 @@ func TestSasIsOmmitedFromFenceHash(t *testing.T) {
 	)
 
 	hash1, err := request1.Hash()
-	if err != nil {
-		t.Fatalf("Failed to compute hash, err: %v", err)
-	}
+	require.NoErrorf(t, err,
+		"Failed to compute hash, err: %v", err,
+	)
 	
 	hash2, err := request2.Hash()
-	if err != nil {
-		t.Fatalf("Failed to compute hash, err: %v", err)
-	}
+	require.NoErrorf(t, err,
+		"Failed to compute hash, err: %v", err,
+	)
 
 	if hash1 != hash2 {
 		t.Fatalf("Expected hashes to be equal, was %v and %v", hash1, hash2)
@@ -125,14 +126,14 @@ func TestSliceGivesUniqueHash(t *testing.T) {
 
 	for _, testCase := range testCases {
 		hash1, err := testCase.request1.Hash()
-		if err != nil {
-			t.Fatalf("[%s] Failed to compute hash, err: %v", testCase.name, err)
-		}
+		require.NoErrorf(t, err,
+			"[%s] Failed to compute hash, err: %v", testCase.name, err,
+		)
 		
 		hash2, err := testCase.request2.Hash()
-		if err != nil {
-			t.Fatalf("[%s] Failed to compute hash, err: %v", testCase.name, err)
-		}
+		require.NoErrorf(t, err,
+			"[%s] Failed to compute hash, err: %v", testCase.name, err,
+		)
 
 		if hash1 == hash2 {
 			t.Fatalf(
@@ -178,14 +179,14 @@ func TestFenceGivesUniqueHash(t *testing.T) {
 
 	for _, testCase := range testCases {
 		hash1, err := testCase.request1.Hash()
-		if err != nil {
-			t.Fatalf("[%s] Failed to compute hash, err: %v", testCase.name, err)
-		}
+		require.NoErrorf(t, err,
+			"[%s] Failed to compute hash, err: %v", testCase.name, err,
+		)
 		
 		hash2, err := testCase.request2.Hash()
-		if err != nil {
-			t.Fatalf("[%s] Failed to compute hash, err: %v", testCase.name, err)
-		}
+		require.NoErrorf(t, err,
+			"[%s] Failed to compute hash, err: %v", testCase.name, err,
+		)
 
 		if hash1 == hash2 {
 			t.Fatalf(

--- a/cmd/query/formats_test.go
+++ b/cmd/query/formats_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -70,7 +69,7 @@ func TestSupportedFormats(t *testing.T) {
 		require.NoError(t, json.Unmarshal(parts[0], &metadata))
 		format := metadata["format"]
 
-		assert.Equalf(t, "<f4", format,
+		require.Equalf(t, "<f4", format,
 			"Test '%v'. Expected format to be <f4, was %v",
 			testcase.base().name, format)
 
@@ -86,7 +85,7 @@ func TestSupportedFormats(t *testing.T) {
 		expected := []float32{108, 109, 110, 111, 112, 113, 114, 115}
 		actual := toLittleEndianFloat32(parts[1], len(expected))
 
-		assert.Equalf(t, expected, actual,
+		require.Equalf(t, expected, actual,
 			"Test '%v'. Expected %v, was %v",
 			testcase.base().name, expected, actual)
 	}

--- a/cmd/query/main_test.go
+++ b/cmd/query/main_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -619,12 +618,12 @@ func TestLogHasNoSas(t *testing.T) {
 
 		requireStatus(t, testcase, w)
 
-		assert.NotContainsf(t, buffer.String(), "sas",
+		require.NotContainsf(t, buffer.String(), "sas",
 			"Test '%v'. Log should not contain SAS (sas)", testcase.base().name)
 		// just in case also check for presence of parts of the token
-		assert.NotContainsf(t, buffer.String(), "se=",
+		require.NotContainsf(t, buffer.String(), "se=",
 			"Test '%v'. Log should not contain SAS (se=)", testcase.base().name)
-		assert.NotContainsf(t, buffer.String(), "se%3D",
+		require.NotContainsf(t, buffer.String(), "se%3D",
 			"Test '%v'. Log should not contain SAS (encoded se=)", testcase.base().name)
 	}
 }
@@ -639,7 +638,7 @@ func testErrorHTTPResponse(t *testing.T, testcases []endpointTest) {
 		err := json.Unmarshal(w.Body.Bytes(), testErrorInfo)
 		require.NoError(t, err, "Test '%v'. Couldn't unmarshal data.", testcase.base().name)
 
-		assert.Containsf(t, testErrorInfo.Error, testcase.base().expectedError,
+		require.Containsf(t, testErrorInfo.Error, testcase.base().expectedError,
 			"Test '%v'. Error string does not contain expected message.", testcase.base().name)
 	}
 }

--- a/cmd/query/utils_main_test.go
+++ b/cmd/query/utils_main_test.go
@@ -217,9 +217,7 @@ func setupTest(t *testing.T, testcase endpointTest) *httptest.ResponseRecorder {
 
 func readMultipartData(t *testing.T, w *httptest.ResponseRecorder) [][]byte {
 	_, params, err := mime.ParseMediaType(w.Result().Header.Get("Content-Type"))
-	if err != nil {
-		t.Fatalf("Cannot parse Content Type")
-	}
+	require.NoErrorf(t, err, "Cannot parse Content Type")
 	mr := multipart.NewReader(w.Body, params["boundary"])
 
 	parts := [][]byte{}
@@ -228,13 +226,9 @@ func readMultipartData(t *testing.T, w *httptest.ResponseRecorder) [][]byte {
 		if err == io.EOF {
 			return parts
 		}
-		if err != nil {
-			t.Fatalf("Couldn't process part")
-		}
+		require.NoErrorf(t, err, "Couldn't process part")
 		data, err := io.ReadAll(p)
-		if err != nil {
-			t.Fatalf("Couldn't read part")
-		}
+		require.NoErrorf(t, err, "Couldn't read part")
 		parts = append(parts, data)
 	}
 }
@@ -244,9 +238,7 @@ func prepareRequest(ctx *gin.Context, t *testing.T, testcase endpointTest) {
 	if jsonRequest == "" {
 		var err error
 		jsonRequest, err = testcase.requestAsJSON()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 	}
 
 	switch method := testcase.base().method; method {

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 )
 
 /** Makes sure that our cache is not growing indefinitely.
@@ -60,12 +61,10 @@ func TestRistrettoCacheMaxSize(t *testing.T) {
 		}
 	}
 
-	if hits != maxEntries {
-		t.Fatalf(
-			"Expected to find %d entries in cache, found %d. Note that this test might " +
-			"be flaky due to internal concurrency in ristretto",
-			maxEntries,
-			hits,
-		)
-	}
+	require.Equalf(t, hits, maxEntries,
+		"Expected to find %d entries in cache, found %d. Note that this test might " +
+		"be flaky due to internal concurrency in ristretto",
+		maxEntries,
+		hits,
+	)
 }

--- a/internal/vds/vds_test.go
+++ b/internal/vds/vds_test.go
@@ -883,7 +883,7 @@ func TestAttribute(t *testing.T) {
 		result, err := toFloat32(attr)
 		require.NoErrorf(t, err, "Couldn't convert to float32")
 
-		require.InDeltaSlice(
+		require.InDeltaSlicef(
 			t,
 			expected[i],
 			*result,
@@ -964,7 +964,7 @@ func TestAttributesAboveBelowStepSizeIgnoredForSampleValue(t *testing.T) {
 			result, err := toFloat32(attr)
 			require.NoErrorf(t, err, "Couldn't convert to float32")
 
-			require.InDeltaSlice(
+			require.InDeltaSlicef(
 				t,
 				expected[i],
 				*result,
@@ -1082,7 +1082,7 @@ func TestAttributesUnaligned(t *testing.T) {
 			result, err := toFloat32(attr)
 			require.NoErrorf(t, err, "Couldn't convert to float32")
 
-			require.InDeltaSlice(
+			require.InDeltaSlicef(
 				t,
 				testCase.expected[i],
 				*result,
@@ -1297,7 +1297,7 @@ func TestAttributesUnalignedAndSubsampled(t *testing.T) {
 		result, err := toFloat32(attr)
 		require.NoErrorf(t, err, "Couldn't convert to float32")
 
-		require.InDeltaSlice(
+		require.InDeltaSlicef(
 			t,
 			expected[i],
 			*result,
@@ -1351,7 +1351,7 @@ func TestAttributesEverythingUnaligned(t *testing.T) {
 		result, err := toFloat32(attr)
 		require.NoErrorf(t, err, "Couldn't convert to float32")
 
-		require.InDeltaSlice(
+		require.InDeltaSlicef(
 			t,
 			expected[i],
 			*result,
@@ -1405,7 +1405,7 @@ func TestAttributesSupersampling(t *testing.T) {
 		result, err := toFloat32(attr)
 		require.NoErrorf(t, err, "Couldn't convert to float32")
 
-		require.InDeltaSlice(
+		require.InDeltaSlicef(
 			t,
 			expected[i],
 			*result,

--- a/internal/vds/vds_test.go
+++ b/internal/vds/vds_test.go
@@ -517,17 +517,8 @@ func TestFenceInterpolation(t *testing.T) {
 		for _, v2 := range interpolationMethods[i+1:] {
 			interpolationMethod, _ := GetInterpolationMethod(v2)
 			buf2, _ := handle.GetFence(CoordinateSystemCdp, fence, interpolationMethod)
-			different := false
-			for k := range buf1 {
-				if buf1[k] != buf2[k] {
-					different = true
-					break
-				}
-			}
-			if !different {
-				msg := "[fence_interpolation]Expected %v interpolation and %v interpolation to be different"
-				t.Errorf(msg, v1, v2)
-			}
+
+			require.NotEqual(t, buf1, buf2)
 		}
 	}
 }

--- a/internal/vds/vds_test.go
+++ b/internal/vds/vds_test.go
@@ -670,8 +670,8 @@ func TestSurfaceWindowVerticalBounds(t *testing.T) {
 			)
 		}
 	
-		if boundsErr == nil && !testcase.inbounds {
-			t.Errorf(
+		if !testcase.inbounds {
+			require.Errorf(t, boundsErr,
 				"[%s] Expected horizon value %f to throw out of bound",
 				testcase.name,
 				testcase.horizon[0][0],

--- a/internal/vds/vds_test.go
+++ b/internal/vds/vds_test.go
@@ -443,37 +443,37 @@ func TestFenceBorders(t *testing.T) {
 		coordinate_system int
 		coordinates       [][]float32
 		interpolation     string
-		error             string
+		err               string
 	}{
 		{
 			name:              "coordinate 2 is just-out-of-upper-bound in direction 0",
 			coordinate_system: CoordinateSystemAnnotation,
 			coordinates:       [][]float32{{5, 9.5}, {6, 11.25}},
-			error:             "is out of boundaries in dimension 0.",
+			err:               "is out of boundaries in dimension 0.",
 		},
 		{
 			name:              "coordinate 1 is just-out-of-upper-bound in direction 1",
 			coordinate_system: CoordinateSystemAnnotation,
 			coordinates:       [][]float32{{5.5, 11.5}, {3, 10}},
-			error:             "is out of boundaries in dimension 1.",
+			err:               "is out of boundaries in dimension 1.",
 		},
 		{
 			name:              "coordinate is long way out of upper-bound in both directions",
 			coordinate_system: CoordinateSystemCdp,
 			coordinates:       [][]float32{{700, 1200}},
-			error:             "is out of boundaries in dimension 0.",
+			err:               "is out of boundaries in dimension 0.",
 		},
 		{
 			name:              "coordinate 2 is just-out-of-lower-bound in direction 1",
 			coordinate_system: CoordinateSystemAnnotation,
 			coordinates:       [][]float32{{0, 11}, {5.9999, 10}, {0.0001, 9.4999}},
-			error:             "is out of boundaries in dimension 1.",
+			err:               "is out of boundaries in dimension 1.",
 		},
 		{
 			name:              "negative coordinate 1 is out-of-lower-bound in direction 0",
 			coordinate_system: CoordinateSystemIndex,
 			coordinates:       [][]float32{{-1, 0}, {-3, 0}},
-			error:             "is out of boundaries in dimension 0.",
+			err:               "is out of boundaries in dimension 0.",
 		},
 	}
 
@@ -487,9 +487,9 @@ func TestFenceBorders(t *testing.T) {
 			msg := "in testcase \"%s\" expected to fail given fence is out of bounds %v"
 			t.Errorf(msg, testcase.name, testcase.coordinates)
 		} else {
-			if !strings.Contains(err.Error(), testcase.error) {
+			if !strings.Contains(err.Error(), testcase.err) {
 				msg := "Unexpected error message in testcase \"%s\", expected \"%s\", was \"%s\""
-				t.Errorf(msg, testcase.name, testcase.error, err.Error())
+				t.Errorf(msg, testcase.name, testcase.err, err.Error())
 			}
 		}
 	}

--- a/internal/vds/vds_test.go
+++ b/internal/vds/vds_test.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"math"
 	"testing"
-"github.com/stretchr/testify/assert"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -883,7 +883,7 @@ func TestAttribute(t *testing.T) {
 		result, err := toFloat32(attr)
 		require.NoErrorf(t, err, "Couldn't convert to float32")
 
-		assert.InDeltaSlice(
+		require.InDeltaSlice(
 			t,
 			expected[i],
 			*result,
@@ -964,7 +964,7 @@ func TestAttributesAboveBelowStepSizeIgnoredForSampleValue(t *testing.T) {
 			result, err := toFloat32(attr)
 			require.NoErrorf(t, err, "Couldn't convert to float32")
 
-			assert.InDeltaSlice(
+			require.InDeltaSlice(
 				t,
 				expected[i],
 				*result,
@@ -1082,7 +1082,7 @@ func TestAttributesUnaligned(t *testing.T) {
 			result, err := toFloat32(attr)
 			require.NoErrorf(t, err, "Couldn't convert to float32")
 
-			assert.InDeltaSlice(
+			require.InDeltaSlice(
 				t,
 				testCase.expected[i],
 				*result,
@@ -1208,7 +1208,7 @@ func TestAttributeSubsamplingAligned(t *testing.T) {
 			result, err := toFloat32(attr)
 			require.NoErrorf(t, err, "[%v] Couldn't convert to float32", testCase.name)
 
-			assert.InDeltaSlicef(
+			require.InDeltaSlicef(
 				t,
 				expected[i],
 				*result,
@@ -1297,7 +1297,7 @@ func TestAttributesUnalignedAndSubsampled(t *testing.T) {
 		result, err := toFloat32(attr)
 		require.NoErrorf(t, err, "Couldn't convert to float32")
 
-		assert.InDeltaSlice(
+		require.InDeltaSlice(
 			t,
 			expected[i],
 			*result,
@@ -1351,7 +1351,7 @@ func TestAttributesEverythingUnaligned(t *testing.T) {
 		result, err := toFloat32(attr)
 		require.NoErrorf(t, err, "Couldn't convert to float32")
 
-		assert.InDeltaSlice(
+		require.InDeltaSlice(
 			t,
 			expected[i],
 			*result,
@@ -1405,7 +1405,7 @@ func TestAttributesSupersampling(t *testing.T) {
 		result, err := toFloat32(attr)
 		require.NoErrorf(t, err, "Couldn't convert to float32")
 
-		assert.InDeltaSlice(
+		require.InDeltaSlice(
 			t,
 			expected[i],
 			*result,

--- a/internal/vds/vds_test.go
+++ b/internal/vds/vds_test.go
@@ -83,15 +83,11 @@ func TestMetadata(t *testing.T) {
 	handle, _ := NewVDSHandle(well_known)
 	defer handle.Close()
 	buf, err := handle.GetMetadata()
-	if err != nil {
-		t.Fatalf("Failed to retrive metadata, err %v", err)
-	}
+	require.NoErrorf(t, err, "Failed to retrive metadata, err %v", err)
 
 	var meta Metadata
 	err = json.Unmarshal(buf, &meta)
-	if err != nil {
-		t.Fatalf("Failed to unmarshall response, err: %v", err)
-	}
+	require.NoErrorf(t, err, "Failed to unmarshall response, err: %v", err)
 
 	if !reflect.DeepEqual(meta, expected) {
 		t.Fatalf("Expected %v, got  %v", expected, meta)
@@ -134,18 +130,14 @@ func TestSliceData(t *testing.T) {
 		handle, _ := NewVDSHandle(well_known)
 		defer handle.Close()
 		buf, err := handle.GetSlice(testcase.lineno, testcase.direction)
-		if err != nil {
-			t.Errorf(
-				"[case: %v] Failed to fetch slice, err: %v",
-				testcase.name,
-				err,
-			)
-		}
+		require.NoErrorf(t, err,
+			"[case: %v] Failed to fetch slice, err: %v",
+			testcase.name,
+			err,
+		)
 
 		slice, err := toFloat32(buf)
-		if err != nil {
-			t.Errorf("[case: %v] Err: %v", testcase.name, err)
-		}
+		require.NoErrorf(t, err, "[case: %v] Err: %v", testcase.name, err)
 
 		if len(*slice) != len(testcase.expected) {
 			msg := "[case: %v] Expected slice of len: %v, got: %v"
@@ -340,23 +332,19 @@ func TestSliceMetadataAxisOrdering(t *testing.T) {
 		handle, _ := NewVDSHandle(well_known)
 		defer handle.Close()
 		buf, err := handle.GetSliceMetadata(testcase.direction)
-		if err != nil {
-			t.Fatalf(
-				"[case: %v] Failed to get slice metadata, err: %v",
-				testcase.name,
-				err,
-			)
-		}
+		require.NoErrorf(t, err,
+			"[case: %v] Failed to get slice metadata, err: %v",
+			testcase.name,
+			err,
+		)
 
 		var meta SliceMetadata
 		err = json.Unmarshal(buf, &meta)
-		if err != nil {
-			t.Fatalf(
-				"[case: %v] Failed to unmarshall response, err: %v",
-				testcase.name,
-				err,
-			)
-		}
+		require.NoErrorf(t, err,
+			"[case: %v] Failed to unmarshall response, err: %v",
+			testcase.name,
+			err,
+		)
 
 		axis := []string{ meta.X.Annotation, meta.Y.Annotation }
 		for i, ax := range(testcase.expectedAxis) {
@@ -412,22 +400,15 @@ func TestFence(t *testing.T) {
 			testcase.coordinates,
 			interpolationMethod,
 		)
-		if err != nil {
-			t.Errorf(
-				"[coordinate_system: %v] Failed to fetch fence, err: %v",
-				testcase.coordinate_system,
-				err,
-			)
-		}
+		require.NoErrorf(t, err,
+			"[coordinate_system: %v] Failed to fetch fence, err: %v",
+			testcase.coordinate_system, err,
+		)
 
 		fence, err := toFloat32(buf)
-		if err != nil {
-			t.Errorf(
-				"[coordinate_system: %v] Err: %v",
-				testcase.coordinate_system,
-				err,
-			)
-		}
+		require.NoErrorf(t, err,
+			"[coordinate_system: %v] Err: %v", testcase.coordinate_system, err,
+		)
 
 		if len(*fence) != len(expected) {
 			msg := "[coordinate_system: %v] Expected fence of len: %v, got: %v"
@@ -582,22 +563,16 @@ func TestFenceNearestInterpolationSnap(t *testing.T) {
 			testcase.coordinates,
 			interpolationMethod,
 		)
-		if err != nil {
-			t.Errorf(
-				"[coordinate_system: %v] Failed to fetch fence, err: %v",
-				testcase.coordinate_system,
-				err,
-			)
-		}
+		require.NoErrorf(t, err,
+			"[coordinate_system: %v] Failed to fetch fence, err: %v",
+			testcase.coordinate_system,
+			err,
+		)
 
 		fence, err := toFloat32(buf)
-		if err != nil {
-			t.Errorf(
-				"[coordinate_system: %v] Err: %v",
-				testcase.coordinate_system,
-				err,
-			)
-		}
+		require.NoErrorf(t, err,
+			"[coordinate_system: %v] Err: %v", testcase.coordinate_system, err,
+		)
 
 		if len(*fence) != len(testcase.expected) {
 			msg := "[coordinate_system: %v] Expected fence of len: %v, got: %v"
@@ -767,9 +742,9 @@ func TestSurfaceUnalignedWithSeismic(t *testing.T) {
 		interpolationMethod,
 	)
 	require.Len(t, buf, len(targetAttributes), "Wrong number of attributes")
-	require.NoError(t, err, "Failed to fetch horizon")
+	require.NoErrorf(t, err, "Failed to fetch horizon")
 	result, err := toFloat32(buf[0])
-	require.NoError(t, err, "Failed to covert to float32 buffer")
+	require.NoErrorf(t, err, "Failed to covert to float32 buffer")
 	require.Equalf(t, expected, *result, "Horizon not as expected")
 }
 
@@ -832,8 +807,8 @@ func TestSurfaceWindowVerticalBounds(t *testing.T) {
 			interpolationMethod,
 		)
 
-		if boundsErr != nil && testcase.inbounds {
-			t.Errorf(
+		if testcase.inbounds {
+			require.NoErrorf(t, boundsErr,
 				"[%s] Expected horizon value %f to be in bounds",
 				testcase.name,
 				testcase.horizon[0][0],
@@ -973,14 +948,16 @@ func TestSurfaceHorizontalBounds(t *testing.T) {
 			targetAttributes,
 			interpolationMethod,
 		)
-		if err != nil {
-			t.Errorf("[%s] Failed to fetch horizon, err: %v", testcase.name, err)
-		}
+		require.NoErrorf(t, err,
+			"[%s] Failed to fetch horizon, err: %v",
+			testcase.name,
+			err,
+		)
 
 		require.Len(t, buf, len(targetAttributes), "Wrong number of attributes")
 
 		result, err := toFloat32(buf[0])
-		require.NoError(t, err, "Couldn't convert to float32")
+		require.NoErrorf(t, err, "Couldn't convert to float32")
 
 		assert.Equalf(
 			t,
@@ -1033,14 +1010,14 @@ func TestAttribute(t *testing.T) {
 		targetAttributes,
 		interpolationMethod,
 	)
-	require.NoError(t, err, "Failed to fetch horizon, err %v", err)
+	require.NoErrorf(t, err, "Failed to fetch horizon, err %v", err)
 	require.Len(t, buf, len(targetAttributes),
 		"Incorrect number of attributes returned",
 	)
 
 	for i, attr := range buf {
 		result, err := toFloat32(attr)
-		require.NoError(t, err, "Couldn't convert to float32")
+		require.NoErrorf(t, err, "Couldn't convert to float32")
 
 		assert.InDeltaSlice(
 			t,
@@ -1112,7 +1089,7 @@ func TestAttributesAboveBelowStepSizeIgnoredForSampleValue(t *testing.T) {
 			targetAttributes,
 			interpolationMethod,
 		)
-		require.NoError(t, err,
+		require.NoErrorf(t, err,
 			"[%s] Failed to fetch horizon, err: %v", testCase.name, err,
 		)
 		require.Len(t, buf, len(targetAttributes),
@@ -1121,7 +1098,7 @@ func TestAttributesAboveBelowStepSizeIgnoredForSampleValue(t *testing.T) {
 
 		for i, attr := range buf {
 			result, err := toFloat32(attr)
-			require.NoError(t, err, "Couldn't convert to float32")
+			require.NoErrorf(t, err, "Couldn't convert to float32")
 
 			assert.InDeltaSlice(
 				t,
@@ -1230,7 +1207,7 @@ func TestAttributesUnaligned(t *testing.T) {
 			targetAttributes,
 			interpolationMethod,
 		)
-		require.NoError(t, err,
+		require.NoErrorf(t, err,
 			"[%s] Failed to fetch horizon, err: %v", testCase.name, err,
 		)
 		require.Len(t, buf, len(targetAttributes),
@@ -1239,7 +1216,7 @@ func TestAttributesUnaligned(t *testing.T) {
 
 		for i, attr := range buf {
 			result, err := toFloat32(attr)
-			require.NoError(t, err, "Couldn't convert to float32")
+			require.NoErrorf(t, err, "Couldn't convert to float32")
 
 			assert.InDeltaSlice(
 				t,
@@ -1356,7 +1333,7 @@ func TestAttributeSubsamplingAligned(t *testing.T) {
 			targetAttributes,
 			interpolationMethod,
 		)
-		require.NoError(t, err,
+		require.NoErrorf(t, err,
 			"[%s] Failed to fetch horizon, err: %v", testCase.name, err,
 		)
 		require.Len(t, buf, len(targetAttributes),
@@ -1365,7 +1342,7 @@ func TestAttributeSubsamplingAligned(t *testing.T) {
 
 		for i, attr := range buf {
 			result, err := toFloat32(attr)
-			require.NoError(t, err, "[%v] Couldn't convert to float32", testCase.name)
+			require.NoErrorf(t, err, "[%v] Couldn't convert to float32", testCase.name)
 
 			assert.InDeltaSlicef(
 				t,
@@ -1447,14 +1424,14 @@ func TestAttributesUnalignedAndSubsampled(t *testing.T) {
 		targetAttributes,
 		interpolationMethod,
 	)
-	require.NoError(t, err, "Failed to fetch horizon, err: %v", err)
+	require.NoErrorf(t, err, "Failed to fetch horizon, err: %v", err)
 	require.Len(t, buf, len(targetAttributes),
 		"Incorrect number of attributes returned",
 	)
 	
 	for i, attr := range buf {
 		result, err := toFloat32(attr)
-		require.NoError(t, err, "Couldn't convert to float32")
+		require.NoErrorf(t, err, "Couldn't convert to float32")
 
 		assert.InDeltaSlice(
 			t,
@@ -1501,14 +1478,14 @@ func TestAttributesEverythingUnaligned(t *testing.T) {
 		targetAttributes,
 		interpolationMethod,
 	)
-	require.NoError(t, err, "Failed to fetch horizon, err: %v", err)
+	require.NoErrorf(t, err, "Failed to fetch horizon, err: %v", err)
 	require.Len(t, buf, len(targetAttributes),
 		"Incorrect number of attributes returned",
 	)
 	
 	for i, attr := range buf {
 		result, err := toFloat32(attr)
-		require.NoError(t, err, "Couldn't convert to float32")
+		require.NoErrorf(t, err, "Couldn't convert to float32")
 
 		assert.InDeltaSlice(
 			t,
@@ -1555,14 +1532,14 @@ func TestAttributesSupersampling(t *testing.T) {
 		targetAttributes,
 		interpolationMethod,
 	)
-	require.NoError(t, err, "Failed to fetch horizon, err: %v", err)
+	require.NoErrorf(t, err, "Failed to fetch horizon, err: %v", err)
 	require.Len(t, buf, len(targetAttributes),
 		"Incorrect number of attributes returned",
 	)
 	
 	for i, attr := range buf {
 		result, err := toFloat32(attr)
-		require.NoError(t, err, "Couldn't convert to float32")
+		require.NoErrorf(t, err, "Couldn't convert to float32")
 
 		assert.InDeltaSlice(
 			t,


### PR DESCRIPTION
When we introduced the module to the repository for the first time, we didn't go back and update old tests. Hence we have a good mix of manually comparisons and the use of require. 

To keep life simple for us, I've also removed all uses of the module assert.