### PR TITLE
Attributes between surfaces: Align surfaces

### DIFF
--- a/internal/core/capi.cpp
+++ b/internal/core/capi.cpp
@@ -81,7 +81,7 @@ int datahandle_free(Context* ctx, DataHandle* f) {
 
 int regular_surface_new(
     Context* ctx,
-    const float* data,
+    float* data,
     size_t nrows,
     size_t ncols,
     float xori,

--- a/internal/core/capi.cpp
+++ b/internal/core/capi.cpp
@@ -99,11 +99,7 @@ int regular_surface_new(
             data,
             nrows,
             ncols,
-            xori,
-            yori,
-            xinc,
-            yinc,
-            rot,
+            Plane(xori, yori, xinc, yinc, rot),
             fillvalue
         );
         return STATUS_OK;

--- a/internal/core/capi.h
+++ b/internal/core/capi.h
@@ -64,7 +64,7 @@ typedef struct RegularSurface RegularSurface;
 
 int regular_surface_new(
     Context* ctx,
-    const float* data,
+    float* data,
     size_t nrows,
     size_t ncols,
     float xori,

--- a/internal/core/cppapi.hpp
+++ b/internal/core/cppapi.hpp
@@ -58,6 +58,33 @@ void attributes(
     void** out
 ) noexcept (false);
 
+/**
+ * Given two input surfaces, primary and secondary, updates third surface,
+ * aligned, which is expected to be shaped as primary surface, with data
+ * belonging to secondary surface.
+ *
+ * For each point on primary surface a nearest point on the secondary surface
+ * will be found and its value will be written to the resulting aligned surface.
+ *
+ * If according to the algorithm described above surfaces appear to intersect,
+ * exception would be thrown.
+ *
+ * If the resulting point appears to be out of secondary surface bounds, aligned
+ * surface fillvalue will be stored at the position. If for the primary or
+ * secondary surface at the point the value of the data is surface's
+ * corresponding fillvalue, aligned surface fillvalue will be stored at the
+ * postion.
+ *
+ * Additionally a parameter primary_is_top would be set determining whether
+ * primary or resulting aligned surface appeared on top of another.
+ */
+void align_surfaces(
+    RegularSurface const& primary,
+    RegularSurface const& secondary,
+    RegularSurface &aligned,
+    bool* primary_is_top
+) noexcept (false);
+
 void slice_metadata(
     DataHandle& handle,
     Direction const direction,

--- a/internal/core/regularsurface.cpp
+++ b/internal/core/regularsurface.cpp
@@ -38,6 +38,22 @@ AffineTransformation AffineTransformation::from_rotation(
     }}));
 }
 
