### PR TITLE
Introduce regular surface subscript

### DIFF
--- a/internal/core/attribute.cpp
+++ b/internal/core/attribute.cpp
@@ -231,8 +231,8 @@ void calc_attributes(
     AttributeMap::AttributeComputeParams params;
 
     for (std::size_t i = from; i < to; ++i) {
-        auto above = reference.value(i) - top.value(i);
-        auto below = bottom.value(i) - reference.value(i);
+        auto above = reference[i] - top[i];
+        auto below = bottom[i] - reference[i];
 
         src_window.move(above, below);
         dst_window.move(above, below);
@@ -256,7 +256,7 @@ void calc_attributes(
             src_window,
             dst_buffer,
             dst_window,
-            reference.value(i)
+            reference[i]
         );
 
         params.update(

--- a/internal/core/cppapi_data.cpp
+++ b/internal/core/cppapi_data.cpp
@@ -268,9 +268,9 @@ void horizon_buffer_offsets(
 
     out[0] = 0;
     for (int i = 0; i < reference.size(); ++i) {
-        float reference_depth = reference.value(i);
-        float top_depth       = top.value(i);
-        float bottom_depth    = bottom.value(i);
+        float reference_depth = reference[i];
+        float top_depth       = top[i];
+        float bottom_depth    = bottom[i];
 
         if (reference_depth == reference.fillvalue() ||
             top_depth == top.fillvalue() ||
@@ -344,9 +344,9 @@ void horizon(
             continue;
         }
 
-        window.move(reference.value(i) - top.value(i), bottom.value(i) - reference.value(i));
+        window.move(reference[i] - top[i], bottom[i] - reference[i]);
 
-        double nearest_reference_depth = window.nearest(reference.value(i));
+        double nearest_reference_depth = window.nearest(reference[i]);
 
         auto const cdp = reference.to_cdp(i);
         auto ij = transform.WorldToAnnotation({cdp.x, cdp.y, 0});
@@ -496,8 +496,8 @@ void align_surfaces(
     SurfacesCrossoverValidator surfaces;
 
     for (std::size_t i = 0; i < primary.size(); ++i) {
-        if (primary.fillvalue() == primary.value(i)) {
-            aligned.set_value(i, aligned.fillvalue());
+        if (primary.fillvalue() == primary[i]) {
+            aligned[i] = aligned.fillvalue();
             continue;
         }
         auto secondary_pos = secondary.from_cdp(primary.to_cdp(i));
@@ -508,20 +508,20 @@ void align_surfaces(
         if (secondary_row < 0 || secondary_row >= secondary.nrows() ||
             (secondary_col < 0 || secondary_col >= secondary.ncols()))
         {
-            aligned.set_value(i, aligned.fillvalue());
+            aligned[i] = aligned.fillvalue();
             continue;
         }
 
-        auto secondary_value = secondary.value(secondary_row, secondary_col);
+        auto secondary_value = secondary[as_pair(secondary_row, secondary_col)];
 
         if(secondary.fillvalue() == secondary_value) {
-            aligned.set_value(i, aligned.fillvalue());
+            aligned[i] = aligned.fillvalue();
             continue;
         }
 
-        aligned.set_value(i, secondary_value);
+        aligned[i] = secondary_value;
 
-        if (surfaces.have_crossed(primary.value(i), aligned.value(i))) {
+        if (surfaces.have_crossed(primary[i], aligned[i])) {
             std::size_t row = i / primary.ncols();
             std::size_t col = i % primary.ncols();
             throw detail::bad_request("Surfaces intersect at primary surface point ("

--- a/internal/core/regularsurface.cpp
+++ b/internal/core/regularsurface.cpp
@@ -95,6 +95,38 @@ Point RegularSurface::from_cdp(
     return this->m_plane.m_inverse_transformation * point;
 }
 
+std::pair<std::size_t, std::size_t> as_pair(std::size_t row, std::size_t col) {
+    return std::pair<std::size_t, std::size_t>(row, col);
+}
+
+float &RegularSurface::operator[](std::size_t i) noexcept(false) {
+    if (i >= this->size())
+        throw std::runtime_error("operator[]: index out of range");
+    return this->m_data[i];
+}
+
+const float &RegularSurface::operator[](std::size_t i) const noexcept(false) {
+    if (i >= this->size())
+        throw std::runtime_error("const operator[]: index out of range");
+    return this->m_data[i];
+}
+
+float &RegularSurface::operator[](std::pair<std::size_t, std::size_t> p) noexcept(false) {
+    if (p.first >= this->nrows())
+        throw std::runtime_error("operator[]: index out of range");
+    if (p.second >= this->ncols())
+        throw std::runtime_error("operator[]: index out of range");
+    return this->m_data[p.first * this->ncols() + p.second];
+}
+
+const float &RegularSurface::operator[](std::pair<std::size_t, std::size_t> p) const noexcept(false) {
+    if (p.first >= this->nrows())
+        throw std::runtime_error("const operator[]: index out of range");
+    if (p.second >= this->ncols())
+        throw std::runtime_error("const operator[]: index out of range");
+    return this->m_data[p.first * this->ncols() + p.second];
+}
+
 float RegularSurface::value(
     std::size_t const row,
     std::size_t const col

--- a/internal/core/regularsurface.cpp
+++ b/internal/core/regularsurface.cpp
@@ -126,25 +126,3 @@ const float &RegularSurface::operator[](std::pair<std::size_t, std::size_t> p) c
         throw std::runtime_error("const operator[]: index out of range");
     return this->m_data[p.first * this->ncols() + p.second];
 }
-
-float RegularSurface::value(
-    std::size_t const row,
-    std::size_t const col
-) const noexcept (false) {
-    if (row >= this->nrows()) throw std::runtime_error("Row out of range");
-    if (col >= this->ncols()) throw std::runtime_error("Col out of range");
-
-    return this->m_data[row * this->ncols() + col];
-};
-
-float RegularSurface::value(std::size_t i) const noexcept (false) {
-    if (i >= this->size()) throw std::runtime_error("index out of range");
-
-    return this->m_data[i];
-}
-
-void RegularSurface::set_value(std::size_t i, float value) noexcept (false) {
-    if (i >= this->size()) throw std::runtime_error("index out of range");
-
-    this->m_data[i] = value;
-}

--- a/internal/core/regularsurface.hpp
+++ b/internal/core/regularsurface.hpp
@@ -121,14 +121,6 @@ public:
 
     float(&operator[](std::pair<std::size_t, std::size_t>) noexcept(false));
     const float(&operator[](std::pair<std::size_t, std::size_t>) const noexcept(false));
-    /* Value at grid position (row, col) */
-    float value(
-        std::size_t const row,
-        std::size_t const col
-    ) const noexcept (false);
-
-    float value(std::size_t i) const noexcept (false);
-    void set_value(std::size_t i, float value) noexcept (false);
 
     float fillvalue() const noexcept (true) { return this->m_fillvalue; };
 

--- a/internal/core/regularsurface.hpp
+++ b/internal/core/regularsurface.hpp
@@ -68,6 +68,8 @@ struct Plane
     AffineTransformation m_inverse_transformation;
 };
 
+std::pair<std::size_t, std::size_t> as_pair(std::size_t row, std::size_t col);
+
 /** Regular Surface - a set of data points over the finite part of 2D plane.
  * It is represented as 2D array with geospacial information. Each array value
  * can mean anything, but in practice it would likely be the depth at the grid
@@ -114,6 +116,11 @@ public:
         Point point
     ) const noexcept (false);
 
+    float(&operator[](std::size_t i) noexcept(false));
+    const float(&operator[](std::size_t i) const noexcept(false));
+
+    float(&operator[](std::pair<std::size_t, std::size_t>) noexcept(false));
+    const float(&operator[](std::pair<std::size_t, std::size_t>) const noexcept(false));
     /* Value at grid position (row, col) */
     float value(
         std::size_t const row,
@@ -125,9 +132,9 @@ public:
 
     float fillvalue() const noexcept (true) { return this->m_fillvalue; };
 
-    std::size_t nrows() const noexcept (true) { return this->m_nrows; };
-    std::size_t ncols() const noexcept (true) { return this->m_ncols; };
-    std::size_t size()  const noexcept (true) { return this->ncols() * this->nrows(); };
+    std::size_t nrows() const noexcept(true) { return this->m_nrows; };
+    std::size_t ncols() const noexcept(true) { return this->m_ncols; };
+    std::size_t size() const noexcept(true) { return this->ncols() * this->nrows(); };
 
     Plane plane() const noexcept (true) { return this->m_plane; };
 private:

--- a/tests/gtest/cppapi_test.cpp
+++ b/tests/gtest/cppapi_test.cpp
@@ -232,7 +232,7 @@ void test_successful_align_call(
 
     for (int i = 0; i < primary.size(); ++i)
     {
-        EXPECT_EQ(aligned.value(i), expected_data[i]) << "Wrong surface at index " << i;
+        EXPECT_EQ(aligned[i], expected_data[i]) << "Wrong surface at index " << i;
     }
 }
 

--- a/tests/gtest/regularsurface_test.cpp
+++ b/tests/gtest/regularsurface_test.cpp
@@ -3,12 +3,17 @@
 
 #include "regularsurface.hpp"
 
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
-namespace
-{
+namespace {
 
-TEST(AffineTransformationTest, InverseProperty)
-{
+static Plane samples_10_plane = Plane(2, 0, 7.2111, 3.6056, 33.69);
+static constexpr float fill = -999.25;
+static constexpr std::size_t nrows = 3;
+static constexpr std::size_t ncols = 2;
+static std::array<float, nrows *ncols> ref_surface_data = {2, 3, 5, 7, 11, 13};
+
+TEST(AffineTransformationTest, InverseProperty) {
     std::random_device rd;
     std::mt19937 gen(rd());
     std::uniform_real_distribution<> distribution(-1000000, 1000000);
@@ -43,6 +48,124 @@ TEST(AffineTransformationTest, InverseProperty)
     EXPECT_NEAR(point.y, f_finv.y, 0.00001) << "f(f_inv(point)).y != point.y";
     EXPECT_NEAR(point.x, finv_f.x, 0.00001) << "f_inv(f(point)).x != point.x";
     EXPECT_NEAR(point.y, finv_f.y, 0.00001) << "f_inv(f(point)).y != point.y";
+}
+
+TEST(RegularSurfaceSubscriptTest, SingleIndexOutOfRange) {
+    RegularSurface surface =
+        RegularSurface(ref_surface_data.data(), nrows, ncols, samples_10_plane, fill);
+
+    std::size_t index_lower = 0;
+    std::size_t index_upper = ref_surface_data.size() - 1;
+    std::size_t index_above_upper = index_upper + 1;
+
+    EXPECT_EQ(surface[index_lower], ref_surface_data[0]) << "Unexpected value";
+
+    EXPECT_EQ(surface[index_upper], ref_surface_data[ref_surface_data.size() - 1])
+        << "Unexpected value";
+
+    EXPECT_THAT([&]() { surface[index_above_upper]; },
+                testing::ThrowsMessage<std::runtime_error>(
+                    testing::HasSubstr("operator[]: index out of range")));
+}
+
+TEST(RegularSurfaceSubscriptTest, SingleSubscriptVersusRefValue) {
+    RegularSurface surface =
+        RegularSurface(ref_surface_data.data(), nrows, ncols, samples_10_plane, fill);
+
+    for (std::size_t i = 0; i < ref_surface_data.size(); i++) {
+        EXPECT_EQ(surface[i], ref_surface_data[i]) << "Unexpected value";
+    }
+}
+
+TEST(RegularSurfaceSubscriptTest, SingleUpdateValue) {
+    std::array<float, nrows *ncols> surface_data = ref_surface_data;
+
+    RegularSurface surface =
+        RegularSurface(surface_data.data(), nrows, ncols, samples_10_plane, fill);
+
+    for (std::size_t i = 0; i < surface_data.size(); i++) {
+        surface[i] *= 2;
+    }
+
+    for (std::size_t i = 0; i < surface_data.size(); i++) {
+        EXPECT_EQ(surface[i], ref_surface_data[i] * 2)
+            << "Unexpected updated value";
+    }
+}
+
+TEST(RegularSurfaceSubscriptTest, DoubleRowOutOfRange) {
+    RegularSurface surface =
+        RegularSurface(ref_surface_data.data(), nrows, ncols, samples_10_plane, fill);
+
+    auto lower_row = as_pair(0, 1);
+    auto upper_row = as_pair(nrows - 1, 1);
+    auto above_upper_row = as_pair(upper_row.first + 1, upper_row.second);
+
+    EXPECT_EQ(surface[lower_row],
+              ref_surface_data[lower_row.first * ncols + lower_row.second])
+        << "Wrong row number";
+
+    EXPECT_EQ(surface[upper_row],
+              ref_surface_data[upper_row.first * ncols + upper_row.second])
+        << "Wrong row number";
+
+    EXPECT_THAT([&]() { surface[above_upper_row]; },
+                testing::ThrowsMessage<std::runtime_error>(
+                    testing::HasSubstr("operator[]: index out of range")));
+}
+
+TEST(RegularSurfaceSubscriptTest, DoubleColOutOfRange) {
+    RegularSurface surface =
+        RegularSurface(ref_surface_data.data(), nrows, ncols, samples_10_plane, fill);
+
+    auto lower_col = as_pair(1, 0);
+    auto upper_col = as_pair(1, ncols - 1);
+    auto above_upper_col = as_pair(upper_col.first, upper_col.second + 1);
+
+    EXPECT_EQ(surface[lower_col],
+              ref_surface_data[lower_col.first * ncols + lower_col.second])
+        << "Wrong col number";
+
+    EXPECT_EQ(surface[upper_col],
+              ref_surface_data[upper_col.first * ncols + upper_col.second])
+        << "Wrong col number";
+
+    EXPECT_THAT([&]() { surface[above_upper_col]; },
+                testing::ThrowsMessage<std::runtime_error>(
+                    testing::HasSubstr("operator[]: index out of range")));
+}
+
+TEST(RegularSurfaceSubscriptTest, DoubleUpdateValues) {
+    std::array<float, nrows *ncols> surface_data = ref_surface_data;
+    RegularSurface surface =
+        RegularSurface(surface_data.data(), nrows, ncols, samples_10_plane, fill);
+
+    for (std::size_t row = 0; row < nrows; row++) {
+        for (std::size_t col = 0; col < ncols; col++) {
+            surface[as_pair(row, col)] *= 2;
+        }
+    }
+
+    for (std::size_t row = 0; row < nrows; row++) {
+        for (std::size_t col = 0; col < ncols; col++) {
+            EXPECT_EQ(surface[as_pair(row, col)],
+                      ref_surface_data[row * ncols + col] * 2)
+                << "Unexpected value after update";
+        }
+    }
+}
+
+TEST(RegularSurfaceSubscriptTest, DoubleVersusReference) {
+    RegularSurface surface =
+        RegularSurface(ref_surface_data.data(), nrows, ncols, samples_10_plane, fill);
+
+    for (std::size_t row = 0; row < nrows; row++) {
+        for (std::size_t col = 0; col < ncols; col++) {
+            auto p = as_pair(row, col);
+            EXPECT_EQ(surface[p], ref_surface_data[row * ncols + col])
+                << "Unexpected value";
+        }
+    }
 }
 
 } // namespace


### PR DESCRIPTION
Introducing parameters via subscript to RegularSurfaces. 

Two types of subscript indexing is available. 
Single subscript has only one integer parameter and is used as follows:
```
std::size_t value = surface[row_nr * nr_of_colums + col_nr];
surface[row_nr * nr_of_colums + col_nr] = value;
```
Second subscript is defined for the Point struct and, thus indirectly allows two parameters:
```
Point p;
p.x = row;
p.y = col;
std::size_t value = surface[p];
surface[p] *= 2;
```

Tests checking read and write as well as comparison to the value function is available in "regularsurfacesubscript_test.cpp".


Close #195 