### PR TITLE
Make cdata array member of regular surface struct

### DIFF
--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -225,6 +225,7 @@ func toError(status C.int, ctx *C.Context) error {
 
 type RegularSurface struct {
 	cSurface *C.struct_RegularSurface
+	cData []C.float
 }
 
 func (r *RegularSurface) get() *C.struct_RegularSurface {
@@ -294,7 +295,7 @@ func NewRegularSurface(
 		return RegularSurface{}, err
 	}
 
-	return RegularSurface{ cSurface: cSurface }, nil
+	return RegularSurface{ cSurface: cSurface, cData: cdata }, nil
 }
 
 type VDSHandle struct {


### PR DESCRIPTION
When we are creating a Regular Surface, we create a 1D array of data points and assign this to 'cdata' variable. This variable is then further passed to the C Regular Surface function as a pointer. However, as 'cdata' is declared within the function, it goes out of scope as soon as the function returns, and Golang memory management reuses that space for other variables, which can result in memory conflicts and errors.

To resolve this issue, in this change, we are modifying the structure of the Regular Surface and making 'cdata' a member of the struct so that it holds the memory as long as the struct remains valid.

This solution ensures that 'cdata' has a fixed location and will not be affected by other declarations.

closes #174