### PR TITLE
Add axis stride to metadata endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,17 @@ To run the tests:
     ```
     Cache is expected to be turned on.
 
-3. Run E2E tests from the tests directory
+3. Create Python test environment (If needed)
+
+    These commands will create, activate and install the required packages for the E2E tests.
+    ```
+    cd tests
+    python -m venv venv
+    source venv/bin/activate
+    pip install -r e2e/requirements-dev.txt
+    ```
+
+4. Run E2E tests from the tests directory
 
     ```
     cd tests

--- a/api/endpoint.go
+++ b/api/endpoint.go
@@ -226,7 +226,7 @@ func validateVerticalWindow(above float32, below float32, stepSize float32) erro
 func (e *Endpoint) attributesAlongSurface(ctx *gin.Context, request AttributeAlongSurfaceRequest) {
 	prepareRequestLogging(ctx, request)
 
-	err := validateVerticalWindow(request.Above, request.Below, request.Stepsize)
+	err := validateVerticalWindow(request.Above, request.Below, request.StepSize)
 	if abortOnError(ctx, err) {
 		return
 	}
@@ -268,7 +268,7 @@ func (e *Endpoint) attributesAlongSurface(ctx *gin.Context, request AttributeAlo
 		request.Surface,
 		request.Above,
 		request.Below,
-		request.Stepsize,
+		request.StepSize,
 		request.Attributes,
 		interpolation,
 	)
@@ -320,7 +320,7 @@ func (e *Endpoint) attributesBetweenSurfaces(ctx *gin.Context, request Attribute
 	data, err := handle.GetAttributesBetweenSurfaces(
 		request.PrimarySurface,
 		request.SecondarySurface,
-		request.Stepsize,
+		request.StepSize,
 		request.Attributes,
 		interpolation,
 	)

--- a/api/request.go
+++ b/api/request.go
@@ -221,7 +221,7 @@ type AttributeRequest struct {
 	// as per "half up" rounding. This is different from openvds logic.
 	Interpolation string `json:"interpolation" example:"linear"`
 
-	// Stepsize for samples within the window defined by above below
+	// StepSize for samples within the window defined by above below
 	//
 	// Samples within the vertical window will be re-sampled to 'stepsize'
 	// using cubic interpolation (modified makima) before the attributes are
@@ -234,7 +234,7 @@ type AttributeRequest struct {
 	//
 	// Setting this to zero, or omitting it will default it to the vertical
 	// stepsize in the VDS volume.
-	Stepsize float32 `json:"stepsize" example:"1.0"`
+	StepSize float32 `json:"stepsize" example:"1.0"`
 
 	// Requested attributes. Multiple attributes can be calculated by the same
 	// request. This is considerably faster than doing one request per
@@ -282,7 +282,7 @@ func (h AttributeAlongSurfaceRequest) Hash() (string, error) {
 func (h AttributeAlongSurfaceRequest) toString() (string, error) {
 	msg := "{vds: %s, Horizon: (ncols: %d, nrows: %d), Rotation: %.2f, " +
 		"Origin: [%.2f, %.2f], Increment: [%.2f, %.2f], FillValue: %.2f, " +
-		"interpolation: %s, Above: %.2f, Below: %.2f, Stepsize: %.2f, " +
+		"interpolation: %s, Above: %.2f, Below: %.2f, StepSize: %.2f, " +
 		"Attributes: %v}"
 	return fmt.Sprintf(
 		msg,
@@ -298,7 +298,7 @@ func (h AttributeAlongSurfaceRequest) toString() (string, error) {
 		h.Interpolation,
 		h.Above,
 		h.Below,
-		h.Stepsize,
+		h.StepSize,
 		h.Attributes,
 	), nil
 }
@@ -347,7 +347,7 @@ func (h AttributeBetweenSurfacesRequest) toString() (string, error) {
 		"Origin: [%.2f, %.2f], Increment: [%.2f, %.2f], FillValue: %.2f. " +
 		"Secondary surface: Values: (ncols: %d, nrows: %d), Rotation: %.2f, " +
 		"Origin: [%.2f, %.2f], Increment: [%.2f, %.2f], FillValue: %.2f. " +
-		"Interpolation: %s, Stepsize: %.2f, Attributes: %v}"
+		"Interpolation: %s, StepSize: %.2f, Attributes: %v}"
 	return fmt.Sprintf(
 		msg,
 		h.Vds,
@@ -368,7 +368,7 @@ func (h AttributeBetweenSurfacesRequest) toString() (string, error) {
 		h.SecondarySurface.Yinc,
 		*h.SecondarySurface.FillValue,
 		h.Interpolation,
-		h.Stepsize,
+		h.StepSize,
 		h.Attributes,
 	), nil
 }

--- a/cmd/query/main_test.go
+++ b/cmd/query/main_test.go
@@ -57,13 +57,13 @@ func TestSliceHappyHTTPResponse(t *testing.T) {
 			"Wrong number of multipart data parts in case '%s'", testcase.name)
 
 		inlineAxis := testSliceAxis{
-			Annotation: "Inline", Max: 3.0, Min: 1.0, Samples: 2, Unit: "unitless",
+			Annotation: "Inline", Max: 3.0, Min: 1.0, Samples: 2, StepSize: 2, Unit: "unitless",
 		}
 		crosslineAxis := testSliceAxis{
-			Annotation: "Crossline", Max: 11.0, Min: 10.0, Samples: 2, Unit: "unitless",
+			Annotation: "Crossline", Max: 11.0, Min: 10.0, Samples: 2, StepSize: 1, Unit: "unitless",
 		}
 		sampleAxis := testSliceAxis{
-			Annotation: "Sample", Max: 16.0, Min: 4.0, Samples: 4, Unit: "ms",
+			Annotation: "Sample", Max: 16.0, Min: 4.0, Samples: 4, StepSize: 4, Unit: "ms",
 		}
 		expectedFormat := "<f4"
 
@@ -383,9 +383,9 @@ func TestMetadataHappyHTTPResponse(t *testing.T) {
 		metadata := w.Body.String()
 		expectedMetadata := `{
 			"axis": [
-				{"annotation": "Inline", "max": 5.0, "min": 1.0, "samples" : 3, "unit": "unitless"},
-				{"annotation": "Crossline", "max": 11.0, "min": 10.0, "samples" : 2, "unit": "unitless"},
-				{"annotation": "Sample", "max": 16.0, "min": 4.0, "samples" : 4, "unit": "ms"}
+				{"annotation": "Inline", "max": 5.0, "min": 1.0, "samples" : 3, "stepsize":2, "unit": "unitless"},
+				{"annotation": "Crossline", "max": 11.0, "min": 10.0, "samples" : 2, "stepsize":1, "unit": "unitless"},
+				{"annotation": "Sample", "max": 16.0, "min": 4.0, "samples" : 4, "stepsize":4, "unit": "ms"}
 			],
 			"boundingBox": {
 				"cdp": [[2,0],[14,8],[12,11],[0,3]],

--- a/cmd/query/main_test.go
+++ b/cmd/query/main_test.go
@@ -57,13 +57,13 @@ func TestSliceHappyHTTPResponse(t *testing.T) {
 			"Wrong number of multipart data parts in case '%s'", testcase.name)
 
 		inlineAxis := testSliceAxis{
-			Annotation: "Inline", Max: 3.0, Min: 1.0, Samples: 2, Unit: "unitless",
+			Annotation: "Inline", Max: 3.0, Min: 1.0, Samples: 2, StepSize: 2, Unit: "unitless",
 		}
 		crosslineAxis := testSliceAxis{
-			Annotation: "Crossline", Max: 11.0, Min: 10.0, Samples: 2, Unit: "unitless",
+			Annotation: "Crossline", Max: 11.0, Min: 10.0, Samples: 2, StepSize: 1, Unit: "unitless",
 		}
 		sampleAxis := testSliceAxis{
-			Annotation: "Sample", Max: 16.0, Min: 4.0, Samples: 4, Unit: "ms",
+			Annotation: "Sample", Max: 16.0, Min: 4.0, Samples: 4, StepSize: 4, Unit: "ms",
 		}
 		expectedFormat := "<f4"
 
@@ -383,9 +383,9 @@ func TestMetadataHappyHTTPResponse(t *testing.T) {
 		metadata := w.Body.String()
 		expectedMetadata := `{
 			"axis": [
-				{"annotation": "Inline", "max": 5.0, "min": 1.0, "samples" : 3, "unit": "unitless"},
-				{"annotation": "Crossline", "max": 11.0, "min": 10.0, "samples" : 2, "unit": "unitless"},
-				{"annotation": "Sample", "max": 16.0, "min": 4.0, "samples" : 4, "unit": "ms"}
+				{"annotation": "Inline", "max": 5.0, "min": 1.0, "samples" : 3, "stepsize":2, "unit": "unitless"},
+				{"annotation": "Crossline", "max": 11.0, "min": 10.0, "samples" : 2, "stepsize":1, "unit": "unitless"},
+				{"annotation": "Sample", "max": 16.0, "min": 4.0, "samples" : 4, "stepsize":4, "unit": "ms"}
 			],
 			"boundingBox": {
 				"cdp": [[2,0],[14,8],[12,11],[0,3]],
@@ -472,7 +472,7 @@ func TestMetadataErrorHTTPResponse(t *testing.T) {
 }
 
 func TestAttributeOutOfBounds(t *testing.T) {
-	newCase := func(name string, above, below, stepSize float32, status int) attributeAlongSurfaceTest {
+	newCase := func(name string, above, below, stepsize float32, status int) attributeAlongSurfaceTest {
 		return attributeAlongSurfaceTest{
 			baseTest{
 				name:           name,
@@ -485,7 +485,7 @@ func TestAttributeOutOfBounds(t *testing.T) {
 				Sas:        "n/a",
 				Above:      above,
 				Below:      below,
-				Stepsize:   stepSize,
+				StepSize:   stepsize,
 				Attributes: []string{"samplevalue"},
 			},
 		}

--- a/cmd/query/main_test.go
+++ b/cmd/query/main_test.go
@@ -497,7 +497,7 @@ func TestAttributeOutOfBounds(t *testing.T) {
 		newCase("Above is too high", 250, 1, 1, http.StatusBadRequest),
 		newCase("Below is too low", 1, -1, 1, http.StatusBadRequest),
 		newCase("Below is too high", 1, 250, 1, http.StatusBadRequest),
-		newCase("Stepsize is too low", 1, 1, -1, http.StatusBadRequest),
+		newCase("StepSize is too low", 1, 1, -1, http.StatusBadRequest),
 	}
 
 	for _, testcase := range testCases {

--- a/cmd/query/utils_main_test.go
+++ b/cmd/query/utils_main_test.go
@@ -148,7 +148,7 @@ func (h attributeAlongSurfaceTest) requestAsJSON() (string, error) {
 	out["surface"] = surface
 	out["above"] = h.attribute.Above
 	out["below"] = h.attribute.Below
-	out["stepsize"] = h.attribute.Stepsize
+	out["stepsize"] = h.attribute.StepSize
 	out["Attributes"] = h.attribute.Attributes
 	if h.attribute.Interpolation != "" {
 		out["interpolation"] = h.attribute.Interpolation
@@ -202,7 +202,7 @@ func (h attributeBetweenSurfacesTest) requestAsJSON() (string, error) {
 	secondary["values"] = h.attribute.ValuesSecondary
 	out["secondarySurface"] = secondary
 
-	out["stepsize"] = h.attribute.Stepsize
+	out["stepsize"] = h.attribute.StepSize
 	out["attributes"] = h.attribute.Attributes
 	if h.attribute.Interpolation != "" {
 		out["interpolation"] = h.attribute.Interpolation
@@ -256,7 +256,7 @@ type testAttributeAlongSurfaceRequest struct {
 	Interpolation string
 	Above         float32
 	Below         float32
-	Stepsize      float32
+	StepSize      float32
 	Attributes    []string
 }
 
@@ -266,7 +266,7 @@ type testAttributeBetweenSurfacesRequest struct {
 	ValuesPrimary   [][]float32
 	ValuesSecondary [][]float32
 	Interpolation   string
-	Stepsize        float32
+	StepSize        float32
 	Attributes      []string
 }
 
@@ -275,6 +275,7 @@ type testSliceAxis struct {
 	Max        float32 `json:"max"        binding:"required"`
 	Min        float32 `json:"min"        binding:"required"`
 	Samples    int     `json:"samples"    binding:"required"`
+	StepSize   float32 `json:"stepsize"   binding:"required"`
 	Unit       string  `json:"unit"       binding:"required"`
 }
 

--- a/internal/core/attribute.hpp
+++ b/internal/core/attribute.hpp
@@ -49,7 +49,7 @@
  */
 class Horizon{
 private:
-    struct StridedIterator {
+    struct StepSizedIterator {
     public:
         using iterator_category = std::forward_iterator_tag;
         using difference_type   = std::ptrdiff_t;
@@ -57,20 +57,20 @@ private:
         using pointer           = const float*;
         using reference         = const float&;
 
-        StridedIterator(pointer cur, std::size_t step) : cur(cur), step(step) {}
+        StepSizedIterator(pointer cur, std::size_t step) : cur(cur), step(step) {}
 
         reference operator*()  { return *this->cur; }
         pointer   operator->() { return  this->cur; }
 
-        StridedIterator& operator++() { this->cur += this->step; return *this; };
+        StepSizedIterator& operator++() { this->cur += this->step; return *this; };
 
         friend
-        bool operator==(StridedIterator const& lhs, StridedIterator const& rhs) {
+        bool operator==(StepSizedIterator const& lhs, StepSizedIterator const& rhs) {
             return lhs.cur == rhs.cur and lhs.step == rhs.step;
         }
 
         friend
-        bool operator!=(StridedIterator const& lhs, StridedIterator const& rhs) {
+        bool operator!=(StepSizedIterator const& lhs, StepSizedIterator const& rhs) {
             return !(lhs == rhs);
         }
     private:
@@ -78,8 +78,8 @@ private:
         std::size_t step;
     };
 
-    struct VerticalIterator : public StridedIterator {
-        VerticalIterator(StridedIterator::pointer cur) : StridedIterator(cur, 1) {}
+    struct VerticalIterator : public StepSizedIterator {
+        VerticalIterator(StepSizedIterator::pointer cur) : StepSizedIterator(cur, 1) {}
     };
 
 public:

--- a/internal/core/axis.cpp
+++ b/internal/core/axis.cpp
@@ -33,7 +33,7 @@ int Axis::dimension() const noexcept(true) {
     return this->m_dimension;
 }
 
-float Axis::stride() const noexcept (true) {
+float Axis::stepsize() const noexcept (true) {
     return (this->max() - this->min()) / (this->nsamples() - 1);
 }
 
@@ -42,8 +42,8 @@ std::string Axis::name() const noexcept(true) {
 }
 
 bool Axis::inrange(float coordinate) const noexcept(true) {
-    return (this->min() - 0.5 * this->stride()) <= coordinate && 
-           (this->max() + 0.5 * this->stride()) >  coordinate;
+    return (this->min() - 0.5 * this->stepsize()) <= coordinate && 
+           (this->max() + 0.5 * this->stepsize()) >  coordinate;
 }
 
 float Axis::to_sample_position(float coordinate) noexcept(false) {

--- a/internal/core/axis.hpp
+++ b/internal/core/axis.hpp
@@ -18,7 +18,7 @@ public:
     float min() const noexcept(true);
     float max() const noexcept(true);
 
-    float stride() const noexcept (true);
+    float stepsize() const noexcept (true);
 
     std::string unit() const noexcept(true);
     int dimension() const noexcept(true);

--- a/internal/core/capi.cpp
+++ b/internal/core/capi.cpp
@@ -360,10 +360,10 @@ int attribute(
         auto const& sample = metadata.sample();
 
         if (stepsize == 0) {
-            stepsize = sample.stride();
+            stepsize = sample.stepsize();
         }
 
-        VerticalWindow src_window(sample.stride(), 2, sample.min());
+        VerticalWindow src_window(sample.stepsize(), 2, sample.min());
         VerticalWindow dst_window(stepsize);
 
         void* outs[nattributes];

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -47,6 +47,9 @@ type Axis struct {
 	// Number of samples along the axis
 	Samples int `json:"samples" example:"1600"`
 
+	// Distance from one sample to the next
+	StepSize float64 `json:"stepsize" example:"4.0"`
+
 	// Axis units
 	Unit string `json:"unit" example:"ms"`
 } // @name Axis

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -82,9 +82,9 @@ func toFloat32(buf []byte) (*[]float32, error) {
 func TestMetadata(t *testing.T) {
 	expected := Metadata{
 		Axis: []*Axis{
-			{Annotation: "Inline", Min: 1, Max: 5, Samples: 3, Unit: "unitless"},
-			{Annotation: "Crossline", Min: 10, Max: 11, Samples: 2, Unit: "unitless"},
-			{Annotation: "Sample", Min: 4, Max: 16, Samples: 4, Unit: "ms"},
+			{Annotation: "Inline", Min: 1, Max: 5, Samples: 3, StepSize: 2, Unit: "unitless"},
+			{Annotation: "Crossline", Min: 10, Max: 11, Samples: 2, StepSize: 1, Unit: "unitless"},
+			{Annotation: "Sample", Min: 4, Max: 16, Samples: 4, StepSize: 4, Unit: "ms"},
 		},
 		BoundingBox: BoundingBox{
 			Cdp:  [][]float64{{2, 0}, {14, 8}, {12, 11}, {0, 3}},
@@ -200,7 +200,7 @@ func TestSliceOutOfBounds(t *testing.T) {
 
 }
 
-func TestSliceStridedLineno(t *testing.T) {
+func TestSliceStepSizedLineno(t *testing.T) {
 	testcases := []struct {
 		name      string
 		lineno    int
@@ -250,6 +250,7 @@ func TestSliceBounds(t *testing.T) {
 		min float64,
 		max float64,
 		samples int,
+		stepsize float64,
 	) Axis {
 		unit := "ms"
 		anno := strings.ToLower(annotation)
@@ -262,6 +263,7 @@ func TestSliceBounds(t *testing.T) {
 			Min:        min,
 			Max:        max,
 			Samples:    samples,
+			StepSize:   stepsize,
 			Unit:       unit,
 		}
 	}
@@ -290,8 +292,8 @@ func TestSliceBounds(t *testing.T) {
 				112, 113, 114, 115,
 			},
 			expectedShape: []int{2, 4},
-			expectedXAxis: newAxis("Sample", 4, 16, 4),
-			expectedYAxis: newAxis("Crossline", 10, 11, 2),
+			expectedXAxis: newAxis("Sample", 4, 16, 4, 4),
+			expectedYAxis: newAxis("Crossline", 10, 11, 2, 1),
 			expectedGeo:   [][]float64{{8, 4}, {6, 7}},
 		},
 		{
@@ -307,8 +309,8 @@ func TestSliceBounds(t *testing.T) {
 				116, 117, 118, 119,
 			},
 			expectedShape: []int{3, 4},
-			expectedXAxis: newAxis("Sample", 4, 16, 4),
-			expectedYAxis: newAxis("Inline", 1, 5, 3),
+			expectedXAxis: newAxis("Sample", 4, 16, 4, 4),
+			expectedYAxis: newAxis("Inline", 1, 5, 3, 2),
 			expectedGeo:   [][]float64{{2, 0}, {14, 8}},
 		},
 		{
@@ -325,8 +327,8 @@ func TestSliceBounds(t *testing.T) {
 				116, 120,
 			},
 			expectedShape: []int{3, 2},
-			expectedXAxis: newAxis("Crossline", 10, 11, 2),
-			expectedYAxis: newAxis("Inline", 1, 5, 3),
+			expectedXAxis: newAxis("Crossline", 10, 11, 2, 1),
+			expectedYAxis: newAxis("Inline", 1, 5, 3, 2),
 			expectedGeo:   [][]float64{{2, 0}, {14, 8}, {12, 11}, {0, 3}},
 		},
 		{
@@ -340,8 +342,8 @@ func TestSliceBounds(t *testing.T) {
 				108, 109, 110, 111,
 			},
 			expectedShape: []int{1, 4},
-			expectedXAxis: newAxis("Sample", 4, 16, 4),
-			expectedYAxis: newAxis("Crossline", 10, 10, 1),
+			expectedXAxis: newAxis("Sample", 4, 16, 4, 4),
+			expectedYAxis: newAxis("Crossline", 10, 10, 1, 1),
 			expectedGeo:   [][]float64{{8, 4}, {8, 4}},
 		},
 		{
@@ -356,8 +358,8 @@ func TestSliceBounds(t *testing.T) {
 				108, 112,
 			},
 			expectedShape: []int{2, 2},
-			expectedXAxis: newAxis("Crossline", 10, 11, 2),
-			expectedYAxis: newAxis("Inline", 1, 3, 2),
+			expectedXAxis: newAxis("Crossline", 10, 11, 2, 1),
+			expectedYAxis: newAxis("Inline", 1, 3, 2, 2),
 			expectedGeo:   [][]float64{{2, 0}, {8, 4}, {6, 7}, {0, 3}},
 		},
 		{
@@ -373,8 +375,8 @@ func TestSliceBounds(t *testing.T) {
 				108,
 			},
 			expectedShape: []int{2, 1},
-			expectedXAxis: newAxis("Crossline", 10, 10, 1),
-			expectedYAxis: newAxis("Inline", 1, 3, 2),
+			expectedXAxis: newAxis("Crossline", 10, 10, 1, 1),
+			expectedYAxis: newAxis("Inline", 1, 3, 2, 2),
 			expectedGeo:   [][]float64{{2, 0}, {8, 4}, {8, 4}, {2, 0}},
 		},
 		{
@@ -390,8 +392,8 @@ func TestSliceBounds(t *testing.T) {
 				109, 110,
 			},
 			expectedShape: []int{2, 2},
-			expectedXAxis: newAxis("Sample", 8, 12, 2),
-			expectedYAxis: newAxis("Inline", 1, 3, 2),
+			expectedXAxis: newAxis("Sample", 8, 12, 2, 4),
+			expectedYAxis: newAxis("Inline", 1, 3, 2, 2),
 			expectedGeo:   [][]float64{{2, 0}, {8, 4}},
 		},
 		{
@@ -408,8 +410,8 @@ func TestSliceBounds(t *testing.T) {
 				118, 122,
 			},
 			expectedShape: []int{3, 2},
-			expectedXAxis: newAxis("Crossline", 10, 11, 2),
-			expectedYAxis: newAxis("Inline", 1, 5, 3),
+			expectedXAxis: newAxis("Crossline", 10, 11, 2, 1),
+			expectedYAxis: newAxis("Inline", 1, 5, 3, 2),
 			expectedGeo:   [][]float64{{2, 0}, {14, 8}, {12, 11}, {0, 3}},
 		},
 		{
@@ -424,8 +426,8 @@ func TestSliceBounds(t *testing.T) {
 				120, 121, 122, 123,
 			},
 			expectedShape: []int{2, 4},
-			expectedXAxis: newAxis("Sample", 4, 16, 4),
-			expectedYAxis: newAxis("Crossline", 10, 11, 2),
+			expectedXAxis: newAxis("Sample", 4, 16, 4, 4),
+			expectedYAxis: newAxis("Crossline", 10, 11, 2, 1),
 			expectedGeo:   [][]float64{{14, 8}, {12, 11}},
 		},
 		{
@@ -441,8 +443,8 @@ func TestSliceBounds(t *testing.T) {
 				122, 123,
 			},
 			expectedShape: []int{2, 2},
-			expectedXAxis: newAxis("Sample", 12, 16, 2),
-			expectedYAxis: newAxis("Crossline", 10, 11, 2),
+			expectedXAxis: newAxis("Sample", 12, 16, 2, 4),
+			expectedYAxis: newAxis("Crossline", 10, 11, 2, 1),
 			expectedGeo:   [][]float64{{14, 8}, {12, 11}},
 		},
 		{
@@ -565,8 +567,8 @@ func TestSliceMetadata(t *testing.T) {
 		Array: Array{
 			Format: "<f4",
 		},
-		X:          Axis{Annotation: "Sample", Min: 4, Max: 16, Samples: 4, Unit: "ms"},
-		Y:          Axis{Annotation: "Inline", Min: 1, Max: 5, Samples: 3, Unit: "unitless"},
+		X:          Axis{Annotation: "Sample", Min: 4, Max: 16, Samples: 4, StepSize: 4, Unit: "ms"},
+		Y:          Axis{Annotation: "Inline", Min: 1, Max: 5, Samples: 3, StepSize: 2, Unit: "unitless"},
 		Geospatial: [][]float64{{0, 3}, {12, 11}},
 		Shape:      []int{3, 4},
 	}

--- a/internal/core/cppapi_data.cpp
+++ b/internal/core/cppapi_data.cpp
@@ -264,7 +264,7 @@ void horizon_buffer_offsets(
     auto xline  = metadata.xline();
     auto sample = metadata.sample();
 
-    VerticalWindow window(sample.stride(), 2, sample.min());
+    VerticalWindow window(sample.stepsize(), 2, sample.min());
 
     out[0] = 0;
     for (int i = 0; i < reference.size(); ++i) {
@@ -337,7 +337,7 @@ void horizon(
     }
     std::unique_ptr< voxel[] > samples(new voxel[nsamples]{{0}});
 
-    VerticalWindow window(sample.stride(), 2, sample.min());
+    VerticalWindow window(sample.stepsize(), 2, sample.min());
     std::size_t cur = 0;
     for (int i = from; i < to; ++i) {
         if(buffer_offsets[i] == buffer_offsets[i+1]) {

--- a/internal/core/cppapi_metadata.cpp
+++ b/internal/core/cppapi_metadata.cpp
@@ -51,17 +51,18 @@ nlohmann::json json_axis(
 
     int dim = axis.dimension();
 
-    float min = axis.min() + axis.stride() * lower[dim];
-    float max = axis.min() + axis.stride() * (upper[dim] - 1); // inclusive
+    float min = axis.min() + axis.stepsize() * lower[dim];
+    float max = axis.min() + axis.stepsize() * (upper[dim] - 1); // inclusive
     std::size_t samples = upper[dim] - lower[dim];
 
     nlohmann::json doc;
     doc = {
-        { "annotation", axis.name() },
-        { "min",        min         },
-        { "max",        max         },
-        { "samples",    samples     },
-        { "unit",       axis.unit() },
+        { "annotation", axis.name()       },
+        { "min",        min               },
+        { "max",        max               },
+        { "samples",    samples           },
+        { "stepsize",     axis.stepsize() },
+        { "unit",       axis.unit()       },
     };
     return doc;
 }

--- a/internal/core/interpolation.hpp
+++ b/internal/core/interpolation.hpp
@@ -8,8 +8,8 @@
 #include <boost/math/interpolators/makima.hpp>
 
 template< typename T >
-struct StrideGenerator {
-    StrideGenerator(T start, T step) : cur(start), step(step) {}
+struct StepSizeGenerator {
+    StepSizeGenerator(T start, T step) : cur(start), step(step) {}
 
     T operator()() {
         T tmp = this->cur;
@@ -34,14 +34,14 @@ void cubic_makima(
     T step  = src_window.stepsize();
 
     std::vector< T > xs(ys.size());
-    std::generate(xs.begin(), xs.end(), StrideGenerator(start, step));
+    std::generate(xs.begin(), xs.end(), StepSizeGenerator(start, step));
 
     using boost::math::interpolators::makima;
     auto spline = makima< std::vector< T >>(std::move(xs), std::move(ys));
 
     start = dst_window.at(0, reference_point);
     step  = dst_window.stepsize();
-    auto gen_x = StrideGenerator(start, step);
+    auto gen_x = StepSizeGenerator(start, step);
     std::generate(dst_buffer.begin(), dst_buffer.end(), [&spline, &gen_x](){
         return spline(gen_x());
     });

--- a/internal/core/subvolume.cpp
+++ b/internal/core/subvolume.cpp
@@ -15,16 +15,16 @@ int lineno_annotation_to_voxel(
 ) {
     float min    = axis.min();
     float max    = axis.max();
-    float stride = axis.stride();
+    float stepsize = axis.stepsize();
 
-    float voxelline = (lineno - min) / stride;
+    float voxelline = (lineno - min) / stepsize;
 
     if (lineno < min || lineno > max || std::floor(voxelline) != voxelline) {
         throw detail::bad_request(
             "Invalid lineno: " + std::to_string(lineno) +
             ", valid range: [" + std::to_string(min) +
             ":" + std::to_string(max) +
-            ":" + std::to_string(stride) + "]"
+            ":" + std::to_string(stepsize) + "]"
         );
     }
 

--- a/tests/e2e/test_requests.py
+++ b/tests/e2e/test_requests.py
@@ -135,8 +135,8 @@ def test_slice(method):
 
     expected_meta = json.loads("""
     {
-        "x": {"annotation": "Sample", "max": 16.0, "min": 4.0, "samples" : 4, "unit": "ms"},
-        "y": {"annotation": "Crossline", "max": 11.0, "min": 10.0, "samples" : 2, "unit": "unitless"},
+        "x": {"annotation": "Sample", "max": 16.0, "min": 4.0, "samples" : 4, "stepsize": 4.0, "unit": "ms"},
+        "y": {"annotation": "Crossline", "max": 11.0, "min": 10.0, "samples" : 2, "stepsize": 1.0, "unit": "unitless"},
         "shape": [ 2, 4],
         "format": "<f4",
         "geospatial": [[14.0, 8.0], [12.0, 11.0]]
@@ -173,9 +173,9 @@ def test_metadata(method):
     metadata = dict(request_metadata(method))
     expected_metadata = {
         "axis": [
-            {"annotation": "Inline",    "max": 5.0,  "min": 1.0,  "samples": 3, "unit": "unitless"},
-            {"annotation": "Crossline", "max": 11.0, "min": 10.0, "samples": 2, "unit": "unitless"},
-            {"annotation": "Sample",    "max": 16.0, "min": 4.0,  "samples": 4, "unit": "ms"}
+            {"annotation": "Inline",    "max": 5.0,  "min": 1.0,  "samples": 3, "stepsize": 2.0, "unit": "unitless"},
+            {"annotation": "Crossline", "max": 11.0, "min": 10.0, "samples": 2, "stepsize": 1.0, "unit": "unitless"},
+            {"annotation": "Sample",    "max": 16.0, "min": 4.0,  "samples": 4, "stepsize": 4.0, "unit": "ms"}
         ],
         "boundingBox": {
             "cdp" : [[2,0]  , [14,8] , [12,11] , [0,3] ],

--- a/tests/performance/script-constant-horizon.js
+++ b/tests/performance/script-constant-horizon.js
@@ -28,10 +28,10 @@ export function setup() {
 
 export default function (params) {
   const [surface, inlineAxis, xlineAxis, sampleAxis] = params;
-  const sampleAxisStride =
+  const sampleAxisStepSize =
     (sampleAxis.max - sampleAxis.min) / (sampleAxis.samples - 1);
   const depth =
-    Math.floor(sampleAxis.samples / 2) * sampleAxisStride + sampleAxis.min;
+    Math.floor(sampleAxis.samples / 2) * sampleAxisStepSize + sampleAxis.min;
   const above = 10;
   const below = 10;
   const stepsize = 1;

--- a/tests/performance/script-random-horizon.js
+++ b/tests/performance/script-random-horizon.js
@@ -28,9 +28,9 @@ export function setup() {
 
 export default function (params) {
   const [surface, inlineAxis, xlineAxis, sampleAxis] = params;
-  const sampleAxisStride =
+  const sampleAxisStepSize =
     (sampleAxis.max - sampleAxis.min) / (sampleAxis.samples - 1);
-  const depth = [sampleAxis.min, sampleAxis.max, sampleAxisStride];
+  const depth = [sampleAxis.min, sampleAxis.max, sampleAxisStepSize];
   const attributes = ["samplevalue", "min", "max", "mean", "rms", "sd"]
   const above = 20;
   const below = 20;


### PR DESCRIPTION
Add axis stride to metadata endpoint

Indexing and accessing the data often require the user to calculate the  stride. 
As a simplification measure this calculation is moved to the sever side. 