### PR TITLE
Endpoint duplication

### DIFF
--- a/api/endpoint.go
+++ b/api/endpoint.go
@@ -91,7 +91,7 @@ func (e *Endpoint) slice(ctx *gin.Context, request SliceRequest) {
 		return
 	}
 
-	cacheKey, err := request.Hash()
+	cacheKey, err := request.hash()
 	if abortOnError(ctx, err) {
 		return
 	}
@@ -140,7 +140,7 @@ func (e *Endpoint) fence(ctx *gin.Context, request FenceRequest) {
 		return
 	}
 
-	cacheKey, err := request.Hash()
+	cacheKey, err := request.hash()
 	if abortOnError(ctx, err) {
 		return
 	}
@@ -236,7 +236,7 @@ func (e *Endpoint) attributesAlongSurface(ctx *gin.Context, request AttributeAlo
 		return
 	}
 
-	cacheKey, err := request.Hash()
+	cacheKey, err := request.hash()
 	if abortOnError(ctx, err) {
 		return
 	}
@@ -289,7 +289,7 @@ func (e *Endpoint) attributesBetweenSurfaces(ctx *gin.Context, request Attribute
 		return
 	}
 
-	cacheKey, err := request.Hash()
+	cacheKey, err := request.hash()
 	if abortOnError(ctx, err) {
 		return
 	}

--- a/api/endpoint.go
+++ b/api/endpoint.go
@@ -122,110 +122,64 @@ func (e *Endpoint) makeDataRequest(
 	writeResponse(ctx, metadata, data)
 }
 
