### PR TITLE
Allow out-of-bound fence requests

### DIFF
--- a/api/endpoint.go
+++ b/api/endpoint.go
@@ -175,6 +175,7 @@ func (e *Endpoint) fence(ctx *gin.Context, request FenceRequest) {
 		coordinateSystem,
 		request.Coordinates,
 		interpolation,
+		request.FillValue,
 	)
 	if abortOnError(ctx, err) {
 		return

--- a/api/request.go
+++ b/api/request.go
@@ -87,8 +87,6 @@ type FenceRequest struct {
 
 	// A list of (x, y) points in the coordinate system specified in
 	// coordinateSystem, for example [[2000.5, 100.5], [2050, 200], [10, 20]].
-	// All coordinates are expected to be inside the bounding box (with outer margin
-	// of half a distance between consecutive lines).
 	Coordinates [][]float32 `json:"coordinates" binding:"required"`
 
 	// Interpolation method
@@ -98,6 +96,12 @@ type FenceRequest struct {
 	// Note: For nearest interpolation result will snap to the nearest point
 	// as per "half up" rounding. This is different from openvds logic.
 	Interpolation string `json:"interpolation" example:"linear"`
+
+	// Providing a FillValue is optional and will be used for the sample points
+	// that lie outside the seismic cube.
+	// Note: In case the FillValue is not set, and any of the provided coordinates
+	// fall outside the seismic cube, the request will be rejected with an error.
+	FillValue *float32 `json:"fillValue"`
 } //@name FenceRequest
 
 func (f FenceRequest) toString() (string, error) {

--- a/cmd/query/main_test.go
+++ b/cmd/query/main_test.go
@@ -179,6 +179,7 @@ func TestFenceHappyHTTPResponse(t *testing.T) {
 				Vds:              well_known,
 				CoordinateSystem: "ilxl",
 				Coordinates:      [][]float32{{3, 11}, {2, 10}},
+				FillValue:        float32(-999.25),
 				Sas:              "n/a",
 			},
 		},
@@ -193,6 +194,7 @@ func TestFenceHappyHTTPResponse(t *testing.T) {
 				Vds:              well_known,
 				CoordinateSystem: "ij",
 				Coordinates:      [][]float32{{0, 1}, {1, 1}, {1, 0}},
+				FillValue:        float32(-999.25),
 				Sas:              "n/a",
 			},
 		},
@@ -247,8 +249,10 @@ func TestFenceErrorHTTPResponse(t *testing.T) {
 			baseTest{
 				name:   "Missing parameters GET request",
 				method: http.MethodGet,
-				jsonRequest: "{\"vds\":\"" + well_known +
-					"\", \"coordinateSystem\":\"ilxl\", \"coordinates\":[[0, 0]]}",
+				jsonRequest: "{\"vds\":\"" + well_known  +
+					"\", \"coordinateSystem\":\"ilxl\"," +
+					"\"fillValue\": -999.25," +
+					"\"coordinates\":[[0, 0]]}",
 				expectedStatus: http.StatusBadRequest,
 				expectedError:  "No valid Sas token is found",
 			},
@@ -258,8 +262,10 @@ func TestFenceErrorHTTPResponse(t *testing.T) {
 			baseTest{
 				name:   "Missing parameters POST Request",
 				method: http.MethodPost,
-				jsonRequest: "{\"vds\":\"" + well_known +
-					"\", \"coordinateSystem\":\"ilxl\", \"sas\": \"n/a\"}",
+				jsonRequest: "{\"vds\":\"" + well_known  +
+					"\", \"coordinateSystem\":\"ilxl\"," +
+					"\"fillValue\": -999.25," +
+					"\"sas\": \"n/a\"}",
 				expectedStatus: http.StatusBadRequest,
 				expectedError:  "Error:Field validation for 'Coordinates'",
 			},

--- a/cmd/query/utils_main_test.go
+++ b/cmd/query/utils_main_test.go
@@ -160,6 +160,7 @@ type testFenceRequest struct {
 	Vds              string      `json:"vds"`
 	CoordinateSystem string      `json:"coordinateSystem"`
 	Coordinates      [][]float32 `json:"coordinates"`
+	FillValue        float32     `json:"fillValue"`
 	Sas              string      `json:"sas"`
 }
 

--- a/internal/core/capi.cpp
+++ b/internal/core/capi.cpp
@@ -166,6 +166,7 @@ int fence(
     const float* coordinates,
     size_t npoints,
     enum interpolation_method interpolation_method,
+    const float* fillValue,
     response* out
 ) {
     try {
@@ -178,6 +179,7 @@ int fence(
             coordinates,
             npoints,
             interpolation_method,
+            fillValue,
             out
         );
         return STATUS_OK;

--- a/internal/core/capi.h
+++ b/internal/core/capi.h
@@ -110,6 +110,7 @@ int fence(
     const float* points,
     size_t npoints,
     enum interpolation_method interpolation_method,
+    const float* fillValue,
     response* out
 );
 

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -445,6 +445,7 @@ func (v VDSHandle) GetFence(
 	coordinateSystem int,
 	coordinates [][]float32,
 	interpolation int,
+	fillValue *float32,
 ) ([]byte, error) {
 	coordinate_len := 2
 	ccoordinates := make([]C.float, len(coordinates)*coordinate_len)
@@ -472,6 +473,7 @@ func (v VDSHandle) GetFence(
 		&ccoordinates[0],
 		C.size_t(len(coordinates)),
 		C.enum_interpolation_method(interpolation),
+		(*C.float)(fillValue),
 		&result,
 	)
 

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -480,13 +480,13 @@ func TestFenceBorders(t *testing.T) {
 		err               string
 	}{
 		{
-			name:              "coordinate 2 is just-out-of-upper-bound in direction 0",
+			name:              "coordinate 1 is just-out-of-upper-bound in direction 0",
 			coordinate_system: CoordinateSystemAnnotation,
 			coordinates:       [][]float32{{5, 9.5}, {6, 11.25}},
 			err:               "is out of boundaries in dimension 0.",
 		},
 		{
-			name:              "coordinate 1 is just-out-of-upper-bound in direction 1",
+			name:              "coordinate 0 is just-out-of-upper-bound in direction 1",
 			coordinate_system: CoordinateSystemAnnotation,
 			coordinates:       [][]float32{{5.5, 11.5}, {3, 10}},
 			err:               "is out of boundaries in dimension 1.",
@@ -498,13 +498,13 @@ func TestFenceBorders(t *testing.T) {
 			err:               "is out of boundaries in dimension 0.",
 		},
 		{
-			name:              "coordinate 2 is just-out-of-lower-bound in direction 1",
+			name:              "coordinate 1 is just-out-of-lower-bound in direction 1",
 			coordinate_system: CoordinateSystemAnnotation,
 			coordinates:       [][]float32{{0, 11}, {5.9999, 10}, {0.0001, 9.4999}},
 			err:               "is out of boundaries in dimension 1.",
 		},
 		{
-			name:              "negative coordinate 1 is out-of-lower-bound in direction 0",
+			name:              "negative coordinate 0 is out-of-lower-bound in direction 0",
 			coordinate_system: CoordinateSystemIndex,
 			coordinates:       [][]float32{{-1, 0}, {-3, 0}},
 			err:               "is out of boundaries in dimension 0.",

--- a/internal/core/cppapi.hpp
+++ b/internal/core/cppapi.hpp
@@ -23,6 +23,7 @@ void fence(
     const float* coordinates,
     size_t npoints,
     enum interpolation_method interpolation_method,
+    const float* fillValue,
     response* out
 ) noexcept (false);
 

--- a/internal/core/cppapi_data.cpp
+++ b/internal/core/cppapi_data.cpp
@@ -158,9 +158,12 @@ void fence(
     const float* coordinates,
     size_t npoints,
     enum interpolation_method interpolation_method,
+    const float* fillValue,
     response* out
 ) {
     MetadataHandle const& metadata = handle.get_metadata();
+
+    std::vector< std::size_t > noval_indicies;
 
     std::unique_ptr< voxel[] > coords(new voxel[npoints]{{0}});
 
@@ -178,9 +181,10 @@ void fence(
             }
         }
     };
-
-    Axis inline_axis = metadata.iline();
+    Axis inline_axis    = metadata.iline();
     Axis crossline_axis = metadata.xline();
+    Axis samples_axis   = metadata.sample();
+    auto nsamples       = samples_axis.nsamples();
 
     for (size_t i = 0; i < npoints; i++) {
         const float x = *(coordinates++);
@@ -189,13 +193,16 @@ void fence(
         auto coordinate = transform_coordinate(x, y);
 
         auto validate_boundary = [&] (const int voxel, Axis const& axis) {
-            if(!axis.inrange(coordinate[voxel])){
-                const std::string coordinate_str =
-                    "(" +std::to_string(x) + "," + std::to_string(y) + ")";
-                throw std::runtime_error(
-                    "Coordinate " + coordinate_str + " is out of boundaries "+
-                    "in dimension "+ std::to_string(voxel)+ "."
-                );
+            if (!axis.inrange(coordinate[voxel])) {
+                if (fillValue == nullptr) {
+                    const std::string coordinate_str =
+                        "(" +std::to_string(x) + "," + std::to_string(y) + ")";
+                    throw detail::bad_request(
+                        "Coordinate " + coordinate_str + " is out of boundaries "+
+                        "in dimension "+ std::to_string(voxel)+ "."
+                    );
+                }
+                noval_indicies.push_back(i * nsamples);
             }
         };
 
@@ -217,7 +224,9 @@ void fence(
         npoints,
         interpolation_method
     );
-
+    if (!noval_indicies.empty()){
+            write_fillvalue(data.get(), noval_indicies, nsamples, *fillValue);
+    }
     return to_response(std::move(data), size, out);
 }
 

--- a/internal/core/cppapi_data.cpp
+++ b/internal/core/cppapi_data.cpp
@@ -101,15 +101,15 @@ void validate_vertical_axis(
 
 /**
  * For every index in 'novals', write n successive floats with value
- * 'fillvalue' to dst. Where n is 'vertical_size'.
+ * 'fillvalue' to dst.
  */
 void write_fillvalue(
     char * dst,
     std::vector< std::size_t > const& novals,
-    std::size_t vertical_size,
+    std::size_t nsamples,
     float fillvalue
 ) {
-    std::vector< float > fill(vertical_size, fillvalue);
+    std::vector< float > fill(nsamples, fillvalue);
     std::for_each(novals.begin(), novals.end(), [&](std::size_t i) {
         std::memcpy(
             dst + i * sizeof(float),


### PR DESCRIPTION
The current behaviour is to throw an error if any coordinate provided in the request falls outside the boundaries of the seismic volume. However, with this pull request, the user will now be able to submit requests containing such coordinates and the response will return fillvalues for all values lying outside the seismic cube.

closes #116