### PR TITLE
Regularsurface as parameter

### DIFF
--- a/api/endpoint.go
+++ b/api/endpoint.go
@@ -254,7 +254,7 @@ func (e *Endpoint) attributes(ctx *gin.Context, request AttributeRequest) {
 		return
 	}
 
-	metadata, err := handle.GetAttributeMetadata(request.Surface.Horizon)
+	metadata, err := handle.GetAttributeMetadata(request.Surface.Values)
 	if abortOnError(ctx, err) {
 		return
 	}

--- a/api/endpoint.go
+++ b/api/endpoint.go
@@ -254,19 +254,13 @@ func (e *Endpoint) attributes(ctx *gin.Context, request AttributeRequest) {
 		return
 	}
 
-	metadata, err := handle.GetAttributeMetadata(request.Horizon)
+	metadata, err := handle.GetAttributeMetadata(request.Surface.Horizon)
 	if abortOnError(ctx, err) {
 		return
 	}
 
 	data, err := handle.GetAttributes(
-		request.Horizon,
-		*request.Xori,
-		*request.Yori,
-		request.Xinc,
-		request.Yinc,
-		*request.Rotation,
-		*request.FillValue,
+		request.Surface,
 		request.Above,
 		request.Below,
 		request.Stepsize,

--- a/api/request.go
+++ b/api/request.go
@@ -185,31 +185,8 @@ func (s SliceRequest) toString() (string, error) {
 type AttributeRequest struct {
 	RequestedResource
 
-	// Horizon / height-map
-	Horizon [][]float32 `json:"horizon" binding:"required"`
-
-	// Rotation of the X-axis (East), counter-clockwise, in degrees
-	Rotation *float32 `json:"rotation" binding:"required"`
-
-	// X-coordinate of the origin
-	Xori *float32 `json:"xori" binding:"required"`
-
-	// Y-coordinate of the origin
-	Yori *float32 `json:"yori" binding:"required"`
-
-	// X-increment - The physical distance between columns in horizon
-	Xinc float32 `json:"xinc" binding:"required"`
-
-	// Y-increment - The physical distance between rows in horizon
-	Yinc float32 `json:"yinc" binding:"required"`
-
-	// Any sample in the input horizon with value == fillValue will be ignored
-	// and the fillValue will be used in the amplitude map.
-	// I.e. for any [i, j] where horizon[i][j] == fillValue then
-	// output[i][j] == fillValue.
-	// Additionally, the fillValue is used for any point in the horizon that
-	// falls outside the bounds of the seismic volume.
-	FillValue *float32 `json:"fillValue" binding:"required"`
+	// Surface along which data must be retrieved
+	Surface core.RegularSurface `json:"surface" binding:"required"`
 
 	// Horizontal interpolation method
 	// Supported options are: nearest, linear, cubic, angular and triangular.
@@ -279,14 +256,14 @@ func (h AttributeRequest) toString() (string, error) {
 	return fmt.Sprintf(
 		msg,
 		h.Vds,
-		len(h.Horizon[0]),
-		len(h.Horizon),
-		*h.Rotation,
-		*h.Xori,
-		*h.Yori,
-		h.Xinc,
-		h.Yinc,
-		*h.FillValue,
+		len(h.Surface.Horizon[0]),
+		len(h.Surface.Horizon),
+		*h.Surface.Rotation,
+		*h.Surface.Xori,
+		*h.Surface.Yori,
+		h.Surface.Xinc,
+		h.Surface.Yinc,
+		*h.Surface.FillValue,
 		h.Interpolation,
 		h.Above,
 		h.Below,

--- a/api/request.go
+++ b/api/request.go
@@ -43,12 +43,12 @@ type Normalizable interface {
 
 func (r *RequestedResource) NormalizeConnection() error {
 	url, err := url.Parse(r.Vds)
-	if  err  != nil {
+	if err != nil {
 		return core.NewInvalidArgument(err.Error())
 	}
 	if strings.TrimSpace(r.Sas) == "" {
 		if url.RawQuery == "" {
-		    return core.NewInvalidArgument("No valid Sas token is found in the request")
+			return core.NewInvalidArgument("No valid Sas token is found in the request")
 		}
 		r.Sas = url.RawQuery
 	}

--- a/api/request.go
+++ b/api/request.go
@@ -256,8 +256,8 @@ func (h AttributeRequest) toString() (string, error) {
 	return fmt.Sprintf(
 		msg,
 		h.Vds,
-		len(h.Surface.Horizon[0]),
-		len(h.Surface.Horizon),
+		len(h.Surface.Values[0]),
+		len(h.Surface.Values),
 		*h.Surface.Rotation,
 		*h.Surface.Xori,
 		*h.Surface.Yori,

--- a/cmd/query/formats_test.go
+++ b/cmd/query/formats_test.go
@@ -104,7 +104,7 @@ func TestSupportedFormatsHorizon(t *testing.T) {
 
 			testAttributeRequest{
 				Vds:        fmt.Sprintf(formatFile, format),
-				Horizon:    [][]float32{{20}},
+				Values:     [][]float32{{20}},
 				Sas:        "n/a",
 				Above:      8.0,
 				Below:      8.0,

--- a/cmd/query/main_test.go
+++ b/cmd/query/main_test.go
@@ -372,7 +372,7 @@ func TestMetadataHappyHTTPResponse(t *testing.T) {
 		require.Regexp(t, expectedMap["importTimeStamp"], actualMap["importTimeStamp"])
 
 		expectedMap["importTimeStamp"] = "dummy"
-		actualMap["importTimeStamp"]   = "dummy"
+		actualMap["importTimeStamp"] = "dummy"
 
 		require.Equal(t, expectedMap, actualMap, "Metadata not equal in case '%s'", testcase.name)
 	}
@@ -454,12 +454,12 @@ func TestAttributeOutOfBounds(t *testing.T) {
 	}
 
 	testCases := []endpointTest{
-		newCase("Min values",           0,   0,   0, http.StatusOK),
-		newCase("Above is too low",    -1,   1,   1, http.StatusBadRequest),
-		newCase("Above is too high",  250,   1,   1, http.StatusBadRequest),
-		newCase("Below is too low",     1,  -1,   1, http.StatusBadRequest),
-		newCase("Below is too high",    1, 250,   1, http.StatusBadRequest),
-		newCase("Stepsize is too low",  1,   1,  -1, http.StatusBadRequest),
+		newCase("Min values", 0, 0, 0, http.StatusOK),
+		newCase("Above is too low", -1, 1, 1, http.StatusBadRequest),
+		newCase("Above is too high", 250, 1, 1, http.StatusBadRequest),
+		newCase("Below is too low", 1, -1, 1, http.StatusBadRequest),
+		newCase("Below is too high", 1, 250, 1, http.StatusBadRequest),
+		newCase("Stepsize is too low", 1, 1, -1, http.StatusBadRequest),
 	}
 
 	for _, testcase := range testCases {
@@ -478,11 +478,11 @@ func TestAttributeHappyHTTPResponse(t *testing.T) {
 			},
 
 			testAttributeRequest{
-				Vds:     samples10,
-				Horizon: [][]float32{{20, 20}, {20, 20}, {20, 20}},
-				Sas:     "n/a",
-				Above:   8.0,
-				Below:   4.0,
+				Vds:        samples10,
+				Horizon:    [][]float32{{20, 20}, {20, 20}, {20, 20}},
+				Sas:        "n/a",
+				Above:      8.0,
+				Below:      4.0,
 				Attributes: []string{"samplevalue"},
 			},
 		},
@@ -545,9 +545,9 @@ func TestAttributeErrorHTTPResponse(t *testing.T) {
 					"Row 0 has 2 elements. Row 1 has 3 elements",
 			},
 			testAttributeRequest{
-				Vds:     well_known,
-				Horizon: [][]float32{{4, 4}, {4, 4, 4}, {4, 4}},
-				Sas:     "n/a",
+				Vds:        well_known,
+				Horizon:    [][]float32{{4, 4}, {4, 4, 4}, {4, 4}},
+				Sas:        "n/a",
 				Attributes: []string{"samplevalue"},
 			},
 		},
@@ -563,7 +563,7 @@ func TestAttributeErrorHTTPResponse(t *testing.T) {
 				Horizon:       [][]float32{{4, 4}, {4, 4}, {4, 4}},
 				Sas:           "n/a",
 				Interpolation: "unsupported",
-				Attributes: []string{"samplevalue"},
+				Attributes:    []string{"samplevalue"},
 			},
 		},
 		attributeTest{
@@ -574,9 +574,9 @@ func TestAttributeErrorHTTPResponse(t *testing.T) {
 				expectedError:  "Could not open VDS",
 			},
 			testAttributeRequest{
-				Vds:     "unknown",
-				Horizon: [][]float32{{4, 4}, {4, 4}, {4, 4}},
-				Sas:     "n/a",
+				Vds:        "unknown",
+				Horizon:    [][]float32{{4, 4}, {4, 4}, {4, 4}},
+				Sas:        "n/a",
 				Attributes: []string{"samplevalue"},
 			},
 		},

--- a/cmd/query/main_test.go
+++ b/cmd/query/main_test.go
@@ -443,7 +443,7 @@ func TestAttributeOutOfBounds(t *testing.T) {
 			},
 			testAttributeRequest{
 				Vds:        samples10,
-				Horizon:    [][]float32{{20}},
+				Values:     [][]float32{{20}},
 				Sas:        "n/a",
 				Above:      above,
 				Below:      below,
@@ -479,7 +479,7 @@ func TestAttributeHappyHTTPResponse(t *testing.T) {
 
 			testAttributeRequest{
 				Vds:        samples10,
-				Horizon:    [][]float32{{20, 20}, {20, 20}, {20, 20}},
+				Values:     [][]float32{{20, 20}, {20, 20}, {20, 20}},
 				Sas:        "n/a",
 				Above:      8.0,
 				Below:      4.0,
@@ -498,8 +498,8 @@ func TestAttributeHappyHTTPResponse(t *testing.T) {
 			"Wrong number of multipart data parts in case '%s'", testcase.name)
 
 		metadata := string(parts[0])
-		xLength := len(testcase.attribute.Horizon)
-		yLength := len(testcase.attribute.Horizon[0])
+		xLength := len(testcase.attribute.Values)
+		yLength := len(testcase.attribute.Values[0])
 		expectedMetadata := `{
 			"shape": [` + fmt.Sprint(xLength) + `,` + fmt.Sprint(yLength) + `],
 			"format": "<f4"
@@ -546,7 +546,7 @@ func TestAttributeErrorHTTPResponse(t *testing.T) {
 			},
 			testAttributeRequest{
 				Vds:        well_known,
-				Horizon:    [][]float32{{4, 4}, {4, 4, 4}, {4, 4}},
+				Values:     [][]float32{{4, 4}, {4, 4, 4}, {4, 4}},
 				Sas:        "n/a",
 				Attributes: []string{"samplevalue"},
 			},
@@ -560,7 +560,7 @@ func TestAttributeErrorHTTPResponse(t *testing.T) {
 			},
 			testAttributeRequest{
 				Vds:           well_known,
-				Horizon:       [][]float32{{4, 4}, {4, 4}, {4, 4}},
+				Values:        [][]float32{{4, 4}, {4, 4}, {4, 4}},
 				Sas:           "n/a",
 				Interpolation: "unsupported",
 				Attributes:    []string{"samplevalue"},
@@ -575,7 +575,7 @@ func TestAttributeErrorHTTPResponse(t *testing.T) {
 			},
 			testAttributeRequest{
 				Vds:        "unknown",
-				Horizon:    [][]float32{{4, 4}, {4, 4}, {4, 4}},
+				Values:     [][]float32{{4, 4}, {4, 4}, {4, 4}},
 				Sas:        "n/a",
 				Attributes: []string{"samplevalue"},
 			},

--- a/cmd/query/utils_main_test.go
+++ b/cmd/query/utils_main_test.go
@@ -118,13 +118,15 @@ func (h attributeTest) requestAsJSON() (string, error) {
 
 	out["vds"] = h.attribute.Vds
 	out["sas"] = h.attribute.Sas
-	out["horizon"] = h.attribute.Horizon
-	out["rotation"] = 33.69
-	out["xinc"] = 7.2111
-	out["yinc"] = 3.6056
-	out["xori"] = 2
-	out["yori"] = 0
-	out["fillValue"] = 666.66
+	surface := map[string]interface{}{}
+	surface["horizon"] = h.attribute.Horizon
+	surface["rotation"] = 33.69
+	surface["xinc"] = 7.2111
+	surface["yinc"] = 3.6056
+	surface["xori"] = 2
+	surface["yori"] = 0
+	surface["fillValue"] = 666.66
+	out["surface"] = surface
 	out["above"] = h.attribute.Above
 	out["below"] = h.attribute.Below
 	out["stepsize"] = h.attribute.Stepsize

--- a/cmd/query/utils_main_test.go
+++ b/cmd/query/utils_main_test.go
@@ -119,7 +119,7 @@ func (h attributeTest) requestAsJSON() (string, error) {
 	out["vds"] = h.attribute.Vds
 	out["sas"] = h.attribute.Sas
 	surface := map[string]interface{}{}
-	surface["horizon"] = h.attribute.Horizon
+	surface["values"] = h.attribute.Values
 	surface["rotation"] = 33.69
 	surface["xinc"] = 7.2111
 	surface["yinc"] = 3.6056
@@ -171,7 +171,7 @@ type testMetadataRequest struct {
 type testAttributeRequest struct {
 	Vds           string
 	Sas           string
-	Horizon       [][]float32
+	Values        [][]float32
 	Interpolation string
 	Above         float32
 	Below         float32

--- a/docs/attribute.md
+++ b/docs/attribute.md
@@ -2,7 +2,7 @@
 
 Calculate attributes such as `maxpos`, `mean` and `rms` around a horizon. The
 number of vertical samples above and below the horizon to include in the
-computation is customizable. See `vertical window` for more details. Multiple
+computation is customizable. See `AttributeRequest` for more details. Multiple
 attributes can be computed by a single request. It's advisable to do so,
 compared to doing one request per attribute, as a single request would be
 *much* faster.

--- a/docs/attribute.md
+++ b/docs/attribute.md
@@ -51,7 +51,7 @@ AttributeMetadata data model.
 *Content-Type: application/octet-stream*
 One part per requested attribute. Each part contains an attribute as a raw byte
 array. The byte arrays need to be parsed into 2D arrays before use. The shape
-is identical to the shape of the input horizon, but can also be found in the
+is identical to the shape of the input values, but can also be found in the
 returned metadata.
 
 Data is always 4 byte IEEE floating point, little endian.

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -298,9 +298,7 @@ func (r *CRegularSurface) Close() error {
 	return nil
 }
 
-func NewCRegularSurface(
-	surface RegularSurface,
-) (CRegularSurface, error) {
+func (surface *RegularSurface) ToCRegularSurface() (CRegularSurface, error) {
 	var cCtx = C.context_new()
 	defer C.context_free(cCtx)
 
@@ -566,9 +564,7 @@ func (v VDSHandle) GetAttributes(
 		cAttributes[i] = C.enum_attribute(targetAttributes[i])
 	}
 
-	cSurface, err := NewCRegularSurface(
-		surface,
-	)
+	cSurface, err := surface.ToCRegularSurface()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -22,6 +22,8 @@ var well_known = make_connection("well_known")
 var samples10 = make_connection("10_samples")
 var prestack = make_connection("prestack")
 
+var fillValue = float32(-999.25)
+
 type gridDefinition struct {
 	xori     float32
 	yori     float32
@@ -720,7 +722,6 @@ func TestOnly3DSupported(t *testing.T) {
 }
 
 func TestSurfaceUnalignedWithSeismic(t *testing.T) {
-	const fillValue = float32(-999.25)
 	const above = float32(4.0)
 	const below = float32(4.0)
 	const stepsize = float32(4.0)
@@ -802,7 +803,6 @@ func TestSurfaceWindowVerticalBounds(t *testing.T) {
 		},
 	}
 
-	fillValue := float32(-999.25)
 	targetAttributes := []string{"min", "samplevalue"}
 	const above = float32(4.0)
 	const below = float32(4.0)
@@ -881,7 +881,6 @@ func TestSurfaceWindowVerticalBounds(t *testing.T) {
  *
  */
 func TestSurfaceHorizontalBounds(t *testing.T) {
-	fill   := float32(-999.25)
 	xinc   := float64(samples10_grid.xinc)
 	yinc   := float64(samples10_grid.yinc)
 	rot    := float64(samples10_grid.rotation)
@@ -911,7 +910,7 @@ func TestSurfaceHorizontalBounds(t *testing.T) {
 			name:     "X coordinate is more than half a bingrid too high",
 			xori:     2.0 + 0.51*xinc*math.Cos(rotrad),
 			yori:     0.0 + 0.51*xinc*math.Sin(rotrad),
-			expected: []float32{-10.5, 4.5, 12.5, -12.5, fill, fill},
+			expected: []float32{-10.5, 4.5, 12.5, -12.5, fillValue, fillValue},
 		},
 		{
 			name:     "X coordinate is almost half a bingrid too low",
@@ -923,7 +922,7 @@ func TestSurfaceHorizontalBounds(t *testing.T) {
 			name:     "X coordinate is more than half a bingrid too low",
 			xori:     2.0 - 0.51*xinc*math.Cos(rotrad),
 			yori:     0.0 - 0.51*xinc*math.Sin(rotrad),
-			expected: []float32{fill, fill, -1.5, 1.5, -10.5, 4.5},
+			expected: []float32{fillValue, fillValue, -1.5, 1.5, -10.5, 4.5},
 		},
 		{
 			name:     "Y coordinate is almost half a bingrid too high",
@@ -935,7 +934,7 @@ func TestSurfaceHorizontalBounds(t *testing.T) {
 			name:     "Y coordinate is more than half a bingrid too high",
 			xori:     2.0 + 0.51*yinc*-math.Sin(rotrad),
 			yori:     0.0 + 0.51*yinc*math.Cos(rotrad),
-			expected: []float32{1.5, fill, 4.5, fill, -12.5, fill},
+			expected: []float32{1.5, fillValue, 4.5, fillValue, -12.5, fillValue},
 		},
 		{
 			name:     "Y coordinate is almost half a bingrid too low",
@@ -947,7 +946,7 @@ func TestSurfaceHorizontalBounds(t *testing.T) {
 			name:     "Y coordinate is more than half a bingrid too low",
 			xori:     2.0 - 0.51*yinc*-math.Sin(rotrad),
 			yori:     0.0 - 0.51*yinc*math.Cos(rotrad),
-			expected: []float32{fill, -1.5, fill, -10.5, fill, 12.5},
+			expected: []float32{fillValue, -1.5, fillValue, -10.5, fillValue, 12.5},
 		},
 	}
 
@@ -961,7 +960,7 @@ func TestSurfaceHorizontalBounds(t *testing.T) {
 			float32(xinc),
 			float32(yinc),
 			float32(rot),
-			fill,
+			fillValue,
 			above,
 			below,
 			stepsize,
@@ -990,8 +989,6 @@ func TestSurfaceHorizontalBounds(t *testing.T) {
 }
 
 func TestAttribute(t *testing.T) {
-	fill := float32(-999.25)
-
 	targetAttributes := []string{
 		"samplevalue",
 		"min",
@@ -1009,27 +1006,27 @@ func TestAttribute(t *testing.T) {
 		"sumneg",
 	}
 	expected := [][]float32{
-		{ -0.5,       0.5,       -8.5,       6.5,      fill, -16.5,      fill, fill }, // samplevalue
-		{ -2.5,      -1.5,      -12.5,       2.5,      fill, -24.5,      fill, fill }, // min
-		{  1.5,       2.5,       -4.5,      10.5,      fill,  -8.5,      fill, fill }, // max
-		{  2.5,       2.5,       12.5,      10.5,      fill,  24.5,      fill, fill }, // maxabs
-		{ -0.5,       0.5,       -8.5,       6.5,      fill, -16.5,      fill, fill }, // mean
-		{  1.3,       1.3,        8.5,       6.5,      fill,  16.5,      fill, fill }, // meanabs
-		{  1,         1.5,        0,         6.5,      fill,  0,         fill, fill }, // meanpos
-		{ -1.5,      -1,         -8.5,       0,        fill, -16.5,      fill, fill }, // meanneg
-		{ -0.5,       0.5,       -8.5,       6.5,      fill, -16.5,      fill, fill }, // median
-		{  1.5,       1.5,        8.958237,  7.0887237,fill,  17.442764, fill, fill }, // rms
-		{  2,           2,        8,         8,        fill,  32,        fill, fill }, // var
-		{  1.4142135, 1.4142135,  2.828427,  2.828427, fill,   5.656854, fill, fill }, // sd
-		{  2,         4.5,        0,         32.5,     fill,   0,        fill, fill }, // sumpos
-		{ -4.5,      -2,        -42.5,       0,        fill, -82.5,      fill, fill }, // sumneg
+		{ -0.5,       0.5,       -8.5,       6.5,      fillValue, -16.5,      fillValue, fillValue }, // samplevalue
+		{ -2.5,      -1.5,      -12.5,       2.5,      fillValue, -24.5,      fillValue, fillValue }, // min
+		{  1.5,       2.5,       -4.5,      10.5,      fillValue,  -8.5,      fillValue, fillValue }, // max
+		{  2.5,       2.5,       12.5,      10.5,      fillValue,  24.5,      fillValue, fillValue }, // maxabs
+		{ -0.5,       0.5,       -8.5,       6.5,      fillValue, -16.5,      fillValue, fillValue }, // mean
+		{  1.3,       1.3,        8.5,       6.5,      fillValue,  16.5,      fillValue, fillValue }, // meanabs
+		{  1,         1.5,        0,         6.5,      fillValue,  0,         fillValue, fillValue }, // meanpos
+		{ -1.5,      -1,         -8.5,       0,        fillValue, -16.5,      fillValue, fillValue }, // meanneg
+		{ -0.5,       0.5,       -8.5,       6.5,      fillValue, -16.5,      fillValue, fillValue }, // median
+		{  1.5,       1.5,        8.958237,  7.0887237,fillValue,  17.442764, fillValue, fillValue }, // rms
+		{  2,           2,        8,         8,        fillValue,  32,        fillValue, fillValue }, // var
+		{  1.4142135, 1.4142135,  2.828427,  2.828427, fillValue,   5.656854, fillValue, fillValue }, // sd
+		{  2,         4.5,        0,         32.5,     fillValue,   0,        fillValue, fillValue }, // sumpos
+		{ -4.5,      -2,        -42.5,       0,        fillValue, -82.5,      fillValue, fillValue }, // sumneg
 	}
 
 	horizon := [][]float32{
 		{ 20,    20 },
 		{ 20,    20 },
-		{ fill,  20 },
-		{ 20,    20 }, // Out-of-bounds, should return fill
+		{ fillValue,  20 },
+		{ 20,    20 }, // Out-of-bounds, should return fillValue
 	}
 
 	interpolationMethod, _ := GetInterpolationMethod("nearest")
@@ -1046,7 +1043,7 @@ func TestAttribute(t *testing.T) {
 		samples10_grid.xinc,
 		samples10_grid.yinc,
 		samples10_grid.rotation,
-		fill,
+		fillValue,
 		above,
 		below,
 		stepsize,
@@ -1076,18 +1073,16 @@ func TestAttribute(t *testing.T) {
 }
 
 func TestAttributeMedianForEvenSampleValue(t *testing.T) {
-	fill := float32(-999.25)
-
 	targetAttributes := []string{"median"}
 	expected := [][]float32{
-		{-1, 1, -9.5, 5.5, fill, -14.5, fill, fill}, // median
+		{-1, 1, -9.5, 5.5, fillValue, -14.5, fillValue, fillValue}, // median
 	}
 
 	horizon := [][]float32{
 		{20, 	20},
 		{20, 	20},
-		{fill, 	20},
-		{20, 	20}, // Out-of-bounds, should return fill
+		{fillValue, 	20},
+		{20, 	20}, // Out-of-bounds, should return fillValue
 	}
 
 	interpolationMethod, _ := GetInterpolationMethod("nearest")
@@ -1104,7 +1099,7 @@ func TestAttributeMedianForEvenSampleValue(t *testing.T) {
 		samples10_grid.xinc,
 		samples10_grid.yinc,
 		samples10_grid.rotation,
-		fill,
+		fillValue,
 		above,
 		below,
 		stepsize,
@@ -1166,7 +1161,6 @@ func TestAttributesAboveBelowStepSizeIgnoredForSampleValue(t *testing.T) {
 		},
 	}
 
-	const fill     = float32(-999.25)
 	horizon  := [][]float32{{ 26.0 }}
 	expected := [][]float32{{  1.0 }}
 
@@ -1183,7 +1177,7 @@ func TestAttributesAboveBelowStepSizeIgnoredForSampleValue(t *testing.T) {
 			samples10_grid.xinc,
 			samples10_grid.yinc,
 			samples10_grid.rotation,
-			fill,
+			fillValue,
 			testCase.above,
 			testCase.below,
 			testCase.stepsize,
@@ -1281,7 +1275,6 @@ func TestAttributesUnaligned(t *testing.T) {
 		},
 	}
 
-	const fill     = float32(-999.25)
 	const above    = float32(8)
 	const below    = float32(4)
 	const stepsize = float32(4)
@@ -1301,7 +1294,7 @@ func TestAttributesUnaligned(t *testing.T) {
 			samples10_grid.xinc,
 			samples10_grid.yinc,
 			samples10_grid.rotation,
-			fill,
+			fillValue,
 			above,
 			below,
 			stepsize,
@@ -1399,7 +1392,6 @@ func TestAttributeSubsamplingAligned(t *testing.T) {
 		},
 	}
 
-	const fill = float32(-999.25)
 	const above = float32(8)
 	const below = float32(4)
 	interpolationMethod, _ := GetInterpolationMethod("nearest")
@@ -1408,13 +1400,13 @@ func TestAttributeSubsamplingAligned(t *testing.T) {
 	horizon := [][]float32{
 		{ 20,    20 },
 		{ 20,    20 },
-		{ fill,  20 },
-		{ 20,    20 }, // Out-of-bounds, should return fill
+		{ fillValue,  20 },
+		{ 20,    20 }, // Out-of-bounds, should return fillValue
 	}
 
 	expected := [][]float32{
-		{ -2.5,  -0.5, -12.5, 2.5, fill, -20.5, fill, fill }, // min
-		{  0.5,   2.5,  -6.5, 8.5, fill,  -8.5, fill, fill }, // max
+		{ -2.5,  -0.5, -12.5, 2.5, fillValue, -20.5, fillValue, fillValue }, // min
+		{  0.5,   2.5,  -6.5, 8.5, fillValue,  -8.5, fillValue, fillValue }, // max
 	}
 	for _, testCase := range testCases {
 		handle, _ := NewVDSHandle(samples10)
@@ -1426,7 +1418,7 @@ func TestAttributeSubsamplingAligned(t *testing.T) {
 			samples10_grid.xinc,
 			samples10_grid.yinc,
 			samples10_grid.rotation,
-			fill,
+			fillValue,
 			above,
 			below,
 			testCase.stepsize,
@@ -1499,7 +1491,6 @@ func TestAttributesUnalignedAndSubsampled(t *testing.T) {
 		{  0.75 }, // max
 		{ -0.75 }, // mean
 	}
-	const fill     = float32(-999.25)
 	const above    = float32(8)
 	const below    = float32(4)
 	const stepsize = float32(2)
@@ -1517,7 +1508,7 @@ func TestAttributesUnalignedAndSubsampled(t *testing.T) {
 		samples10_grid.xinc,
 		samples10_grid.yinc,
 		samples10_grid.rotation,
-		fill,
+		fillValue,
 		above,
 		below,
 		stepsize,
@@ -1553,7 +1544,6 @@ func TestAttributesEverythingUnaligned(t *testing.T) {
 		{ 2.500 }, // max
 		{ 1.375 }, // mean
 	}
-	const fill     = float32(-999.25)
 	const above    = float32(5)
 	const below    = float32(7)
 	const stepsize = float32(3)
@@ -1571,7 +1561,7 @@ func TestAttributesEverythingUnaligned(t *testing.T) {
 		samples10_grid.xinc,
 		samples10_grid.yinc,
 		samples10_grid.rotation,
-		fill,
+		fillValue,
 		above,
 		below,
 		stepsize,
@@ -1607,7 +1597,6 @@ func TestAttributesSupersampling(t *testing.T) {
 		{  2.250 }, // max
 		{  1.000 }, // mean
 	}
-	const fill     = float32(-999.25)
 	const above    = float32(8)
 	const below    = float32(8)
 	const stepsize = float32(5) // VDS is sampled at 4ms
@@ -1625,7 +1614,7 @@ func TestAttributesSupersampling(t *testing.T) {
 		samples10_grid.xinc,
 		samples10_grid.yinc,
 		samples10_grid.rotation,
-		fill,
+		fillValue,
 		above,
 		below,
 		stepsize,

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -49,7 +49,7 @@ var samples10_grid = well_known_grid
 
 func samples10Surface(data [][]float32) RegularSurface {
 	return RegularSurface{
-		Horizon:   data,
+		Values:    data,
 		Rotation:  &samples10_grid.rotation,
 		Xori:      &samples10_grid.xori,
 		Yori:      &samples10_grid.yori,
@@ -745,7 +745,7 @@ func TestSurfaceUnalignedWithSeismic(t *testing.T) {
 		fillValue, fillValue, 12.5, fillValue, -10.5, fillValue, -1.5,
 	}
 
-	horizon := [][]float32{
+	values := [][]float32{
 		{fillValue, fillValue, fillValue, fillValue, fillValue, fillValue, fillValue},
 		{fillValue, fillValue, 16, fillValue, 16, fillValue, 16},
 		{fillValue, fillValue, 16, fillValue, 16, fillValue, 16},
@@ -758,7 +758,7 @@ func TestSurfaceUnalignedWithSeismic(t *testing.T) {
 	yori := float32(18)
 
 	surface := RegularSurface{
-		Horizon:   horizon,
+		Values:    values,
 		Rotation:  &rotation,
 		Xori:      &xori,
 		Yori:      &yori,
@@ -789,38 +789,38 @@ func TestSurfaceUnalignedWithSeismic(t *testing.T) {
 func TestSurfaceWindowVerticalBounds(t *testing.T) {
 	testcases := []struct {
 		name     string
-		horizon  [][]float32
+		values   [][]float32
 		inbounds bool
 	}{
 		// 2 samples is the margin needed for interpolation
 		{
 			name:     "Top of window is 2 samples from first depth recording",
-			horizon:  [][]float32{{16.00}},
+			values:   [][]float32{{16.00}},
 			inbounds: true,
 		},
 		{
 			name:     "Top of window is less than 2 samples from the top",
-			horizon:  [][]float32{{13.00}},
+			values:   [][]float32{{13.00}},
 			inbounds: false,
 		},
 		{
 			name:     "Bottom of window is 2 samples from last depth recording",
-			horizon:  [][]float32{{28.00}},
+			values:   [][]float32{{28.00}},
 			inbounds: true,
 		},
 		{
 			name:     "Bottom of window is less than 2 samples from last depth recording",
-			horizon:  [][]float32{{31.00}},
+			values:   [][]float32{{31.00}},
 			inbounds: false,
 		},
 		{
 			name:     "Some values inbounds, some out of bounds",
-			horizon:  [][]float32{{22.00, 32.00, 12.00}, {18.00, 31.00, 28.00}, {16.00, 15.00, 13.00}},
+			values:   [][]float32{{22.00, 32.00, 12.00}, {18.00, 31.00, 28.00}, {16.00, 15.00, 13.00}},
 			inbounds: false,
 		},
 		{
 			name:     "Fillvalue should not be bounds checked",
-			horizon:  [][]float32{{-999.25}},
+			values:   [][]float32{{-999.25}},
 			inbounds: true,
 		},
 	}
@@ -831,7 +831,7 @@ func TestSurfaceWindowVerticalBounds(t *testing.T) {
 	const stepsize = float32(4.0)
 
 	for _, testcase := range testcases {
-		surface := samples10Surface(testcase.horizon)
+		surface := samples10Surface(testcase.values)
 		interpolationMethod, _ := GetInterpolationMethod("nearest")
 		handle, _ := NewVDSHandle(samples10)
 		defer handle.Close()
@@ -848,7 +848,7 @@ func TestSurfaceWindowVerticalBounds(t *testing.T) {
 			require.NoErrorf(t, boundsErr,
 				"[%s] Expected horizon value %f to be in bounds",
 				testcase.name,
-				testcase.horizon[0][0],
+				testcase.values[0][0],
 			)
 		}
 
@@ -857,7 +857,7 @@ func TestSurfaceWindowVerticalBounds(t *testing.T) {
 				"out of vertical bound",
 				"[%s] Expected horizon value %f to throw out of bound",
 				testcase.name,
-				testcase.horizon[0][0],
+				testcase.values[0][0],
 			)
 		}
 	}
@@ -903,7 +903,7 @@ func TestSurfaceHorizontalBounds(t *testing.T) {
 	rot := float64(samples10_grid.rotation)
 	rotrad := rot * math.Pi / 180
 
-	horizon := [][]float32{{16, 16}, {16, 16}, {16, 16}}
+	values := [][]float32{{16, 16}, {16, 16}, {16, 16}}
 
 	targetAttributes := []string{"samplevalue"}
 	interpolationMethod, _ := GetInterpolationMethod("nearest")
@@ -972,7 +972,7 @@ func TestSurfaceHorizontalBounds(t *testing.T) {
 		xori32 := float32(testcase.xori)
 		yori32 := float32(testcase.yori)
 		surface := RegularSurface{
-			Horizon:   horizon,
+			Values:    values,
 			Rotation:  &rot32,
 			Xori:      &xori32,
 			Yori:      &yori32,
@@ -1045,14 +1045,14 @@ func TestAttribute(t *testing.T) {
 		{-4.5, -2, -42.5, 0, fillValue, -82.5, fillValue, fillValue},                          // sumneg
 	}
 
-	horizon := [][]float32{
+	values := [][]float32{
 		{20, 20},
 		{20, 20},
 		{fillValue, 20},
 		{20, 20}, // Out-of-bounds, should return fillValue
 	}
 
-	surface := samples10Surface(horizon)
+	surface := samples10Surface(values)
 
 	interpolationMethod, _ := GetInterpolationMethod("nearest")
 	const above = float32(8.0)
@@ -1097,14 +1097,14 @@ func TestAttributeMedianForEvenSampleValue(t *testing.T) {
 		{-1, 1, -9.5, 5.5, fillValue, -14.5, fillValue, fillValue}, // median
 	}
 
-	horizon := [][]float32{
+	values := [][]float32{
 		{20, 20},
 		{20, 20},
 		{fillValue, 20},
 		{20, 20}, // Out-of-bounds, should return fillValue
 	}
 
-	surface := samples10Surface(horizon)
+	surface := samples10Surface(values)
 
 	interpolationMethod, _ := GetInterpolationMethod("nearest")
 	const above = float32(8.0)
@@ -1176,13 +1176,13 @@ func TestAttributesAboveBelowStepSizeIgnoredForSampleValue(t *testing.T) {
 		},
 	}
 
-	horizon := [][]float32{{26.0}}
+	values := [][]float32{{26.0}}
 	expected := [][]float32{{1.0}}
 
 	targetAttributes := []string{"samplevalue"}
 	interpolationMethod, _ := GetInterpolationMethod("nearest")
 
-	surface := samples10Surface(horizon)
+	surface := samples10Surface(values)
 
 	for _, testCase := range testCases {
 		handle, _ := NewVDSHandle(samples10)
@@ -1294,9 +1294,9 @@ func TestAttributesUnaligned(t *testing.T) {
 	interpolationMethod, _ := GetInterpolationMethod("nearest")
 
 	for _, testCase := range testCases {
-		horizon := [][]float32{{20 + testCase.offset}}
+		values := [][]float32{{20 + testCase.offset}}
 
-		surface := samples10Surface(horizon)
+		surface := samples10Surface(values)
 
 		handle, _ := NewVDSHandle(samples10)
 		defer handle.Close()
@@ -1404,7 +1404,7 @@ func TestAttributeSubsamplingAligned(t *testing.T) {
 	interpolationMethod, _ := GetInterpolationMethod("nearest")
 	targetAttributes := []string{"min", "max"}
 
-	horizon := [][]float32{
+	values := [][]float32{
 		{20, 20},
 		{20, 20},
 		{fillValue, 20},
@@ -1416,7 +1416,7 @@ func TestAttributeSubsamplingAligned(t *testing.T) {
 		{0.5, 2.5, -6.5, 8.5, fillValue, -8.5, fillValue, fillValue},     // max
 	}
 
-	surface := samples10Surface(horizon)
+	surface := samples10Surface(values)
 
 	for _, testCase := range testCases {
 		handle, _ := NewVDSHandle(samples10)
@@ -1501,9 +1501,9 @@ func TestAttributesUnalignedAndSubsampled(t *testing.T) {
 
 	targetAttributes := []string{"min", "max", "mean"}
 	interpolationMethod, _ := GetInterpolationMethod("nearest")
-	horizon := [][]float32{{21}}
+	values := [][]float32{{21}}
 
-	surface := samples10Surface(horizon)
+	surface := samples10Surface(values)
 
 	handle, _ := NewVDSHandle(samples10)
 	defer handle.Close()
@@ -1550,9 +1550,9 @@ func TestAttributesEverythingUnaligned(t *testing.T) {
 
 	targetAttributes := []string{"samplevalue", "min", "max", "mean"}
 	interpolationMethod, _ := GetInterpolationMethod("nearest")
-	horizon := [][]float32{{26}}
+	values := [][]float32{{26}}
 
-	surface := samples10Surface(horizon)
+	surface := samples10Surface(values)
 
 	handle, _ := NewVDSHandle(samples10)
 	defer handle.Close()
@@ -1599,9 +1599,9 @@ func TestAttributesSupersampling(t *testing.T) {
 
 	targetAttributes := []string{"samplevalue", "min", "max", "mean"}
 	interpolationMethod, _ := GetInterpolationMethod("nearest")
-	horizon := [][]float32{{26}}
+	values := [][]float32{{26}}
 
-	surface := samples10Surface(horizon)
+	surface := samples10Surface(values)
 
 	handle, _ := NewVDSHandle(samples10)
 	defer handle.Close()
@@ -1636,7 +1636,7 @@ func TestAttributesSupersampling(t *testing.T) {
 }
 
 func TestAttributeMetadata(t *testing.T) {
-	horizon := [][]float32{
+	values := [][]float32{
 		{10, 10, 10, 10, 10, 10},
 		{10, 10, 10, 10, 10, 10},
 	}
@@ -1649,7 +1649,7 @@ func TestAttributeMetadata(t *testing.T) {
 
 	handle, _ := NewVDSHandle(well_known)
 	defer handle.Close()
-	buf, err := handle.GetAttributeMetadata(horizon)
+	buf, err := handle.GetAttributeMetadata(values)
 	require.NoErrorf(t, err, "Failed to retrieve attribute metadata, err %v", err)
 
 	var meta AttributeMetadata

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -47,14 +47,14 @@ var well_known_grid gridDefinition = gridDefinition{
 
 var samples10_grid = well_known_grid
 
-func samples10Surface(data [][]float32) RegularSurface{
+func samples10Surface(data [][]float32) RegularSurface {
 	return RegularSurface{
-		Horizon: data,
-		Rotation: &samples10_grid.rotation,
-		Xori: &samples10_grid.xori,
-		Yori: &samples10_grid.yori,
-		Xinc: samples10_grid.xinc,
-		Yinc: samples10_grid.yinc,
+		Horizon:   data,
+		Rotation:  &samples10_grid.rotation,
+		Xori:      &samples10_grid.xori,
+		Yori:      &samples10_grid.yori,
+		Xinc:      samples10_grid.xinc,
+		Yinc:      samples10_grid.yinc,
 		FillValue: &fillValue,
 	}
 }
@@ -80,17 +80,17 @@ func toFloat32(buf []byte) (*[]float32, error) {
 func TestMetadata(t *testing.T) {
 	expected := Metadata{
 		Axis: []*Axis{
-			{ Annotation: "Inline",    Min: 1,  Max: 5,  Samples: 3, Unit: "unitless" },
-			{ Annotation: "Crossline", Min: 10, Max: 11, Samples: 2, Unit: "unitless" },
-			{ Annotation: "Sample",    Min: 4,  Max: 16, Samples: 4, Unit: "ms"       },
+			{Annotation: "Inline", Min: 1, Max: 5, Samples: 3, Unit: "unitless"},
+			{Annotation: "Crossline", Min: 10, Max: 11, Samples: 2, Unit: "unitless"},
+			{Annotation: "Sample", Min: 4, Max: 16, Samples: 4, Unit: "ms"},
 		},
 		BoundingBox: BoundingBox{
-			Cdp:  [][]float64{ {2, 0}, {14, 8}, {12, 11}, {0, 3} },
-			Ilxl: [][]float64{ {1, 10}, {5, 10}, {5, 11}, {1, 11}},
-			Ij:   [][]float64{ {0, 0}, {2, 0}, {2, 1}, {0, 1}},
+			Cdp:  [][]float64{{2, 0}, {14, 8}, {12, 11}, {0, 3}},
+			Ilxl: [][]float64{{1, 10}, {5, 10}, {5, 11}, {1, 11}},
+			Ij:   [][]float64{{0, 0}, {2, 0}, {2, 1}, {0, 1}},
 		},
-		Crs            : "utmXX",
-		InputFileName  : "well_known.segy",
+		Crs:             "utmXX",
+		InputFileName:   "well_known.segy",
 		ImportTimeStamp: `^\d{4}-\d{2}-\d{2}[A-Z]\d{2}:\d{2}:\d{2}\.\d{3}[A-Z]$`,
 	}
 
@@ -106,7 +106,7 @@ func TestMetadata(t *testing.T) {
 	require.Regexp(t, expected.ImportTimeStamp, meta.ImportTimeStamp)
 
 	expected.ImportTimeStamp = "dummy"
-	meta.ImportTimeStamp     = "dummy"
+	meta.ImportTimeStamp = "dummy"
 
 	require.Equal(t, meta, expected)
 }
@@ -129,18 +129,18 @@ func TestSliceData(t *testing.T) {
 		117, 121, // il: 5, xl: all, samples: 1
 	}
 
-	testcases := []struct{
-			name      string
-			lineno    int
-			direction int
-			expected  []float32
-	} {
-		{ name: "inline",    lineno: 3,  direction: AxisInline,    expected: il   },
-		{ name: "i",         lineno: 1,  direction: AxisI,         expected: il   },
-		{ name: "crossline", lineno: 10, direction: AxisCrossline, expected: xl   },
-		{ name: "j",         lineno: 0,  direction: AxisJ,         expected: xl   },
-		{ name: "time",      lineno: 8,  direction: AxisTime,      expected: time },
-		{ name: "j",         lineno: 1,  direction: AxisK,         expected: time },
+	testcases := []struct {
+		name      string
+		lineno    int
+		direction int
+		expected  []float32
+	}{
+		{name: "inline", lineno: 3, direction: AxisInline, expected: il},
+		{name: "i", lineno: 1, direction: AxisI, expected: il},
+		{name: "crossline", lineno: 10, direction: AxisCrossline, expected: xl},
+		{name: "j", lineno: 0, direction: AxisJ, expected: xl},
+		{name: "time", lineno: 8, direction: AxisTime, expected: time},
+		{name: "j", lineno: 1, direction: AxisK, expected: time},
 	}
 
 	for _, testcase := range testcases {
@@ -161,23 +161,23 @@ func TestSliceData(t *testing.T) {
 }
 
 func TestSliceOutOfBounds(t *testing.T) {
-	testcases := []struct{
-			name      string
-			lineno    int
-			direction int
-	} {
-		{ name: "Inline too low",     lineno: 0,  direction: AxisInline    },
-		{ name: "Inline too high",    lineno: 6,  direction: AxisInline    },
-		{ name: "Crossline too low",  lineno: 9,  direction: AxisCrossline },
-		{ name: "Crossline too high", lineno: 12, direction: AxisCrossline },
-		{ name: "Time too low",       lineno: 3,  direction: AxisTime      },
-		{ name: "Time too high",      lineno: 17, direction: AxisTime      },
-		{ name: "I too low",          lineno: -1, direction: AxisI         },
-		{ name: "I too high",         lineno: 3,  direction: AxisI         },
-		{ name: "J too low",          lineno: -1, direction: AxisJ         },
-		{ name: "J too high",         lineno: 2,  direction: AxisJ         },
-		{ name: "K too low",          lineno: -1, direction: AxisK         },
-		{ name: "K too high",         lineno: 4,  direction: AxisK         },
+	testcases := []struct {
+		name      string
+		lineno    int
+		direction int
+	}{
+		{name: "Inline too low", lineno: 0, direction: AxisInline},
+		{name: "Inline too high", lineno: 6, direction: AxisInline},
+		{name: "Crossline too low", lineno: 9, direction: AxisCrossline},
+		{name: "Crossline too high", lineno: 12, direction: AxisCrossline},
+		{name: "Time too low", lineno: 3, direction: AxisTime},
+		{name: "Time too high", lineno: 17, direction: AxisTime},
+		{name: "I too low", lineno: -1, direction: AxisI},
+		{name: "I too high", lineno: 3, direction: AxisI},
+		{name: "J too low", lineno: -1, direction: AxisJ},
+		{name: "J too high", lineno: 2, direction: AxisJ},
+		{name: "K too low", lineno: -1, direction: AxisK},
+		{name: "K too high", lineno: 4, direction: AxisK},
 	}
 
 	for _, testcase := range testcases {
@@ -191,13 +191,13 @@ func TestSliceOutOfBounds(t *testing.T) {
 }
 
 func TestSliceStridedLineno(t *testing.T) {
-	testcases := []struct{
-			name      string
-			lineno    int
-			direction int
-	} {
-		{ name: "inline", lineno: 2, direction: AxisInline },
-		{ name: "time",   lineno: 5, direction: AxisTime   },
+	testcases := []struct {
+		name      string
+		lineno    int
+		direction int
+	}{
+		{name: "inline", lineno: 2, direction: AxisInline},
+		{name: "time", lineno: 5, direction: AxisTime},
 	}
 
 	for _, testcase := range testcases {
@@ -210,12 +210,12 @@ func TestSliceStridedLineno(t *testing.T) {
 }
 
 func TestSliceInvalidAxis(t *testing.T) {
-	testcases := []struct{
-			name      string
-			direction int
-	} {
-		{ name: "Too small", direction: -1 },
-		{ name: "Too large", direction: 8  },
+	testcases := []struct {
+		name      string
+		direction int
+	}{
+		{name: "Too small", direction: -1},
+		{name: "Too large", direction: 8},
 	}
 
 	for _, testcase := range testcases {
@@ -741,8 +741,8 @@ func TestSurfaceUnalignedWithSeismic(t *testing.T) {
 
 	expected := []float32{
 		fillValue, fillValue, fillValue, fillValue, fillValue, fillValue, fillValue,
-		fillValue, fillValue, -12.5, fillValue,   4.5, fillValue,  1.5,
-		fillValue, fillValue,  12.5, fillValue, -10.5, fillValue, -1.5,
+		fillValue, fillValue, -12.5, fillValue, 4.5, fillValue, 1.5,
+		fillValue, fillValue, 12.5, fillValue, -10.5, fillValue, -1.5,
 	}
 
 	horizon := [][]float32{
@@ -751,19 +751,19 @@ func TestSurfaceUnalignedWithSeismic(t *testing.T) {
 		{fillValue, fillValue, 16, fillValue, 16, fillValue, 16},
 	}
 
-	rotation := samples10_grid.rotation+270
-	xinc := samples10_grid.xinc/2.0
+	rotation := samples10_grid.rotation + 270
+	xinc := samples10_grid.xinc / 2.0
 	yinc := -samples10_grid.yinc
 	xori := float32(16)
 	yori := float32(18)
 
 	surface := RegularSurface{
-		Horizon: horizon,
-		Rotation: &rotation,
-		Xori: &xori,
-		Yori: &yori,
-		Xinc: xinc,
-		Yinc: yinc,
+		Horizon:   horizon,
+		Rotation:  &rotation,
+		Xori:      &xori,
+		Yori:      &yori,
+		Xinc:      xinc,
+		Yinc:      yinc,
 		FillValue: &fillValue,
 	}
 
@@ -898,9 +898,9 @@ func TestSurfaceWindowVerticalBounds(t *testing.T) {
  *
  */
 func TestSurfaceHorizontalBounds(t *testing.T) {
-	xinc   := float64(samples10_grid.xinc)
-	yinc   := float64(samples10_grid.yinc)
-	rot    := float64(samples10_grid.rotation)
+	xinc := float64(samples10_grid.xinc)
+	yinc := float64(samples10_grid.yinc)
+	rot := float64(samples10_grid.rotation)
 	rotrad := rot * math.Pi / 180
 
 	horizon := [][]float32{{16, 16}, {16, 16}, {16, 16}}
@@ -972,12 +972,12 @@ func TestSurfaceHorizontalBounds(t *testing.T) {
 		xori32 := float32(testcase.xori)
 		yori32 := float32(testcase.yori)
 		surface := RegularSurface{
-			Horizon: horizon,
-			Rotation: &rot32,
-			Xori: &xori32,
-			Yori: &yori32,
-			Xinc: float32(xinc),
-			Yinc: float32(yinc),
+			Horizon:   horizon,
+			Rotation:  &rot32,
+			Xori:      &xori32,
+			Yori:      &yori32,
+			Xinc:      float32(xinc),
+			Yinc:      float32(yinc),
 			FillValue: &fillValue,
 		}
 		handle, _ := NewVDSHandle(samples10)
@@ -1029,27 +1029,27 @@ func TestAttribute(t *testing.T) {
 		"sumneg",
 	}
 	expected := [][]float32{
-		{ -0.5,       0.5,       -8.5,       6.5,      fillValue, -16.5,      fillValue, fillValue }, // samplevalue
-		{ -2.5,      -1.5,      -12.5,       2.5,      fillValue, -24.5,      fillValue, fillValue }, // min
-		{  1.5,       2.5,       -4.5,      10.5,      fillValue,  -8.5,      fillValue, fillValue }, // max
-		{  2.5,       2.5,       12.5,      10.5,      fillValue,  24.5,      fillValue, fillValue }, // maxabs
-		{ -0.5,       0.5,       -8.5,       6.5,      fillValue, -16.5,      fillValue, fillValue }, // mean
-		{  1.3,       1.3,        8.5,       6.5,      fillValue,  16.5,      fillValue, fillValue }, // meanabs
-		{  1,         1.5,        0,         6.5,      fillValue,  0,         fillValue, fillValue }, // meanpos
-		{ -1.5,      -1,         -8.5,       0,        fillValue, -16.5,      fillValue, fillValue }, // meanneg
-		{ -0.5,       0.5,       -8.5,       6.5,      fillValue, -16.5,      fillValue, fillValue }, // median
-		{  1.5,       1.5,        8.958237,  7.0887237,fillValue,  17.442764, fillValue, fillValue }, // rms
-		{  2,           2,        8,         8,        fillValue,  32,        fillValue, fillValue }, // var
-		{  1.4142135, 1.4142135,  2.828427,  2.828427, fillValue,   5.656854, fillValue, fillValue }, // sd
-		{  2,         4.5,        0,         32.5,     fillValue,   0,        fillValue, fillValue }, // sumpos
-		{ -4.5,      -2,        -42.5,       0,        fillValue, -82.5,      fillValue, fillValue }, // sumneg
+		{-0.5, 0.5, -8.5, 6.5, fillValue, -16.5, fillValue, fillValue},                        // samplevalue
+		{-2.5, -1.5, -12.5, 2.5, fillValue, -24.5, fillValue, fillValue},                      // min
+		{1.5, 2.5, -4.5, 10.5, fillValue, -8.5, fillValue, fillValue},                         // max
+		{2.5, 2.5, 12.5, 10.5, fillValue, 24.5, fillValue, fillValue},                         // maxabs
+		{-0.5, 0.5, -8.5, 6.5, fillValue, -16.5, fillValue, fillValue},                        // mean
+		{1.3, 1.3, 8.5, 6.5, fillValue, 16.5, fillValue, fillValue},                           // meanabs
+		{1, 1.5, 0, 6.5, fillValue, 0, fillValue, fillValue},                                  // meanpos
+		{-1.5, -1, -8.5, 0, fillValue, -16.5, fillValue, fillValue},                           // meanneg
+		{-0.5, 0.5, -8.5, 6.5, fillValue, -16.5, fillValue, fillValue},                        // median
+		{1.5, 1.5, 8.958237, 7.0887237, fillValue, 17.442764, fillValue, fillValue},           // rms
+		{2, 2, 8, 8, fillValue, 32, fillValue, fillValue},                                     // var
+		{1.4142135, 1.4142135, 2.828427, 2.828427, fillValue, 5.656854, fillValue, fillValue}, // sd
+		{2, 4.5, 0, 32.5, fillValue, 0, fillValue, fillValue},                                 // sumpos
+		{-4.5, -2, -42.5, 0, fillValue, -82.5, fillValue, fillValue},                          // sumneg
 	}
 
 	horizon := [][]float32{
-		{ 20,    20 },
-		{ 20,    20 },
-		{ fillValue,  20 },
-		{ 20,    20 }, // Out-of-bounds, should return fillValue
+		{20, 20},
+		{20, 20},
+		{fillValue, 20},
+		{20, 20}, // Out-of-bounds, should return fillValue
 	}
 
 	surface := samples10Surface(horizon)
@@ -1098,18 +1098,18 @@ func TestAttributeMedianForEvenSampleValue(t *testing.T) {
 	}
 
 	horizon := [][]float32{
-		{20, 	20},
-		{20, 	20},
-		{fillValue, 	20},
-		{20, 	20}, // Out-of-bounds, should return fillValue
+		{20, 20},
+		{20, 20},
+		{fillValue, 20},
+		{20, 20}, // Out-of-bounds, should return fillValue
 	}
 
 	surface := samples10Surface(horizon)
 
 	interpolationMethod, _ := GetInterpolationMethod("nearest")
-	const above 	= float32(8.0)
-	const below 	= float32(4.0)
-	const stepsize	= float32(4.0)
+	const above = float32(8.0)
+	const below = float32(4.0)
+	const stepsize = float32(4.0)
 
 	handle, _ := NewVDSHandle(samples10)
 	defer handle.Close()
@@ -1176,8 +1176,8 @@ func TestAttributesAboveBelowStepSizeIgnoredForSampleValue(t *testing.T) {
 		},
 	}
 
-	horizon  := [][]float32{{ 26.0 }}
-	expected := [][]float32{{  1.0 }}
+	horizon := [][]float32{{26.0}}
+	expected := [][]float32{{1.0}}
 
 	targetAttributes := []string{"samplevalue"}
 	interpolationMethod, _ := GetInterpolationMethod("nearest")
@@ -1286,8 +1286,8 @@ func TestAttributesUnaligned(t *testing.T) {
 		},
 	}
 
-	const above    = float32(8)
-	const below    = float32(4)
+	const above = float32(8)
+	const below = float32(4)
 	const stepsize = float32(4)
 
 	targetAttributes := []string{"min", "max", "mean"}
@@ -1405,15 +1405,15 @@ func TestAttributeSubsamplingAligned(t *testing.T) {
 	targetAttributes := []string{"min", "max"}
 
 	horizon := [][]float32{
-		{ 20,    20 },
-		{ 20,    20 },
-		{ fillValue,  20 },
-		{ 20,    20 }, // Out-of-bounds, should return fillValue
+		{20, 20},
+		{20, 20},
+		{fillValue, 20},
+		{20, 20}, // Out-of-bounds, should return fillValue
 	}
 
 	expected := [][]float32{
-		{ -2.5,  -0.5, -12.5, 2.5, fillValue, -20.5, fillValue, fillValue }, // min
-		{  0.5,   2.5,  -6.5, 8.5, fillValue,  -8.5, fillValue, fillValue }, // max
+		{-2.5, -0.5, -12.5, 2.5, fillValue, -20.5, fillValue, fillValue}, // min
+		{0.5, 2.5, -6.5, 8.5, fillValue, -8.5, fillValue, fillValue},     // max
 	}
 
 	surface := samples10Surface(horizon)
@@ -1491,12 +1491,12 @@ func TestAttributeSubsamplingAligned(t *testing.T) {
  */
 func TestAttributesUnalignedAndSubsampled(t *testing.T) {
 	expected := [][]float32{
-		{ -2.25 }, // min
-		{  0.75 }, // max
-		{ -0.75 }, // mean
+		{-2.25}, // min
+		{0.75},  // max
+		{-0.75}, // mean
 	}
-	const above    = float32(8)
-	const below    = float32(4)
+	const above = float32(8)
+	const below = float32(4)
 	const stepsize = float32(2)
 
 	targetAttributes := []string{"min", "max", "mean"}
@@ -1539,13 +1539,13 @@ func TestAttributesUnalignedAndSubsampled(t *testing.T) {
 
 func TestAttributesEverythingUnaligned(t *testing.T) {
 	expected := [][]float32{
-		{ 1.000 }, //samplevalue
-		{ 0.250 }, // min
-		{ 2.500 }, // max
-		{ 1.375 }, // mean
+		{1.000}, //samplevalue
+		{0.250}, // min
+		{2.500}, // max
+		{1.375}, // mean
 	}
-	const above    = float32(5)
-	const below    = float32(7)
+	const above = float32(5)
+	const below = float32(7)
 	const stepsize = float32(3)
 
 	targetAttributes := []string{"samplevalue", "min", "max", "mean"}
@@ -1588,13 +1588,13 @@ func TestAttributesEverythingUnaligned(t *testing.T) {
 
 func TestAttributesSupersampling(t *testing.T) {
 	expected := [][]float32{
-		{  1.000 }, //samplevalue
-		{ -0.250 }, // min
-		{  2.250 }, // max
-		{  1.000 }, // mean
+		{1.000},  //samplevalue
+		{-0.250}, // min
+		{2.250},  // max
+		{1.000},  // mean
 	}
-	const above    = float32(8)
-	const below    = float32(8)
+	const above = float32(8)
+	const below = float32(8)
 	const stepsize = float32(5) // VDS is sampled at 4ms
 
 	targetAttributes := []string{"samplevalue", "min", "max", "mean"}

--- a/internal/core/cppapi_data.cpp
+++ b/internal/core/cppapi_data.cpp
@@ -275,13 +275,13 @@ void horizon(
      * that the output amplitude map is exacty the same dimensions as the input
      * height map (horizon). That gives us 2 cases to explicitly handle:
      *
-     * 1) If a sample (region of samples) in the input horizon is marked as
+     * 1) If a sample (region of samples) in the input values is marked as
      * missing by the fillvalue then the fillvalue is used in that position in
      * the output array too:
      *
      *      input[n][m] == fillvalue => output[n][m] == fillvalue
      *
-     * 2) If a sample (or region of samples) in the input horizon is out of
+     * 2) If a sample (or region of samples) in the input values is out of
      * bounds in the horizontal plane, the output sample is populated by the
      * fillvalue.
      *

--- a/tests/e2e/test_requests.py
+++ b/tests/e2e/test_requests.py
@@ -65,14 +65,14 @@ def make_metadata_request(vds=VDSURL, sas="sas"):
 def make_attribute_request(
     vds=SAMPLES10_URL,
     surface=surface(),
-    horizon=[[20]],
+    values=[[20]],
     above=8,
     below=8,
     attributes=["samplevalue"],
     sas="sas"
 ):
     regular_surface = {
-        "horizon": horizon,
+        "values": values,
         "fillValue": -999.25,
     }
     regular_surface.update(surface)
@@ -163,12 +163,12 @@ def test_metadata(method):
 
 
 def test_attributes():
-    horizon = [
+    values = [
         [20, 20],
         [20, 20],
         [20, 20]
     ]
-    meta, data = request_attributes("post", horizon)
+    meta, data = request_attributes("post", values)
 
     expected = np.array([[-0.5, 0.5], [-8.5, 6.5], [16.5, -16.5]])
     assert np.array_equal(data, expected)
@@ -372,11 +372,11 @@ def request_metadata(method):
     return rdata.json()
 
 
-def request_attributes(method, horizon):
+def request_attributes(method, values):
     sas = generate_container_signature(
         STORAGE_ACCOUNT_NAME, CONTAINER, STORAGE_ACCOUNT_KEY)
 
-    payload = make_attribute_request(horizon=horizon, sas=sas)
+    payload = make_attribute_request(values=values, sas=sas)
     rdata = send_request("horizon", method, payload)
     rdata.raise_for_status()
 

--- a/tests/e2e/test_requests.py
+++ b/tests/e2e/test_requests.py
@@ -71,9 +71,14 @@ def make_attribute_request(
     attributes=["samplevalue"],
     sas="sas"
 ):
-    request = {
-        "fillValue": -999.25,
+    regular_surface = {
         "horizon": horizon,
+        "fillValue": -999.25,
+    }
+    regular_surface.update(surface)
+
+    request = {
+        "surface": regular_surface,
         "interpolation": "nearest",
         "vds": vds,
         "sas": sas,
@@ -81,7 +86,6 @@ def make_attribute_request(
         "below": below,
         "attributes": attributes
     }
-    request.update(surface)
     return request
 
 

--- a/tests/performance/helpers/horizon-helpers.js
+++ b/tests/performance/helpers/horizon-helpers.js
@@ -9,9 +9,16 @@ export function sendHorizonRequest(
 ) {
   const vds = __ENV.VDS;
   const sas = __ENV.SAS;
-  let properties = {
+
+  const surfaceProperties = {
     fillValue: -999.25,
     horizon: horizon,
+  }
+
+  const regularSurface = Object.assign({}, surfaceProperties, surface);
+
+  let properties = {
+    surface : regularSurface,
     interpolation: "linear",
     vds: vds,
     sas: sas,

--- a/tests/performance/helpers/horizon-helpers.js
+++ b/tests/performance/helpers/horizon-helpers.js
@@ -5,14 +5,14 @@ import {
 } from "./request-helpers.js";
 
 export function sendHorizonRequest(
-  horizon, surface, above, below, stepsize, attributes
+  values, surface, above, below, stepsize, attributes
 ) {
   const vds = __ENV.VDS;
   const sas = __ENV.SAS;
 
   const surfaceProperties = {
     fillValue: -999.25,
-    horizon: horizon,
+    values: values,
   }
 
   const regularSurface = Object.assign({}, surfaceProperties, surface);
@@ -64,9 +64,9 @@ export function sendConstantHorizonRequest(
   rows, columns, depth, surface, above, below, stepsize, attributes
 ){
   let rowArray = new Array(columns).fill(depth);
-  let horizon = new Array(rows).fill(rowArray);
+  let values = new Array(rows).fill(rowArray);
   console.log(`Requesting horizon of size ${columns * rows}`);
-  return sendHorizonRequest(horizon, surface, above, below, stepsize, attributes);
+  return sendHorizonRequest(values, surface, above, below, stepsize, attributes);
 }
 
 /**
@@ -78,11 +78,11 @@ export function sendRandomHorizonRequest(
 ) {
   const [depthMin, depthMax, depthStep] = depth;
   const margin = 3; //margin to avoid hitting the borders and getting the error message
-  let horizon = Array.from({ length: rows }, () =>
+  let values = Array.from({ length: rows }, () =>
     Array.from({ length: columns }, () =>
       getRandom(depthMin + margin*depthStep+above, depthMax - margin*depthStep-below, depthStep)
     )
   );
   console.log(`Requesting horizon of size ${columns * rows}`);
-  return sendHorizonRequest(horizon, surface, above, below, stepsize, attributes);
+  return sendHorizonRequest(values, surface, above, below, stepsize, attributes);
 }


### PR DESCRIPTION
RegularSurface is displayed in the docs as `core.RegularSurface`, but I don't see how to fix that.