### PR TITLE
Subcube + BoundedPlane

### DIFF
--- a/internal/core/CMakeLists.txt
+++ b/internal/core/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(cppcore
   direction.cpp
   metadatahandle.cpp
   regularsurface.cpp
-  subvolume.cpp
+  subcube.cpp
   verticalwindow.cpp
 )
 

--- a/internal/core/capi.cpp
+++ b/internal/core/capi.cpp
@@ -97,9 +97,7 @@ int regular_surface_new(
 
         *out = new RegularSurface(
             data,
-            nrows,
-            ncols,
-            Plane(xori, yori, xinc, yinc, rot),
+            BoundedPlane(Plane(xori, yori, xinc, yinc, rot), nrows, ncols),
             fillvalue
         );
         return STATUS_OK;

--- a/internal/core/cppapi_data.cpp
+++ b/internal/core/cppapi_data.cpp
@@ -245,15 +245,13 @@ void horizon_buffer_offsets(
     std::size_t* out,
     std::size_t out_size
 ) {
-    if (reference.size() != top.size() or reference.size() != bottom.size()) {
-        throw std::runtime_error("Expected surfaces to be of the same size");
-    }
-
     if (!(reference.plane() == top.plane() && reference.plane() == bottom.plane())) {
-        throw std::runtime_error("Expected surfaces to have the same plane");
+        throw std::runtime_error("Expected surfaces to have the same plane and size");
     }
 
-    if (out_size != (reference.size() + 1)) {
+    auto const horizontal = reference.plane();
+
+    if (out_size != (horizontal.size() + 1)) {
         throw std::runtime_error("out buffer must be the size of surface + 1");
     }
 
@@ -267,7 +265,7 @@ void horizon_buffer_offsets(
     VerticalWindow window(sample.stepsize(), 2, sample.min());
 
     out[0] = 0;
-    for (int i = 0; i < reference.size(); ++i) {
+    for (int i = 0; i < horizontal.size(); ++i) {
         float reference_depth = reference[i];
         float top_depth       = top[i];
         float bottom_depth    = bottom[i];
@@ -287,7 +285,7 @@ void horizon_buffer_offsets(
                 "Planes are not ordered as top <= reference <= bottom");
         }
 
-        auto const cdp = reference.to_cdp(i);
+        auto const cdp = horizontal.to_cdp(i);
         auto ij = transform.WorldToAnnotation({cdp.x, cdp.y, 0});
 
         if (not iline.inrange(ij[0]) or not xline.inrange(ij[1])) {
@@ -312,15 +310,13 @@ void horizon(
     std::size_t to,
     void* out
 ) {
-    if (reference.size() != top.size() or reference.size() != bottom.size()) {
-        throw std::runtime_error("Expected surfaces to be of the same size");
-    }
-
     if (!(reference.plane() == top.plane() && reference.plane() == bottom.plane())) {
-        throw std::runtime_error("Expected surfaces to have the same plane");
+        throw std::runtime_error("Expected surfaces to have the same plane and size");
     }
 
-    if (to > reference.size()){
+    auto const horizontal = reference.plane();
+
+    if (to > horizontal.size()){
         throw std::invalid_argument("'to' must be less than surface size");
     }
 
@@ -348,7 +344,7 @@ void horizon(
 
         double nearest_reference_depth = window.nearest(reference[i]);
 
-        auto const cdp = reference.to_cdp(i);
+        auto const cdp = horizontal.to_cdp(i);
         auto ij = transform.WorldToAnnotation({cdp.x, cdp.y, 0});
 
         double nearest_top_depth    = nearest_reference_depth -
@@ -359,8 +355,8 @@ void horizon(
         if (not sample.inrange(nearest_top_depth) or
             not sample.inrange(nearest_bottom_depth))
         {
-            auto row = i / reference.ncols();
-            auto col = i % reference.ncols();
+            auto row = i / horizontal.ncols();
+            auto col = i % horizontal.ncols();
             throw std::runtime_error(
                 "Vertical window is out of vertical bounds at"
                 " row: " + std::to_string(row) +
@@ -418,12 +414,8 @@ void attributes(
     std::size_t to,
     void** out
 ) {
-    if (reference.size() != top.size() or reference.size() != bottom.size()) {
-        throw std::runtime_error("Expected surfaces to be of the same size");
-    }
-
     if (!(reference.plane() == top.plane() && reference.plane() == bottom.plane())) {
-        throw std::runtime_error("Expected surfaces to have the same plane");
+        throw std::runtime_error("Expected surfaces to have the same plane and size");
     }
 
     std::size_t size = horizon.mapsize();
@@ -488,7 +480,7 @@ void align_surfaces(
     RegularSurface &aligned,
     bool* primary_is_top
 ) {
-    if (primary.size() != aligned.size() or !(primary.plane() == aligned.plane())) {
+    if (!(primary.plane() == aligned.plane())) {
         throw std::runtime_error(
             "Expected primary and aligned surfaces to differ in data only.");
     }
@@ -500,13 +492,13 @@ void align_surfaces(
             aligned[i] = aligned.fillvalue();
             continue;
         }
-        auto secondary_pos = secondary.from_cdp(primary.to_cdp(i));
+        auto secondary_pos = secondary.plane().from_cdp(primary.plane().to_cdp(i));
         // calculated value can be out of bounds, also negative
         auto secondary_row = std::lround(secondary_pos.x);
         auto secondary_col = std::lround(secondary_pos.y);
 
-        if (secondary_row < 0 || secondary_row >= secondary.nrows() ||
-            (secondary_col < 0 || secondary_col >= secondary.ncols()))
+        if (secondary_row < 0 || secondary_row >= secondary.plane().nrows() ||
+            (secondary_col < 0 || secondary_col >= secondary.plane().ncols()))
         {
             aligned[i] = aligned.fillvalue();
             continue;
@@ -522,8 +514,8 @@ void align_surfaces(
         aligned[i] = secondary_value;
 
         if (surfaces.have_crossed(primary[i], aligned[i])) {
-            std::size_t row = i / primary.ncols();
-            std::size_t col = i % primary.ncols();
+            std::size_t row = i / primary.plane().ncols();
+            std::size_t col = i % primary.plane().ncols();
             throw detail::bad_request("Surfaces intersect at primary surface point ("
                                         + std::to_string(row) + ", "
                                         + std::to_string(col) + ")");

--- a/internal/core/cppapi_data.cpp
+++ b/internal/core/cppapi_data.cpp
@@ -355,8 +355,8 @@ void horizon(
         if (not sample.inrange(nearest_top_depth) or
             not sample.inrange(nearest_bottom_depth))
         {
-            auto row = i / horizontal.ncols();
-            auto col = i % horizontal.ncols();
+            auto row = horizontal.row(i);
+            auto col = horizontal.col(i);
             throw std::runtime_error(
                 "Vertical window is out of vertical bounds at"
                 " row: " + std::to_string(row) +
@@ -514,8 +514,8 @@ void align_surfaces(
         aligned[i] = secondary_value;
 
         if (surfaces.have_crossed(primary[i], aligned[i])) {
-            std::size_t row = i / primary.plane().ncols();
-            std::size_t col = i % primary.plane().ncols();
+            std::size_t row = primary.plane().row(i);
+            std::size_t col = primary.plane().col(i);
             throw detail::bad_request("Surfaces intersect at primary surface point ("
                                         + std::to_string(row) + ", "
                                         + std::to_string(col) + ")");

--- a/internal/core/cppapi_data.cpp
+++ b/internal/core/cppapi_data.cpp
@@ -15,7 +15,7 @@
 #include "exceptions.hpp"
 #include "metadatahandle.hpp"
 #include "regularsurface.hpp"
-#include "subvolume.hpp"
+#include "subcube.hpp"
 #include "verticalwindow.hpp"
 
 namespace {
@@ -147,14 +147,14 @@ void slice(
         validate_vertical_axis(metadata.sample(), bound_dir);
     }
 
-    SubVolume bounds(metadata);
+    SubCube bounds(metadata);
     bounds.constrain(metadata, slicebounds);
     bounds.set_slice(axis, lineno, direction.coordinate_system());
 
-    std::int64_t const size = handle.subvolume_buffer_size(bounds);
+    std::int64_t const size = handle.subcube_buffer_size(bounds);
 
     std::unique_ptr< char[] > data(new char[size]);
-    handle.read_subvolume(data.get(), size, bounds);
+    handle.read_subcube(data.get(), size, bounds);
 
     return to_response(std::move(data), size, out);
 }

--- a/internal/core/cppapi_metadata.cpp
+++ b/internal/core/cppapi_metadata.cpp
@@ -44,10 +44,10 @@ void to_response(nlohmann::json const& metadata, response* response) {
 
 nlohmann::json json_axis(
     Axis const& axis,
-    SubVolume const& subvolume
+    SubCube const& subcube
 ) {
-    auto const& lower = subvolume.bounds.lower;
-    auto const& upper = subvolume.bounds.upper;
+    auto const& lower = subcube.bounds.lower;
+    auto const& upper = subcube.bounds.upper;
 
     int dim = axis.dimension();
 
@@ -72,7 +72,7 @@ nlohmann::json json_slice_geospatial(
     Direction const direction,
     Axis const& axis,
     int lineno,
-    SubVolume const& bounds
+    SubCube const& bounds
 ) {
     auto const& transformer = metadata.coordinate_transformer();
 
@@ -158,7 +158,7 @@ void slice_metadata(
     Axis const& crossline_axis = metadata.xline();
     Axis const& sample_axis = metadata.sample();
 
-    SubVolume bounds(metadata);
+    SubCube bounds(metadata);
     bounds.constrain(metadata, slicebounds);
     bounds.set_slice(axis, lineno, direction.coordinate_system());
 
@@ -223,7 +223,7 @@ void metadata(DataHandle& handle, response* out) {
     meta["boundingBox"]["cdp"]  = bbox.world();
     meta["boundingBox"]["ilxl"] = bbox.annotation();
 
-    SubVolume volume(metadata);
+    SubCube volume(metadata);
 
     Axis const& inline_axis = metadata.iline();
     meta["axis"].push_back(json_axis(inline_axis, volume));

--- a/internal/core/datahandle.cpp
+++ b/internal/core/datahandle.cpp
@@ -6,7 +6,7 @@
 #include <OpenVDS/OpenVDS.h>
 
 #include "metadatahandle.hpp"
-#include "subvolume.hpp"
+#include "subcube.hpp"
 
 namespace {
 
@@ -57,12 +57,12 @@ OpenVDS::VolumeDataFormat DataHandle::format() noexcept (true) {
     return OpenVDS::VolumeDataFormat::Format_R32;
 }
 
-std::int64_t DataHandle::subvolume_buffer_size(
-    SubVolume const& subvolume
+std::int64_t DataHandle::subcube_buffer_size(
+    SubCube const& subcube
 ) noexcept (false) {
     std::int64_t size = this->m_access_manager.GetVolumeSubsetBufferSize(
-        subvolume.bounds.lower,
-        subvolume.bounds.upper,
+        subcube.bounds.lower,
+        subcube.bounds.upper,
         DataHandle::format(),
         DataHandle::lod_level,
         DataHandle::channel
@@ -71,10 +71,10 @@ std::int64_t DataHandle::subvolume_buffer_size(
     return size;
 }
 
-void DataHandle::read_subvolume(
+void DataHandle::read_subcube(
     void * const buffer,
     std::int64_t size,
-    SubVolume const& subvolume
+    SubCube const& subcube
 ) noexcept (false) {
     auto request = this->m_access_manager.RequestVolumeSubset(
         buffer,
@@ -82,8 +82,8 @@ void DataHandle::read_subvolume(
         OpenVDS::Dimensions_012,
         DataHandle::lod_level,
         DataHandle::channel,
-        subvolume.bounds.lower,
-        subvolume.bounds.upper,
+        subcube.bounds.lower,
+        subcube.bounds.upper,
         DataHandle::format()
     );
     bool const success = request.get()->WaitForCompletion();

--- a/internal/core/datahandle.hpp
+++ b/internal/core/datahandle.hpp
@@ -7,7 +7,7 @@
 #include <OpenVDS/OpenVDS.h>
 
 #include "metadatahandle.hpp"
-#include "subvolume.hpp"
+#include "subcube.hpp"
 
 using voxel = float[OpenVDS::Dimensionality_Max];
 
@@ -20,12 +20,12 @@ public:
 
     static OpenVDS::VolumeDataFormat format() noexcept (true);
 
-    std::int64_t subvolume_buffer_size(SubVolume const& subvolume) noexcept (false);
+    std::int64_t subcube_buffer_size(SubCube const& subcube) noexcept (false);
 
-    void read_subvolume(
+    void read_subcube(
         void * const buffer,
         std::int64_t size,
-        SubVolume const& subvolume
+        SubCube const& subcube
     ) noexcept (false);
 
     std::int64_t traces_buffer_size(std::size_t const ntraces) noexcept (false);

--- a/internal/core/regularsurface.cpp
+++ b/internal/core/regularsurface.cpp
@@ -68,7 +68,11 @@ bool Plane::operator==(const Plane& other) const {
     return this->m_transformation == other.m_transformation;
 }
 
-Point RegularSurface::to_cdp(
+bool BoundedPlane::operator==(const BoundedPlane& other) const {
+    return Plane::operator==(other) && this->m_nrows == other.m_nrows && this->m_ncols == other.m_ncols;
+}
+
+Point BoundedPlane::to_cdp(
     std::size_t const row,
     std::size_t const col
 ) const noexcept (false) {
@@ -77,10 +81,10 @@ Point RegularSurface::to_cdp(
 
     Point point {static_cast<double>(row), static_cast<double>(col)};
 
-    return this->m_plane.m_transformation * point;
+    return this->m_transformation * point;
 }
 
-Point RegularSurface::to_cdp(
+Point BoundedPlane::to_cdp(
     std::size_t i
 ) const noexcept(false) {
     auto row = i / this->ncols();
@@ -89,10 +93,10 @@ Point RegularSurface::to_cdp(
     return to_cdp(row, col);
 }
 
-Point RegularSurface::from_cdp(
+Point BoundedPlane::from_cdp(
     Point point
 ) const noexcept (false) {
-    return this->m_plane.m_inverse_transformation * point;
+    return this->m_inverse_transformation * point;
 }
 
 std::pair<std::size_t, std::size_t> as_pair(std::size_t row, std::size_t col) {
@@ -100,29 +104,29 @@ std::pair<std::size_t, std::size_t> as_pair(std::size_t row, std::size_t col) {
 }
 
 float &RegularSurface::operator[](std::size_t i) noexcept(false) {
-    if (i >= this->size())
+    if (i >= this->m_plane.size())
         throw std::runtime_error("operator[]: index out of range");
     return this->m_data[i];
 }
 
 const float &RegularSurface::operator[](std::size_t i) const noexcept(false) {
-    if (i >= this->size())
+    if (i >= this->m_plane.size())
         throw std::runtime_error("const operator[]: index out of range");
     return this->m_data[i];
 }
 
 float &RegularSurface::operator[](std::pair<std::size_t, std::size_t> p) noexcept(false) {
-    if (p.first >= this->nrows())
+    if (p.first >= this->m_plane.nrows())
         throw std::runtime_error("operator[]: index out of range");
-    if (p.second >= this->ncols())
+    if (p.second >= this->m_plane.ncols())
         throw std::runtime_error("operator[]: index out of range");
-    return this->m_data[p.first * this->ncols() + p.second];
+    return this->m_data[p.first * this->m_plane.ncols() + p.second];
 }
 
 const float &RegularSurface::operator[](std::pair<std::size_t, std::size_t> p) const noexcept(false) {
-    if (p.first >= this->nrows())
+    if (p.first >= this->m_plane.nrows())
         throw std::runtime_error("const operator[]: index out of range");
-    if (p.second >= this->ncols())
+    if (p.second >= this->m_plane.ncols())
         throw std::runtime_error("const operator[]: index out of range");
-    return this->m_data[p.first * this->ncols() + p.second];
+    return this->m_data[p.first * this->m_plane.ncols() + p.second];
 }

--- a/internal/core/regularsurface.cpp
+++ b/internal/core/regularsurface.cpp
@@ -64,11 +64,11 @@ AffineTransformation AffineTransformation::inverse_from_rotation(
     }}));
 }
 
-bool Plane::operator==(const Plane& other) const {
+bool Plane::operator==(const Plane& other) const noexcept(true) {
     return this->m_transformation == other.m_transformation;
 }
 
-bool BoundedPlane::operator==(const BoundedPlane& other) const {
+bool BoundedPlane::operator==(const BoundedPlane& other) const noexcept(true) {
     return Plane::operator==(other) && this->m_nrows == other.m_nrows && this->m_ncols == other.m_ncols;
 }
 

--- a/internal/core/regularsurface.cpp
+++ b/internal/core/regularsurface.cpp
@@ -72,6 +72,18 @@ bool BoundedPlane::operator==(const BoundedPlane& other) const {
     return Plane::operator==(other) && this->m_nrows == other.m_nrows && this->m_ncols == other.m_ncols;
 }
 
+std::size_t BoundedPlane::row(std::size_t i) const noexcept (false) {
+    if (i >= this->size())
+        throw std::runtime_error("Index out of range");
+    return i / this->ncols();
+}
+
+std::size_t BoundedPlane::col(std::size_t i) const noexcept (false) {
+    if (i >= this->size())
+        throw std::runtime_error("Index out of range");
+    return i % this->ncols();
+}
+
 Point BoundedPlane::to_cdp(
     std::size_t const row,
     std::size_t const col

--- a/internal/core/regularsurface.hpp
+++ b/internal/core/regularsurface.hpp
@@ -62,7 +62,7 @@ struct Plane
      * here would be equal only when parameters provided in the constructor were
      * equal.
      */
-    bool operator==(const Plane& other) const;
+    bool operator==(const Plane& other) const noexcept(true);
 
     AffineTransformation m_transformation;
     AffineTransformation m_inverse_transformation;
@@ -91,7 +91,7 @@ struct BoundedPlane : public Plane
         Point point
     ) const noexcept (false);
 
-    bool operator==(const BoundedPlane& other) const;
+    bool operator==(const BoundedPlane& other) const noexcept(true);
 
     std::size_t nrows() const noexcept (true) { return this->m_nrows; };
     std::size_t ncols() const noexcept (true) { return this->m_ncols; };

--- a/internal/core/regularsurface.hpp
+++ b/internal/core/regularsurface.hpp
@@ -68,6 +68,40 @@ struct Plane
     AffineTransformation m_inverse_transformation;
 };
 
+struct BoundedPlane : public Plane
+{
+    BoundedPlane(
+        Plane plane,
+        std::size_t nrows,
+        std::size_t ncols
+    ) : Plane(plane), m_nrows(nrows), m_ncols(ncols) {}
+
+    /* Grid position (row, col) -> world coordinates */
+    Point to_cdp(
+        std::size_t const row,
+        std::size_t const col
+    ) const noexcept (false);
+
+    Point to_cdp(
+        std::size_t i
+    ) const noexcept(false);
+
+    /* World coordinates -> grid position */
+    Point from_cdp(
+        Point point
+    ) const noexcept (false);
+
+    bool operator==(const BoundedPlane& other) const;
+
+    std::size_t nrows() const noexcept (true) { return this->m_nrows; };
+    std::size_t ncols() const noexcept (true) { return this->m_ncols; };
+    std::size_t size()  const noexcept (true) { return this->ncols() * this->nrows(); };
+
+private:
+    std::size_t  m_nrows;
+    std::size_t  m_ncols;
+};
+
 std::pair<std::size_t, std::size_t> as_pair(std::size_t row, std::size_t col);
 
 /** Regular Surface - a set of data points over the finite part of 2D plane.
@@ -90,31 +124,21 @@ class RegularSurface{
 public:
     RegularSurface(
         float* data,
-        std::size_t  nrows,
-        std::size_t  ncols,
-        Plane plane,
+        BoundedPlane plane,
         float fillvalue
     ) : m_data(data),
-        m_nrows(nrows),
-        m_ncols(ncols),
         m_fillvalue(fillvalue),
         m_plane(plane)
     {}
 
-    /* Grid position (row, col) -> world coordinates */
-    Point to_cdp(
-        std::size_t const row,
-        std::size_t const col
-    ) const noexcept (false);
-
-    Point to_cdp(
-        std::size_t i
-    ) const noexcept(false);
-
-    /* World coordinates -> grid position */
-    Point from_cdp(
-        Point point
-    ) const noexcept (false);
+    RegularSurface(
+        float* data,
+        std::size_t  nrows,
+        std::size_t  ncols,
+        Plane plane,
+        float fillvalue
+    ) : RegularSurface(data, BoundedPlane(plane, nrows, ncols), fillvalue)
+    {}
 
     float(&operator[](std::size_t i) noexcept(false));
     const float(&operator[](std::size_t i) const noexcept(false));
@@ -124,17 +148,14 @@ public:
 
     float fillvalue() const noexcept (true) { return this->m_fillvalue; };
 
-    std::size_t nrows() const noexcept(true) { return this->m_nrows; };
-    std::size_t ncols() const noexcept(true) { return this->m_ncols; };
-    std::size_t size() const noexcept(true) { return this->ncols() * this->nrows(); };
+    std::size_t size() const noexcept (true) { return this->m_plane.size(); };
 
-    Plane plane() const noexcept (true) { return this->m_plane; };
+    BoundedPlane const& plane() const noexcept(true) { return this->m_plane; };
+
 private:
-    float*       m_data;
-    std::size_t  m_nrows;
-    std::size_t  m_ncols;
-    float        m_fillvalue;
-    const Plane  m_plane;
+    float*             m_data;
+    float              m_fillvalue;
+    const BoundedPlane m_plane;
 };
 
 // } // namespace surface

--- a/internal/core/regularsurface.hpp
+++ b/internal/core/regularsurface.hpp
@@ -97,6 +97,9 @@ struct BoundedPlane : public Plane
     std::size_t ncols() const noexcept (true) { return this->m_ncols; };
     std::size_t size()  const noexcept (true) { return this->ncols() * this->nrows(); };
 
+    std::size_t row(std::size_t i) const noexcept (false);
+    std::size_t col(std::size_t i) const noexcept (false);
+
 private:
     std::size_t  m_nrows;
     std::size_t  m_ncols;

--- a/internal/core/subcube.cpp
+++ b/internal/core/subcube.cpp
@@ -1,4 +1,4 @@
-#include "subvolume.hpp"
+#include "subcube.hpp"
 
 #include <stdexcept>
 
@@ -71,7 +71,7 @@ int to_voxel(
 
 } /* namespace */
 
-SubVolume::SubVolume(MetadataHandle const& metadata) {
+SubCube::SubCube(MetadataHandle const& metadata) {
     auto const& iline  = metadata.iline();
     auto const& xline  = metadata.xline();
     auto const& sample = metadata.sample();
@@ -82,7 +82,7 @@ SubVolume::SubVolume(MetadataHandle const& metadata) {
 }
 
 
-void SubVolume::constrain(
+void SubCube::constrain(
     MetadataHandle const& metadata,
     std::vector< Bound > const& bounds
 ) noexcept (false) {
@@ -99,7 +99,7 @@ void SubVolume::constrain(
     }
 }
 
-void SubVolume::set_slice(
+void SubCube::set_slice(
     Axis const&                  axis,
     int const                    lineno,
     enum coordinate_system const coordinate_system

--- a/internal/core/subcube.hpp
+++ b/internal/core/subcube.hpp
@@ -1,5 +1,5 @@
-#ifndef VDS_SLICE_SUBVOLUME_HPP
-#define VDS_SLICE_SUBVOLUME_HPP
+#ifndef VDS_SLICE_SUBCUBE_HPP
+#define VDS_SLICE_SUBCUBE_HPP
 
 #include <OpenVDS/OpenVDS.h>
 
@@ -7,13 +7,13 @@
 #include "metadatahandle.hpp"
 #include "ctypes.h"
 
-struct SubVolume {
+struct SubCube {
     struct {
         int lower[OpenVDS::VolumeDataLayout::Dimensionality_Max]{0, 0, 0, 0, 0, 0};
         int upper[OpenVDS::VolumeDataLayout::Dimensionality_Max]{1, 1, 1, 1, 1, 1};
     } bounds;
 
-    SubVolume(MetadataHandle const& metadata);
+    SubCube(MetadataHandle const& metadata);
 
     void set_slice(
         Axis const&                  axis,
@@ -27,4 +27,4 @@ struct SubVolume {
     ) noexcept (false);
 };
 
-#endif /* VDS_SLICE_SUBVOLUME_HPP */
+#endif /* VDS_SLICE_SUBCUBE_HPP */

--- a/tests/gtest/cppapi_test.cpp
+++ b/tests/gtest/cppapi_test.cpp
@@ -244,7 +244,7 @@ void test_successful_align_call(
 ) {
     std::vector< float> data(primary.size());
     RegularSurface aligned = RegularSurface(
-        data.data(), primary.nrows(), primary.ncols(), primary.plane(), secondary.fillvalue());
+        data.data(), primary.plane(), secondary.fillvalue());
 
     test_successful_align_call(primary, secondary, aligned, expected_data, expected_primary_is_top);
 }
@@ -397,7 +397,7 @@ TEST_F(SurfaceAlignmentTest, HolesInData)
 
     std::vector< float> data(primary.size());
     RegularSurface aligned = RegularSurface(
-        data.data(), primary.nrows(), primary.ncols(), primary.plane(), fill3);
+        data.data(), primary.plane(), fill3);
 
     test_successful_align_call(primary, secondary, aligned, expected.data(), true);
 }


### PR DESCRIPTION
Two preparations for the next PR which will try to restructure the way we manage attributes (successfully or not is a different question)

1. Subvolume -> Subcube as I will likely name another structure Subvolume.
2. BoundedPlane was needed for nicer handling of plane information as this Subvolume kinda will represent data between RegularSurfaces based on the same horizontal stuff.

Changes should however make sense even if next PR is never merged.