### PR TITLE
Use Azure Key Vaults to obtain allowlist in Radix

### DIFF
--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -13,8 +13,6 @@ spec:
   components:
     - name: server
       dockerfileName: Dockerfile
-      secrets:
-        - VDSSLICE_STORAGE_ACCOUNTS
       ports:
         - name: http
           port: 8080
@@ -23,6 +21,9 @@ spec:
       publicPort: http
       monitoringConfig:
         portName: metrics
+      identity:
+        azure:
+          clientId: fd162526-89a0-448a-979f-655c0717db52
       environmentConfig:
         - environment: dev
           variables:
@@ -30,6 +31,13 @@ spec:
             VDSSLICE_CACHE_SIZE: 512 # MB
             VDSSLICE_METRICS: true
             VDSSLICE_METRICS_PORT: 8081
+          secretRefs:
+            azureKeyVaults:
+              - name: S067-RadixKeyvault
+                useAzureIdentity: true
+                items:
+                  - name: playground-dev-allowlist
+                    envVar: VDSSLICE_STORAGE_ACCOUNTS
           monitoring: true
           resources:
             requests:
@@ -44,6 +52,13 @@ spec:
             VDSSLICE_CACHE_SIZE: 256 # MB
             VDSSLICE_METRICS: true
             VDSSLICE_METRICS_PORT: 8081
+          secretRefs:
+            azureKeyVaults:
+              - name: S067-RadixKeyvault
+                useAzureIdentity: true
+                items:
+                  - name: playground-test-allowlist
+                    envVar: VDSSLICE_STORAGE_ACCOUNTS
           monitoring: true
           resources:
             requests:


### PR DESCRIPTION
It is troublesome to find a good place to keep allowed storage accounts list. Thus we want to change to a better solution than keeping it locally in team notes.

Keeping the list as env variable in Radix (not as secret) would make it visible and more easily changable, but Radix is not a permanent storage. So if our app gets deleted, the list goes with it.

Other suggestions like finding out if storage account belongs to specified tenant seem not be an option for us as they require far wider privileges than the ones we have.

Keeping allowlist as a secret in Key Vault assures list is persistent. We still have to update the list ourselves (unless we create a separate solution on top), but the team can see previous versions of the secret and thus create a new version of the same secret with updated list.

Note that on version change the secret is updated by Radix, but because we set the variables up on the start of server, our running server does not benefit from that update and has to be restarted manually. But as we do not expect frequent changes to the allowlist, the behavior is good enough for now.

Currently playground test env is updated with the solution.
Radix reference: https://radix.equinor.com/guides/azure-key-vaults/

closes #65 