### PR TITLE
Wait for all goroutines to complete before returning

### DIFF
--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -592,11 +592,17 @@ func (v VDSHandle) GetAttributes(
 		remaining -= size
 	}
 
+	// Wait for all gorutines to finish and collect any errors
+	var computeErrors []error
 	for i := 0; i < nRoutines; i++ {
 		err := <- errs
 		if err != nil {
-			return nil, err
+			computeErrors = append(computeErrors, err)
 		}
+	}
+	
+	if len(computeErrors) > 0 {
+		return nil, computeErrors[0]
 	}
 
 	out := make([][]byte, len(targetAttributes))


### PR DESCRIPTION
This commit fixes an bug in VDSHandle.GetAttributes that causes server crashes when c.attributes return a nonzero error code.

What happens is that GetAttributes fires of multiple goroutines, each calling C.attribute on parts of the data. Each goroutine reports errors back to the main thread on a error channel. The main thread is then blocked until it gets as many responses as it sent of goroutines. Unless there is an error, then it returns immediately. And that's the bug. The early return means that go free's all of GetAttributes' local variables. Local variables that are still referenced and used in C by the not-yet-completed goroutines. And the server goes boom...

The fix is simply to gather up any errors and delay the return until all goroutines have completed.

Currently, there is no way for our C.attribute function to return a nonzero error code. Atleast, not when called from
VDSHandle.GetAttributes as that does all nessesary input checks before calling the c function. That's why this error has passes under the radar and also why this patch doesn't include any tests.