-func (e *Endpoint) slice(ctx *gin.Context, request SliceRequest) {
-	prepareRequestLogging(ctx, request)
-	conn, err := e.MakeVdsConnection(request.Vds, request.Sas)
-	if abortOnError(ctx, err) {
-		return
-	}
-
-	cacheKey, err := request.hash()
-	if abortOnError(ctx, err) {
-		return
-	}
-
-	cacheEntry, hit := e.Cache.Get(cacheKey)
-	if hit && conn.IsAuthorizedToRead() {
-		ctx.Set("cache-hit", true)
-		writeResponse(ctx, cacheEntry.Metadata(), cacheEntry.Data())
-		return
-	}
-
-	handle, err := core.NewVDSHandle(conn)
-	if abortOnError(ctx, err) {
-		return
-	}
-	defer handle.Close()
-
+func (request SliceRequest) execute(
+	handle core.VDSHandle,
+) (data [][]byte, metadata []byte, err error) {
 	axis, err := core.GetAxis(strings.ToLower(request.Direction))
-	if abortOnError(ctx, err) {
+	if err != nil {
 		return
 	}
 
-	metadata, err := handle.GetSliceMetadata(
+	metadata, err = handle.GetSliceMetadata(
 		*request.Lineno,
 		axis,
 		request.Bounds,
 	)
-	if abortOnError(ctx, err) {
+	if err != nil {
 		return
 	}
 
-	data, err := handle.GetSlice(*request.Lineno, axis, request.Bounds)
-	if abortOnError(ctx, err) {
+	res, err := handle.GetSlice(*request.Lineno, axis, request.Bounds)
+	if err != nil {
 		return
 	}
+	data = [][]byte{res}
 
-	e.Cache.Set(cacheKey, cache.NewCacheEntry([][]byte{data}, metadata))
-
-	writeResponse(ctx, metadata, [][]byte{data})
+	return data, metadata, nil
 }
 
-func (e *Endpoint) fence(ctx *gin.Context, request FenceRequest) {
-	prepareRequestLogging(ctx, request)
-	conn, err := e.MakeVdsConnection(request.Vds, request.Sas)
-	if abortOnError(ctx, err) {
-		return
-	}
-
-	cacheKey, err := request.hash()
-	if abortOnError(ctx, err) {
-		return
-	}
-
-	cacheEntry, hit := e.Cache.Get(cacheKey)
-	if hit && conn.IsAuthorizedToRead() {
-		ctx.Set("cache-hit", true)
-		writeResponse(ctx, cacheEntry.Metadata(), cacheEntry.Data())
-		return
-	}
-
-	handle, err := core.NewVDSHandle(conn)
-	if abortOnError(ctx, err) {
-		return
-	}
-	defer handle.Close()
-
+func (request FenceRequest) execute(
+	handle core.VDSHandle,
+) (data [][]byte, metadata []byte, err error) {
 	coordinateSystem, err := core.GetCoordinateSystem(
 		strings.ToLower(request.CoordinateSystem),
 	)
-	if abortOnError(ctx, err) {
+	if err != nil {
 		return
 	}
 
 	interpolation, err := core.GetInterpolationMethod(request.Interpolation)
-	if abortOnError(ctx, err) {
+	if err != nil {
 		return
 	}
 
-	metadata, err := handle.GetFenceMetadata(request.Coordinates)
-	if abortOnError(ctx, err) {
+	metadata, err = handle.GetFenceMetadata(request.Coordinates)
+	if err != nil {
 		return
 	}
 
-	data, err := handle.GetFence(
+	res, err := handle.GetFence(
 		coordinateSystem,
 		request.Coordinates,
 		interpolation,
 		request.FillValue,
 	)
-	if abortOnError(ctx, err) {
+	if err != nil {
 		return
 	}
+	data = [][]byte{res}
 
-	e.Cache.Set(cacheKey, cache.NewCacheEntry([][]byte{data}, metadata))
-
-	writeResponse(ctx, metadata, [][]byte{data})
+	return data, metadata, nil
 }
 
 func validateVerticalWindow(above float32, below float32, stepSize float32) error {
@@ -261,48 +215,25 @@ func validateVerticalWindow(above float32, below float32, stepSize float32) erro
 	return nil
 }
 
-func (e *Endpoint) attributesAlongSurface(ctx *gin.Context, request AttributeAlongSurfaceRequest) {
-	prepareRequestLogging(ctx, request)
-
-	err := validateVerticalWindow(request.Above, request.Below, request.Stepsize)
-	if abortOnError(ctx, err) {
-		return
-	}
-
-	conn, err := e.MakeVdsConnection(request.Vds, request.Sas)
-	if abortOnError(ctx, err) {
-		return
-	}
-
-	cacheKey, err := request.hash()
-	if abortOnError(ctx, err) {
-		return
-	}
-
-	handle, err := core.NewVDSHandle(conn)
-	if abortOnError(ctx, err) {
-		return
-	}
-	defer handle.Close()
-
-	cacheEntry, hit := e.Cache.Get(cacheKey)
-	if hit && conn.IsAuthorizedToRead() {
-		ctx.Set("cache-hit", true)
-		writeResponse(ctx, cacheEntry.Metadata(), cacheEntry.Data())
+func (request AttributeAlongSurfaceRequest) execute(
+	handle core.VDSHandle,
+) (data [][]byte, metadata []byte, err error) {
+	err = validateVerticalWindow(request.Above, request.Below, request.Stepsize)
+	if err != nil {
 		return
 	}
 
 	interpolation, err := core.GetInterpolationMethod(request.Interpolation)
-	if abortOnError(ctx, err) {
+	if err != nil {
 		return
 	}
 
-	metadata, err := handle.GetAttributeMetadata(request.Surface.Values)
-	if abortOnError(ctx, err) {
+	metadata, err = handle.GetAttributeMetadata(request.Surface.Values)
+	if err != nil {
 		return
 	}
 
-	data, err := handle.GetAttributesAlongSurface(
+	data, err = handle.GetAttributesAlongSurface(
 		request.Surface,
 		request.Above,
 		request.Below,
@@ -310,65 +241,38 @@ func (e *Endpoint) attributesAlongSurface(ctx *gin.Context, request AttributeAlo
 		request.Attributes,
 		interpolation,
 	)
-	if abortOnError(ctx, err) {
+	if err != nil {
 		return
 	}
 
-	e.Cache.Set(cacheKey, cache.NewCacheEntry(data, metadata))
-
-	writeResponse(ctx, metadata, data)
+	return data, metadata, nil
 }
 
-func (e *Endpoint) attributesBetweenSurfaces(ctx *gin.Context, request AttributeBetweenSurfacesRequest) {
-	prepareRequestLogging(ctx, request)
-
-	conn, err := e.MakeVdsConnection(request.Vds, request.Sas)
-	if abortOnError(ctx, err) {
-		return
-	}
-
-	cacheKey, err := request.hash()
-	if abortOnError(ctx, err) {
-		return
-	}
-
-	handle, err := core.NewVDSHandle(conn)
-	if abortOnError(ctx, err) {
-		return
-	}
-	defer handle.Close()
-
-	cacheEntry, hit := e.Cache.Get(cacheKey)
-	if hit && conn.IsAuthorizedToRead() {
-		ctx.Set("cache-hit", true)
-		writeResponse(ctx, cacheEntry.Metadata(), cacheEntry.Data())
-		return
-	}
-
+func (request AttributeBetweenSurfacesRequest) execute(
+	handle core.VDSHandle,
+) (data [][]byte, metadata []byte, err error) {
 	interpolation, err := core.GetInterpolationMethod(request.Interpolation)
-	if abortOnError(ctx, err) {
+	if err != nil {
 		return
 	}
 
-	metadata, err := handle.GetAttributeMetadata(request.PrimarySurface.Values)
-	if abortOnError(ctx, err) {
+	metadata, err = handle.GetAttributeMetadata(request.PrimarySurface.Values)
+	if err != nil {
 		return
 	}
 
-	data, err := handle.GetAttributesBetweenSurfaces(
+	data, err = handle.GetAttributesBetweenSurfaces(
 		request.PrimarySurface,
 		request.SecondarySurface,
 		request.Stepsize,
 		request.Attributes,
 		interpolation,
 	)
-	if abortOnError(ctx, err) {
+	if err != nil {
 		return
 	}
 
-	e.Cache.Set(cacheKey, cache.NewCacheEntry(data, metadata))
-
-	writeResponse(ctx, metadata, data)
+	return data, metadata, nil
 }
 
 func parseGetRequest(ctx *gin.Context, v Normalizable) error {
@@ -452,7 +356,7 @@ func (e *Endpoint) SliceGet(ctx *gin.Context) {
 		return
 	}
 
-	e.slice(ctx, request)
+	e.makeDataRequest(ctx, request)
 }
 
 // SlicePost godoc
@@ -473,7 +377,7 @@ func (e *Endpoint) SlicePost(ctx *gin.Context) {
 		return
 	}
 
-	e.slice(ctx, request)
+	e.makeDataRequest(ctx, request)
 }
 
 // FenceGet godoc
@@ -494,7 +398,7 @@ func (e *Endpoint) FenceGet(ctx *gin.Context) {
 		return
 	}
 
-	e.fence(ctx, request)
+	e.makeDataRequest(ctx, request)
 }
 
 // FencePost godoc
@@ -515,7 +419,7 @@ func (e *Endpoint) FencePost(ctx *gin.Context) {
 		return
 	}
 
-	e.fence(ctx, request)
+	e.makeDataRequest(ctx, request)
 }
 
 // AttributesAlongSurfacePost godoc
@@ -536,7 +440,7 @@ func (e *Endpoint) AttributesAlongSurfacePost(ctx *gin.Context) {
 		return
 	}
 
-	e.attributesAlongSurface(ctx, request)
+	e.makeDataRequest(ctx, request)
 }
 
 // AttributesBetweenSurfacesPost godoc
@@ -557,5 +461,5 @@ func (e *Endpoint) AttributesBetweenSurfacesPost(ctx *gin.Context) {
 		return
 	}
 
-	e.attributesBetweenSurfaces(ctx, request)
+	e.makeDataRequest(ctx, request)
 }

--- a/api/request.go
+++ b/api/request.go
@@ -132,7 +132,7 @@ func (f FenceRequest) toString() (string, error) {
  * The hash is computed based on all fields that contribute toward a unique response.
  * I.e. every field except the sas token.
  */
-func (f FenceRequest) Hash() (string, error) {
+func (f FenceRequest) hash() (string, error) {
 	// Strip the sas token before computing hash
 	f.Sas = ""
 	return cache.Hash(f)
@@ -189,7 +189,7 @@ type SliceRequest struct {
  * The hash is computed based on all fields that contribute toward a unique response.
  * I.e. every field except the sas token.
  */
-func (s SliceRequest) Hash() (string, error) {
+func (s SliceRequest) hash() (string, error) {
 	// Strip the sas token before computing hash
 	s.Sas = ""
 	return cache.Hash(s)
@@ -273,7 +273,7 @@ type AttributeAlongSurfaceRequest struct {
  * The hash is computed based on all fields that contribute toward a unique response.
  * I.e. every field except the sas token.
  */
-func (h AttributeAlongSurfaceRequest) Hash() (string, error) {
+func (h AttributeAlongSurfaceRequest) hash() (string, error) {
 	// Strip the sas token before computing hash
 	h.Sas = ""
 	return cache.Hash(h)
@@ -335,7 +335,7 @@ type AttributeBetweenSurfacesRequest struct {
  * The hash is computed based on all fields that contribute toward a unique response.
  * I.e. every field except the sas token.
  */
-func (h AttributeBetweenSurfacesRequest) Hash() (string, error) {
+func (h AttributeBetweenSurfacesRequest) hash() (string, error) {
 	// Strip the sas token before computing hash
 	h.Sas = ""
 	return cache.Hash(h)

--- a/api/request.go
+++ b/api/request.go
@@ -34,6 +34,17 @@ type RequestedResource struct {
 	Sas string `json:"sas,omitempty" example:"sp=r&st=2022-09-12T09:44:17Z&se=2022-09-12T17:44:17Z&spr=https&sv=2021-06-08&sr=c&sig=..."`
 }
 
+func (r RequestedResource) credentials() (string, string) {
+	return r.Vds, r.Sas
+}
+
+type DataRequest interface {
+	toString() (string, error)
+	hash() (string, error)
+	credentials() (string, string)
+	execute(handle core.VDSHandle) (data [][]byte, metadata []byte, err error)
+}
+
 type Stringable interface {
 	toString() (string, error)
 }

--- a/api/request_test.go
+++ b/api/request_test.go
@@ -54,12 +54,12 @@ func TestSasIsOmmitedFromSliceHash(t *testing.T) {
 	request1 := newSliceRequest("some-path", "some-sas", "inline", 9961)
 	request2 := newSliceRequest("some-path", "different-sas", "inline", 9961)
 
-	hash1, err := request1.Hash()
+	hash1, err := request1.hash()
 	require.NoErrorf(t, err,
 		"Failed to compute hash, err: %v", err,
 	)
 
-	hash2, err := request2.Hash()
+	hash2, err := request2.hash()
 	require.NoErrorf(t, err,
 		"Failed to compute hash, err: %v", err,
 	)
@@ -83,12 +83,12 @@ func TestSasIsOmmitedFromFenceHash(t *testing.T) {
 		"linear",
 	)
 
-	hash1, err := request1.Hash()
+	hash1, err := request1.hash()
 	require.NoErrorf(t, err,
 		"Failed to compute hash, err: %v", err,
 	)
 
-	hash2, err := request2.Hash()
+	hash2, err := request2.hash()
 	require.NoErrorf(t, err,
 		"Failed to compute hash, err: %v", err,
 	)
@@ -120,12 +120,12 @@ func TestSliceGivesUniqueHash(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		hash1, err := testCase.request1.Hash()
+		hash1, err := testCase.request1.hash()
 		require.NoErrorf(t, err,
 			"[%s] Failed to compute hash, err: %v", testCase.name, err,
 		)
 
-		hash2, err := testCase.request2.Hash()
+		hash2, err := testCase.request2.hash()
 		require.NoErrorf(t, err,
 			"[%s] Failed to compute hash, err: %v", testCase.name, err,
 		)
@@ -169,12 +169,12 @@ func TestFenceGivesUniqueHash(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		hash1, err := testCase.request1.Hash()
+		hash1, err := testCase.request1.hash()
 		require.NoErrorf(t, err,
 			"[%s] Failed to compute hash, err: %v", testCase.name, err,
 		)
 
-		hash2, err := testCase.request2.Hash()
+		hash2, err := testCase.request2.hash()
 		require.NoErrorf(t, err,
 			"[%s] Failed to compute hash, err: %v", testCase.name, err,
 		)

--- a/api/request_test.go
+++ b/api/request_test.go
@@ -7,10 +7,10 @@ import (
 )
 
 func newSliceRequest(
-	vds       string,
-	sas       string,
+	vds string,
+	sas string,
 	direction string,
-	lineno    int,
+	lineno int,
 ) SliceRequest {
 	return SliceRequest{
 		RequestedResource: RequestedResource{
@@ -23,11 +23,11 @@ func newSliceRequest(
 }
 
 func newFenceRequest(
-	vds              string,
-	sas              string,
+	vds string,
+	sas string,
 	coordinateSystem string,
-	coordinates      [][]float32,
-	interpolation    string,
+	coordinates [][]float32,
+	interpolation string,
 ) FenceRequest {
 	return FenceRequest{
 		RequestedResource: RequestedResource{
@@ -72,14 +72,14 @@ func TestSasIsOmmitedFromFenceHash(t *testing.T) {
 		"some-path",
 		"some-sas",
 		"ij",
-		[][]float32{{1,2}, {2,3}},
+		[][]float32{{1, 2}, {2, 3}},
 		"linear",
 	)
 	request2 := newFenceRequest(
 		"some-path",
 		"different-sas",
 		"ij",
-		[][]float32{{1,2}, {2,3}},
+		[][]float32{{1, 2}, {2, 3}},
 		"linear",
 	)
 
@@ -87,7 +87,7 @@ func TestSasIsOmmitedFromFenceHash(t *testing.T) {
 	require.NoErrorf(t, err,
 		"Failed to compute hash, err: %v", err,
 	)
-	
+
 	hash2, err := request2.Hash()
 	require.NoErrorf(t, err,
 		"Failed to compute hash, err: %v", err,
@@ -97,23 +97,23 @@ func TestSasIsOmmitedFromFenceHash(t *testing.T) {
 }
 
 func TestSliceGivesUniqueHash(t *testing.T) {
-	testCases := []struct{
+	testCases := []struct {
 		name     string
 		request1 SliceRequest
 		request2 SliceRequest
 	}{
 		{
-			name: "Vds differ",
+			name:     "Vds differ",
 			request1: newSliceRequest("vds1", "sas", "inline", 10),
 			request2: newSliceRequest("vds2", "sas", "inline", 10),
 		},
 		{
-			name: "direction differ",
+			name:     "direction differ",
 			request1: newSliceRequest("vds", "sas", "inline", 10),
-			request2: newSliceRequest("vds", "sas", "i",      10),
+			request2: newSliceRequest("vds", "sas", "i", 10),
 		},
 		{
-			name: "lineno differ",
+			name:     "lineno differ",
 			request1: newSliceRequest("vds", "sas", "inline", 10),
 			request2: newSliceRequest("vds", "sas", "inline", 11),
 		},
@@ -124,7 +124,7 @@ func TestSliceGivesUniqueHash(t *testing.T) {
 		require.NoErrorf(t, err,
 			"[%s] Failed to compute hash, err: %v", testCase.name, err,
 		)
-		
+
 		hash2, err := testCase.request2.Hash()
 		require.NoErrorf(t, err,
 			"[%s] Failed to compute hash, err: %v", testCase.name, err,
@@ -138,31 +138,31 @@ func TestSliceGivesUniqueHash(t *testing.T) {
 }
 
 func TestFenceGivesUniqueHash(t *testing.T) {
-	fence1 := [][]float32{{ 1, 2 }, {3, 4}}
-	fence2 := [][]float32{{ 2, 2 }, {3, 4}}
+	fence1 := [][]float32{{1, 2}, {3, 4}}
+	fence2 := [][]float32{{2, 2}, {3, 4}}
 
-	testCases := []struct{
+	testCases := []struct {
 		name     string
 		request1 FenceRequest
 		request2 FenceRequest
 	}{
 		{
-			name: "Vds differ",
+			name:     "Vds differ",
 			request1: newFenceRequest("vds1", "sas", "ij", fence1, "linear"),
 			request2: newFenceRequest("vds2", "sas", "ij", fence1, "linear"),
 		},
 		{
-			name: "Coordinate system differ",
-			request1: newFenceRequest("vds", "sas", "ij",  fence1, "linear"),
+			name:     "Coordinate system differ",
+			request1: newFenceRequest("vds", "sas", "ij", fence1, "linear"),
 			request2: newFenceRequest("vds", "sas", "cdp", fence1, "linear"),
 		},
 		{
-			name: "Coordinates differ",
+			name:     "Coordinates differ",
 			request1: newFenceRequest("vds", "sas", "ij", fence1, "linear"),
 			request2: newFenceRequest("vds", "sas", "ij", fence2, "linear"),
 		},
 		{
-			name: "Interpolation differ",
+			name:     "Interpolation differ",
 			request1: newFenceRequest("vds", "sas", "ij", fence1, "linear"),
 			request2: newFenceRequest("vds", "sas", "ij", fence1, "cubic"),
 		},
@@ -173,7 +173,7 @@ func TestFenceGivesUniqueHash(t *testing.T) {
 		require.NoErrorf(t, err,
 			"[%s] Failed to compute hash, err: %v", testCase.name, err,
 		)
-		
+
 		hash2, err := testCase.request2.Hash()
 		require.NoErrorf(t, err,
 			"[%s] Failed to compute hash, err: %v", testCase.name, err,
@@ -241,8 +241,8 @@ func TestExtractSasFromUrl(t *testing.T) {
 func TestPortPresenceInURL(t *testing.T) {
 
 	testCases := []struct {
-		request     RequestedResource
-		expected    string
+		request  RequestedResource
+		expected string
 	}{
 		{
 			request: newRequestedResource(


### PR DESCRIPTION
I've been irritated for a while that our endpoints are copied whenever we need a new one.
This attempts to extract away currently duplicated logic.