+AffineTransformation AffineTransformation::inverse_from_rotation(
+    double xori,
+    double yori,
+    double xinc,
+    double yinc,
+    double rot
+) noexcept(true) {
+    double rad = rot * (M_PI / 180);
+    /**
+     * Matrix inverse to the one above.
+     */
+    return AffineTransformation(base_type({{
+        std::cos(rad) / xinc, std::sin(rad) / xinc, -(std::sin(rad) * yori + std::cos(rad) * xori) / xinc,
+       -std::sin(rad) / yinc, std::cos(rad) / yinc,  (std::sin(rad) * xori - std::cos(rad) * yori) / yinc
+    }}));
+}
 
 Point RegularSurface::to_cdp(
     std::size_t const row,
@@ -49,6 +65,12 @@ Point RegularSurface::to_cdp(
     Point point {static_cast<double>(row), static_cast<double>(col)};
 
     return this->m_transformation * point;
+}
+
+Point RegularSurface::from_cdp(
+    Point point
+) const noexcept (false) {
+    return this->m_inverse_transformation * point;
 }
 
 float RegularSurface::value(

--- a/internal/core/regularsurface.cpp
+++ b/internal/core/regularsurface.cpp
@@ -80,6 +80,15 @@ Point RegularSurface::to_cdp(
     return this->m_plane.m_transformation * point;
 }
 
+Point RegularSurface::to_cdp(
+    std::size_t i
+) const noexcept(false) {
+    auto row = i / this->ncols();
+    auto col = i % this->ncols();
+
+    return to_cdp(row, col);
+}
+
 Point RegularSurface::from_cdp(
     Point point
 ) const noexcept (false) {

--- a/internal/core/regularsurface.cpp
+++ b/internal/core/regularsurface.cpp
@@ -110,3 +110,9 @@ float RegularSurface::value(std::size_t i) const noexcept (false) {
 
     return this->m_data[i];
 }
+
+void RegularSurface::set_value(std::size_t i, float value) noexcept (false) {
+    if (i >= this->size()) throw std::runtime_error("index out of range");
+
+    this->m_data[i] = value;
+}

--- a/internal/core/regularsurface.cpp
+++ b/internal/core/regularsurface.cpp
@@ -12,11 +12,11 @@ Point AffineTransformation::operator*(Point p) const noexcept (true) {
 
 
 AffineTransformation AffineTransformation::from_rotation(
-    float xori,
-    float yori,
-    float xinc,
-    float yinc,
-    float rot
+    double xori,
+    double yori,
+    double xinc,
+    double yinc,
+    double rot
 ) noexcept (true) {
     double rad = rot * (M_PI / 180);
     /**

--- a/internal/core/regularsurface.cpp
+++ b/internal/core/regularsurface.cpp
@@ -10,6 +10,15 @@ Point AffineTransformation::operator*(Point p) const noexcept (true) {
     };
 };
 
+bool operator==(
+    AffineTransformation const& left,
+    AffineTransformation const& right
+) noexcept (true) {
+    const auto& lhs = static_cast< const AffineTransformation::base_type& >(left);
+    const auto& rhs = static_cast< const AffineTransformation::base_type& >(right);
+
+    return lhs == rhs;
+};
 
 AffineTransformation AffineTransformation::from_rotation(
     double xori,
@@ -55,6 +64,10 @@ AffineTransformation AffineTransformation::inverse_from_rotation(
     }}));
 }
 
+bool Plane::operator==(const Plane& other) const {
+    return this->m_transformation == other.m_transformation;
+}
+
 Point RegularSurface::to_cdp(
     std::size_t const row,
     std::size_t const col
@@ -64,13 +77,13 @@ Point RegularSurface::to_cdp(
 
     Point point {static_cast<double>(row), static_cast<double>(col)};
 
-    return this->m_transformation * point;
+    return this->m_plane.m_transformation * point;
 }
 
 Point RegularSurface::from_cdp(
     Point point
 ) const noexcept (false) {
-    return this->m_inverse_transformation * point;
+    return this->m_plane.m_inverse_transformation * point;
 }
 
 float RegularSurface::value(

--- a/internal/core/regularsurface.hpp
+++ b/internal/core/regularsurface.hpp
@@ -105,6 +105,10 @@ public:
         std::size_t const col
     ) const noexcept (false);
 
+    Point to_cdp(
+        std::size_t i
+    ) const noexcept(false);
+
     /* World coordinates -> grid position */
     Point from_cdp(
         Point point

--- a/internal/core/regularsurface.hpp
+++ b/internal/core/regularsurface.hpp
@@ -22,6 +22,15 @@ struct AffineTransformation : private std::array< std::array< double, 3>, 2 > {
         double yinc,
         double rot
     ) noexcept (true);
+
+    /* Make inverse transformation to the one created from rotation */
+    static AffineTransformation inverse_from_rotation(
+        double xori,
+        double yori,
+        double xinc,
+        double yinc,
+        double rot
+    )noexcept (true);
 };
 
 
@@ -58,13 +67,20 @@ public:
         m_ncols(ncols),
         m_fillvalue(fillvalue),
         m_transformation(
-            AffineTransformation::from_rotation(xori, yori, xinc, yinc, rot))
+            AffineTransformation::from_rotation(xori, yori, xinc, yinc, rot)),
+        m_inverse_transformation(
+            AffineTransformation::inverse_from_rotation(xori, yori, xinc, yinc, rot))
     {}
 
     /* Grid position (row, col) -> world coordinates */
     Point to_cdp(
         std::size_t const row,
         std::size_t const col
+    ) const noexcept (false);
+
+    /* World coordinates -> grid position */
+    Point from_cdp(
+        Point point
     ) const noexcept (false);
 
     /* Value at grid position (row, col) */
@@ -86,6 +102,7 @@ private:
     std::size_t  m_ncols;
     float        m_fillvalue;
     AffineTransformation    m_transformation;
+    AffineTransformation    m_inverse_transformation;
 };
 
 // } // namespace surface

--- a/internal/core/regularsurface.hpp
+++ b/internal/core/regularsurface.hpp
@@ -16,11 +16,11 @@ struct AffineTransformation : private std::array< std::array< double, 3>, 2 > {
     Point operator*(Point p) const noexcept (true);
 
     static AffineTransformation from_rotation(
-        float xori,
-        float yori,
-        float xinc,
-        float yinc,
-        float rot
+        double xori,
+        double yori,
+        double xinc,
+        double yinc,
+        double rot
     ) noexcept (true);
 };
 

--- a/internal/core/regularsurface.hpp
+++ b/internal/core/regularsurface.hpp
@@ -87,7 +87,7 @@ class RegularSurface{
 
 public:
     RegularSurface(
-        const float* data,
+        float* data,
         std::size_t  nrows,
         std::size_t  ncols,
         Plane plane,
@@ -121,6 +121,7 @@ public:
     ) const noexcept (false);
 
     float value(std::size_t i) const noexcept (false);
+    void set_value(std::size_t i, float value) noexcept (false);
     
     float fillvalue() const noexcept (true) { return this->m_fillvalue; };
 
@@ -130,7 +131,7 @@ public:
 
     Plane plane() const noexcept (true) { return this->m_plane; };
 private:
-    const float* m_data;
+    float*       m_data;
     std::size_t  m_nrows;
     std::size_t  m_ncols;
     float        m_fillvalue;

--- a/tests/gtest/CMakeLists.txt
+++ b/tests/gtest/CMakeLists.txt
@@ -8,6 +8,7 @@ FetchContent_MakeAvailable(googletest)
 
 add_executable(cppcoretests
   cppapi_test.cpp
+  regularsurface_test.cpp
 )
 
 target_link_libraries(cppcoretests

--- a/tests/gtest/cppapi_test.cpp
+++ b/tests/gtest/cppapi_test.cpp
@@ -11,6 +11,8 @@ namespace
 const std::string SAMPLES_10 = "file://10_samples_default.vds";
 const std::string CREDENTIALS = "";
 
+Plane other_plane = Plane(2, 3, 4.472, 2.236, 333.43);
+
 class HorizonTest : public ::testing::Test
 {
   protected:
@@ -63,12 +65,6 @@ TEST_F(HorizonTest, DataForUnalignedSurface)
     static constexpr int ncols = 6;
     static constexpr std::size_t size = nrows * ncols;
 
-    const float xori = 2;
-    const float yori = 3;
-    const float xinc = 4.472;
-    const float yinc = 2.236;
-    const float rot = 333.43;
-
     const std::array<float, size> surface_data = {
         24, 20, 24, 24, 24, 20,
         20, 20, 20, 24, 20, 24,
@@ -83,17 +79,17 @@ TEST_F(HorizonTest, DataForUnalignedSurface)
         nodata, nodata, nodata, nodata, nodata, nodata
     };
 
-    RegularSurface unaligned_surface =
-        RegularSurface(surface_data.data(), nrows, ncols, xori, yori, xinc, yinc, rot, fill);
+    RegularSurface surface =
+        RegularSurface(surface_data.data(), nrows, ncols, other_plane, fill);
 
     std::size_t horizon_size;
-    cppapi::horizon_size(*handle, unaligned_surface, above, below, &horizon_size);
+    cppapi::horizon_size(*handle, surface, above, below, &horizon_size);
 
     std::vector< float> res(horizon_size);
-    cppapi::horizon(*handle, unaligned_surface, above, below, NEAREST, 0, size, res.data());
+    cppapi::horizon(*handle, surface, above, below, NEAREST, 0, size, res.data());
 
-    std::size_t vsize = horizon_size / (unaligned_surface.size() * sizeof(float));
-    Horizon horizon(res.data(), size, vsize, unaligned_surface.fillvalue());
+    std::size_t vsize = horizon_size / (surface.size() * sizeof(float));
+    Horizon horizon(res.data(), size, vsize, surface.fillvalue());
 
     /* We are checking here points unordered. Meaning that if all points in a
      * row appear somewhere in the horizon, we assume we are good. Alternative

--- a/tests/gtest/cppapi_test.cpp
+++ b/tests/gtest/cppapi_test.cpp
@@ -11,6 +11,8 @@ namespace
 const std::string SAMPLES_10 = "file://10_samples_default.vds";
 const std::string CREDENTIALS = "";
 
+Plane samples_10_plane = Plane(2, 0, 7.2111, 3.6056, 33.69);
+Plane larger_plane = Plane(-8, -11, 7.2111, 3.6056, 33.69);
 Plane other_plane = Plane(2, 3, 4.472, 2.236, 333.43);
 
 class HorizonTest : public ::testing::Test
@@ -109,4 +111,355 @@ TEST_F(HorizonTest, DataForUnalignedSurface)
         }
     }
 }
+
+class SurfaceAlignmentTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        handle = make_datahandle(SAMPLES_10.c_str(), CREDENTIALS.c_str());
+    }
+
+    void TearDown() override
+    {
+        delete handle;
+    }
+
+    DataHandle *handle;
+
+    static constexpr float fill = -999.25;
+};
+
+void test_successful_align_call(
+    RegularSurface const &primary,
+    RegularSurface const &secondary,
+    RegularSurface &aligned,
+    const float *expected_data,
+    bool expected_primary_is_top
+) {
+    bool primary_is_top;
+    cppapi::align_surfaces(primary, secondary, aligned, &primary_is_top);
+
+    EXPECT_EQ(primary_is_top, expected_primary_is_top) << "Wrong column number";
+
+    for (int i = 0; i < primary.size(); ++i)
+    {
+        EXPECT_EQ(aligned.value(i), expected_data[i]) << "Wrong surface at index " << i;
+    }
+}
+
+void test_successful_align_call(
+    RegularSurface const &primary,
+    RegularSurface const &secondary,
+    const float *expected_data,
+    bool expected_primary_is_top
+) {
+    std::vector< float> data(primary.size());
+    RegularSurface aligned = RegularSurface(
+        data.data(), primary.nrows(), primary.ncols(), primary.plane(), secondary.fillvalue());
+
+    test_successful_align_call(primary, secondary, aligned, expected_data, expected_primary_is_top);
+}
+
+TEST_F(SurfaceAlignmentTest, AlignedSurfaces)
+{
+    static constexpr std::size_t nrows = 3;
+    static constexpr std::size_t ncols = 2;
+    std::array<float, nrows * ncols> primary_surface_data = {
+        20, 20,
+        20, 20,
+        20, 20
+    };
+    std::array<float, nrows * ncols> secondary_surface_data = {
+        24, 25,
+        26, 27,
+        28, 29
+    };
+
+    RegularSurface primary = RegularSurface(
+        primary_surface_data.data(), nrows, ncols, samples_10_plane, fill);
+    RegularSurface secondary = RegularSurface(
+        secondary_surface_data.data(), nrows, ncols, samples_10_plane, fill);
+
+    test_successful_align_call(primary, secondary, secondary_surface_data.data(), true);
+}
+
+TEST_F(SurfaceAlignmentTest, PrimaryIsBottom)
+{
+    static constexpr std::size_t nrows = 3;
+    static constexpr std::size_t ncols = 2;
+    std::array<float, nrows * ncols> primary_surface_data = {
+        30, 30,
+        30, 30,
+        30, 30
+    };
+    std::array<float, nrows * ncols> secondary_surface_data = {
+        24, 25,
+        26, 27,
+        28, 29
+    };
+
+    RegularSurface primary = RegularSurface(
+        primary_surface_data.data(), nrows, ncols, samples_10_plane, fill);
+    RegularSurface secondary = RegularSurface(
+        secondary_surface_data.data(), nrows, ncols, samples_10_plane, fill);
+
+    test_successful_align_call(primary, secondary, secondary_surface_data.data(), false);
+}
+
+TEST_F(SurfaceAlignmentTest, SecondaryLarger)
+{
+    static constexpr std::size_t pnrows = 2;
+    static constexpr std::size_t pncols = 1;
+
+    std::array<float, pnrows * pncols> primary_surface_data = {
+        20,
+        20
+    };
+
+    static constexpr std::size_t snrows = 3;
+    static constexpr std::size_t sncols = 2;
+
+    std::array<float, snrows * sncols> secondary_surface_data = {
+        24, 25,
+        26, 27,
+        28, 29
+    };
+
+    const std::array<float, pnrows * pncols> expected = {
+        24,
+        26
+    };
+
+    RegularSurface primary = RegularSurface(
+        primary_surface_data.data(), pnrows, pncols, samples_10_plane, fill);
+    RegularSurface secondary = RegularSurface(
+        secondary_surface_data.data(), snrows, sncols, samples_10_plane, fill);
+
+    test_successful_align_call(primary, secondary, expected.data(), true);
+}
+
+TEST_F(SurfaceAlignmentTest, PrimaryLarger)
+{
+    static constexpr std::size_t pnrows = 3;
+    static constexpr std::size_t pncols = 2;
+
+    std::array<float, pnrows * pncols> primary_surface_data = {
+        20, 20,
+        20, 20,
+        20, 20
+    };
+
+    static constexpr std::size_t snrows = 2;
+    static constexpr std::size_t sncols = 1;
+
+    std::array<float, snrows * sncols> secondary_surface_data = {
+        24,
+        26,
+    };
+
+    const std::array<float, pnrows * pncols> expected = {
+        24, fill,
+        26, fill,
+        fill, fill
+    };
+
+    RegularSurface primary = RegularSurface(
+        primary_surface_data.data(), pnrows, pncols, samples_10_plane, fill);
+    RegularSurface secondary = RegularSurface(
+        secondary_surface_data.data(), snrows, sncols, samples_10_plane, fill);
+
+    test_successful_align_call(primary, secondary, expected.data(), true);
+}
+
+TEST_F(SurfaceAlignmentTest, HolesInData)
+{
+    static constexpr std::size_t pnrows = 3;
+    static constexpr std::size_t pncols = 2;
+
+    float fill1 = 111.11;
+    float fill2 = 222.22;
+    float fill3 = 333.33;
+
+    std::array<float, pnrows * pncols> primary_surface_data = {
+        20, 20,
+        fill1, fill1,
+        20, 20
+    };
+
+    static constexpr std::size_t snrows = 3;
+    static constexpr std::size_t sncols = 2;
+
+    std::array<float, snrows * sncols> secondary_surface_data = {
+        fill2, 25,
+        26, fill2,
+        fill2, 29
+    };
+
+    const std::array<float, pnrows * pncols> expected = {
+        fill3, 25,
+        fill3, fill3,
+        fill3, 29
+    };
+
+    RegularSurface primary = RegularSurface(
+        primary_surface_data.data(), pnrows, pncols, samples_10_plane, fill1);
+    RegularSurface secondary = RegularSurface(
+        secondary_surface_data.data(), snrows, sncols, samples_10_plane, fill2);
+
+    std::vector< float> data(primary.size());
+    RegularSurface aligned = RegularSurface(
+        data.data(), primary.nrows(), primary.ncols(), primary.plane(), fill3);
+
+    test_successful_align_call(primary, secondary, aligned, expected.data(), true);
+}
+
+TEST_F(SurfaceAlignmentTest, SurfaceDifferentOrigin)
+{
+    static constexpr std::size_t pnrows = 6;
+    static constexpr std::size_t pncols = 4;
+
+    std::array<float, pnrows * pncols> primary_surface_data = {
+        10, 10, 10, 10,
+        10, 10, 10, 10,
+        10, 10, 10, 10,
+        10, 10, 10, 10,
+        10, 10, 10, 10,
+        10, 10, 10, 10
+    };
+
+    static constexpr std::size_t snrows = 3;
+    static constexpr std::size_t sncols = 2;
+
+    std::array<float, snrows * sncols> secondary_surface_data = {
+        24, 25,
+        26, 27,
+        28, 29,
+    };
+
+    const std::array<float, pnrows * pncols> expected = {
+        fill, fill, fill, fill,
+        fill, fill, fill, fill,
+        fill, 24,   25,   fill,
+        fill, 26,   27,   fill,
+        fill, 28,   29,   fill,
+        fill, fill, fill, fill,
+    };
+
+    RegularSurface primary = RegularSurface(
+        primary_surface_data.data(), pnrows, pncols, larger_plane, fill);
+    RegularSurface secondary = RegularSurface(
+        secondary_surface_data.data(), snrows, sncols, samples_10_plane, fill);
+
+    test_successful_align_call(primary, secondary, expected.data(), true);
+}
+
+TEST_F(SurfaceAlignmentTest, UnalignedSurfacesPrimaryAligned)
+{
+    static constexpr std::size_t pnrows = 3;
+    static constexpr std::size_t pncols = 2;
+
+    std::array<float, pnrows * pncols> primary_surface_data = {
+        5, 5,
+        5, 5,
+        5, 5
+    };
+
+    static constexpr std::size_t snrows = 4;
+    static constexpr std::size_t sncols = 6;
+
+    std::array<float, snrows * sncols> secondary_surface_data = {
+        10, 11, 12, 13, 14, 15,
+        16, 17, 18, 19, 20, 21,
+        22, 23, 24, 25, 26, 27,
+        28, 29, 30, 31, 32, 33
+    };
+
+    const std::array<float, pnrows * pncols> expected = {
+        fill, 10,
+        18, 12,
+        26, 21
+    };
+
+    RegularSurface primary = RegularSurface(
+        primary_surface_data.data(), pnrows, pncols, samples_10_plane, fill);
+    RegularSurface secondary = RegularSurface(
+        secondary_surface_data.data(), snrows, sncols, other_plane, fill);
+
+    test_successful_align_call(primary, secondary, expected.data(), true);
+}
+
+TEST_F(SurfaceAlignmentTest, UnalignedSurfacesPrimaryUnaligned)
+{
+    static constexpr std::size_t pnrows = 4;
+    static constexpr std::size_t pncols = 6;
+
+    std::array<float, pnrows * pncols> primary_surface_data = {
+        20, 20, 20, 20, 20, 20,
+        20, 20, 20, 20, 20, 20,
+        20, 20, 20, 20, 20, 20,
+        20, 20, 20, 20, 20, 20,
+    };
+
+    static constexpr std::size_t snrows = 3;
+    static constexpr std::size_t sncols = 2;
+
+    std::array<float, snrows * sncols> secondary_surface_data = {
+        24, 25,
+        26, 27,
+        28, 29
+    };
+
+    const std::array<float, pnrows * pncols> expected = {
+        25, 27, 27, fill, fill, fill,
+        26, 26, 26, 27, 29, 29,
+        fill, fill, fill, fill, 28, 28,
+        fill, fill, fill, fill, fill, fill
+    };
+
+    RegularSurface primary = RegularSurface(
+        primary_surface_data.data(), pnrows, pncols, other_plane, fill);
+    RegularSurface secondary = RegularSurface(
+        secondary_surface_data.data(), snrows, sncols, samples_10_plane, fill);
+
+    test_successful_align_call(primary, secondary, expected.data(), true);
+}
+
+TEST_F(SurfaceAlignmentTest, IntersectingSurfaces)
+{
+    static constexpr std::size_t pnrows = 3;
+    static constexpr std::size_t pncols = 2;
+
+    std::array<float, pnrows * pncols> primary_surface_data = {
+        35, 5, // fill, less
+        18, 8, // equals, less
+        27, 20 // greater, less
+    };
+
+    static constexpr std::size_t snrows = 4;
+    static constexpr std::size_t sncols = 6;
+
+    std::array<float, snrows * sncols> secondary_surface_data = {
+        10, 11, 12, 13, 14, 15,
+        16, 17, 18, 19, 20, 21,
+        22, 23, 24, 25, 26, 27,
+        28, 29, 30, 31, 32, 33
+    };
+
+    RegularSurface primary = RegularSurface(
+        primary_surface_data.data(), pnrows, pncols, samples_10_plane, fill);
+    RegularSurface secondary = RegularSurface(
+        secondary_surface_data.data(), snrows, sncols, other_plane, fill);
+
+    std::vector< float> data(primary.size());
+    RegularSurface aligned = RegularSurface(
+        data.data(), pnrows, pncols, samples_10_plane, fill);
+    bool primary_is_top;
+
+    EXPECT_THAT(
+        [&]() { cppapi::align_surfaces(primary, secondary, aligned, &primary_is_top); },
+        testing::ThrowsMessage<std::runtime_error>(
+            testing::HasSubstr("Surfaces intersect at primary surface point (2, 0)")));
+}
+
 } // namespace

--- a/tests/gtest/cppapi_test.cpp
+++ b/tests/gtest/cppapi_test.cpp
@@ -65,7 +65,7 @@ TEST_F(HorizonTest, DataForUnalignedSurface)
     static constexpr int ncols = 6;
     static constexpr std::size_t size = nrows * ncols;
 
-    const std::array<float, size> surface_data = {
+    std::array<float, size> surface_data = {
         24, 20, 24, 24, 24, 20,
         20, 20, 20, 24, 20, 24,
         20, 24, 20, 20, 24, 20,

--- a/tests/gtest/regularsurface_test.cpp
+++ b/tests/gtest/regularsurface_test.cpp
@@ -1,0 +1,48 @@
+#include <limits>
+#include <random>
+
+#include "regularsurface.hpp"
+
+#include "gtest/gtest.h"
+namespace
+{
+
+TEST(AffineTransformationTest, InverseProperty)
+{
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_real_distribution<> distribution(-1000000, 1000000);
+
+    auto xinc = distribution(gen);
+    if (xinc == 0) {
+        xinc = 1;
+    }
+    auto yinc = distribution(gen);
+    if (yinc == 0) {
+        yinc = 1;
+    }
+    auto rot = distribution(gen);
+    auto xori = distribution(gen);
+    auto yori = distribution(gen);
+
+    auto x = distribution(gen);
+    auto y = distribution(gen);
+
+    std::printf(
+        "Test runs on: xinc: %.17g, yinc: %.17g, rot: %.17g, xori: %.17g, yori: %.17g, point: (%.17g, %.17g).\n",
+        xinc, yinc, rot, xori, yori, x, y);
+
+    auto f = AffineTransformation::from_rotation(xori, yori, xinc, yinc, rot);
+    auto f_inv = AffineTransformation::inverse_from_rotation(xori, yori, xinc, yinc, rot);
+
+    Point point{x, y};
+    Point f_finv = f * (f_inv * point);
+    Point finv_f = f_inv * (f * point);
+
+    EXPECT_NEAR(point.x, f_finv.x, 0.00001) << "f(f_inv(point)).x != point.x";
+    EXPECT_NEAR(point.y, f_finv.y, 0.00001) << "f(f_inv(point)).y != point.y";
+    EXPECT_NEAR(point.x, finv_f.x, 0.00001) << "f_inv(f(point)).x != point.x";
+    EXPECT_NEAR(point.y, finv_f.y, 0.00001) << "f_inv(f(point)).y != point.y";
+}
+
+} // namespace


### PR DESCRIPTION
First part of the attributes between surfaces saga!

Totally ignored suggested threshold value. Let me know if there was actual user need for it for some reason and what is the the usecase. Without it I am just snapping to closest point on the secondary surface grid and taking whichever value is there.