### PR TITLE
Add position of minimum value attribute

### DIFF
--- a/docs/attribute_along.md
+++ b/docs/attribute_along.md
@@ -24,6 +24,7 @@ samplevalue | Seismic sample value at the exact surface position
 min         | Minimum value
 min_at      | Minimum value position
 max         | Maximum value
+max_at      | Maximum value position
 maxabs      | Absolute maximum value
 mean        | Mean value
 meanabs     | Mean of absolute values

--- a/docs/attribute_along.md
+++ b/docs/attribute_along.md
@@ -26,6 +26,7 @@ min_at      | Minimum value position
 max         | Maximum value
 max_at      | Maximum value position
 maxabs      | Absolute maximum value
+maxabs_at   | Absolute maximum value position
 mean        | Mean value
 meanabs     | Mean of absolute values
 meanpos     | Mean of positive values

--- a/docs/attribute_along.md
+++ b/docs/attribute_along.md
@@ -22,6 +22,7 @@ Name        | Description
 ------------|------------
 samplevalue | Seismic sample value at the exact surface position
 min         | Minimum value
+min_at      | Minimum value position
 max         | Maximum value
 maxabs      | Absolute maximum value
 mean        | Mean value

--- a/docs/attribute_between.md
+++ b/docs/attribute_between.md
@@ -26,6 +26,7 @@ samplevalue | Seismic sample value at the primary surface position
 min         | Minimum value
 min_at      | Minimum value position
 max         | Maximum value
+max_at      | Maximum value position
 maxabs      | Absolute maximum value
 mean        | Mean value
 meanabs     | Mean of absolute values

--- a/docs/attribute_between.md
+++ b/docs/attribute_between.md
@@ -24,6 +24,7 @@ Name        | Description
 ------------|------------
 samplevalue | Seismic sample value at the primary surface position
 min         | Minimum value
+min_at      | Minimum value position
 max         | Maximum value
 maxabs      | Absolute maximum value
 mean        | Mean value

--- a/docs/attribute_between.md
+++ b/docs/attribute_between.md
@@ -28,6 +28,7 @@ min_at      | Minimum value position
 max         | Maximum value
 max_at      | Maximum value position
 maxabs      | Absolute maximum value
+maxabs_at   | Absolute maximum value position
 mean        | Mean value
 meanabs     | Mean of absolute values
 meanpos     | Mean of positive values

--- a/internal/core/attribute.cpp
+++ b/internal/core/attribute.cpp
@@ -39,6 +39,16 @@ float Max::compute(
     return *std::max_element(segment.begin(), segment.end());
 }
 
+float MaxAt::compute(
+    ResampledSegment const & segment
+) noexcept (false) {
+    auto max_index = std::distance(
+        segment.begin(),
+        std::max_element(segment.begin(), segment.end())
+    );
+    return segment.sample_position_at(max_index);
+}
+
 float MaxAbs::compute(
     ResampledSegment const & segment
 ) noexcept (false) {

--- a/internal/core/attribute.cpp
+++ b/internal/core/attribute.cpp
@@ -24,6 +24,15 @@ float Min::compute(
     return *std::min_element(segment.begin(), segment.end());
 }
 
+float MinAt::compute(
+    ResampledSegment const & segment) noexcept(false) {
+    auto min_index = std::distance(
+            segment.begin(),
+            std::min_element(segment.begin(), segment.end())
+        );
+    return segment.sample_position_at(min_index);
+}
+
 float Max::compute(
     ResampledSegment const & segment
 ) noexcept (false) {

--- a/internal/core/attribute.cpp
+++ b/internal/core/attribute.cpp
@@ -49,15 +49,42 @@ float MaxAt::compute(
     return segment.sample_position_at(max_index);
 }
 
-float MaxAbs::compute(
+namespace {
+
+double max_abs(
     ResampledSegment const & segment
-) noexcept (false) {
+){
     auto max = *std::max_element(segment.begin(), segment.end(),
     [](const double& a, const double& b) { 
             return std::abs(a) < std::abs(b); 
         }
     );
     return std::abs(max);
+}
+
+} // namespace
+
+float MaxAbs::compute(
+    ResampledSegment const & segment
+) noexcept (false) {
+    return max_abs(segment);
+}
+
+float MaxAbsAt::compute(
+    ResampledSegment const & segment
+) noexcept (false) {
+
+    auto max_abs_val = max_abs(segment);
+    auto max_abs_index = std::distance(
+        segment.begin(),
+        std::find_if(segment.begin(), segment.end(),
+        [&](const double& val) {
+                return std::abs(val) == max_abs_val;
+            }
+        )
+    );
+
+    return segment.sample_position_at(max_abs_index);
 }
 
 float Mean::compute(

--- a/internal/core/attribute.hpp
+++ b/internal/core/attribute.hpp
@@ -48,6 +48,13 @@ public:
     float compute(ResampledSegment const & segment) noexcept (false) override;
 };
 
+class MinAt final : public AttributeMap {
+public:
+    MinAt(void* dst, std::size_t size) : AttributeMap(dst, size) {}
+
+    float compute(ResampledSegment const & segment) noexcept (false) override;
+};
+
 class Max final : public AttributeMap {
 public:
     Max(void* dst, std::size_t size) : AttributeMap(dst, size) {}

--- a/internal/core/attribute.hpp
+++ b/internal/core/attribute.hpp
@@ -62,6 +62,13 @@ public:
     float compute(ResampledSegment const & segment) noexcept (false) override;
 };
 
+class MaxAt final : public AttributeMap {
+public:
+    MaxAt(void* dst, std::size_t size) : AttributeMap(dst, size) {}
+
+    float compute(ResampledSegment const & segment) noexcept (false) override;
+};
+
 class MaxAbs final : public AttributeMap {
 public:
     MaxAbs(void* dst, std::size_t size) : AttributeMap(dst, size) {}

--- a/internal/core/attribute.hpp
+++ b/internal/core/attribute.hpp
@@ -76,6 +76,13 @@ public:
     float compute(ResampledSegment const & segment) noexcept (false) override;
 };
 
+class MaxAbsAt final : public AttributeMap {
+public:
+    MaxAbsAt(void* dst, std::size_t size) : AttributeMap(dst, size) {}
+
+    float compute(ResampledSegment const & segment) noexcept (false) override;
+};
+
 class Mean final : public AttributeMap {
 public:
     Mean(void* dst, std::size_t size) : AttributeMap(dst, size) {}

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -233,6 +233,8 @@ func GetAttributeType(attribute string) (int, error) {
 		return C.VALUE, nil
 	case "min":
 		return C.MIN, nil
+	case "min_at":
+		return C.MINAT, nil
 	case "max":
 		return C.MAX, nil
 	case "maxabs":
@@ -261,7 +263,7 @@ func GetAttributeType(attribute string) (int, error) {
 		fallthrough
 	default:
 		options := []string{
-			"samplevalue", "min", "max", "maxabs", "mean", "meanabs", "meanpos",
+			"samplevalue", "min", "min_at", "max", "maxabs", "mean", "meanabs", "meanpos",
 			"meanneg", "median", "rms", "var", "sd", "sumpos", "sumneg",
 		}
 		msg := "invalid attribute '%s', valid options are: %s"

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -237,6 +237,8 @@ func GetAttributeType(attribute string) (int, error) {
 		return C.MINAT, nil
 	case "max":
 		return C.MAX, nil
+	case "max_at":
+		return C.MAXAT, nil
 	case "maxabs":
 		return C.MAXABS, nil
 	case "mean":
@@ -263,7 +265,7 @@ func GetAttributeType(attribute string) (int, error) {
 		fallthrough
 	default:
 		options := []string{
-			"samplevalue", "min", "min_at", "max", "maxabs", "mean", "meanabs", "meanpos",
+			"samplevalue", "min", "min_at", "max", "max_at", "maxabs", "mean", "meanabs", "meanpos",
 			"meanneg", "median", "rms", "var", "sd", "sumpos", "sumneg",
 		}
 		msg := "invalid attribute '%s', valid options are: %s"

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -241,6 +241,8 @@ func GetAttributeType(attribute string) (int, error) {
 		return C.MAXAT, nil
 	case "maxabs":
 		return C.MAXABS, nil
+	case "maxabs_at":
+		return C.MAXABSAT, nil
 	case "mean":
 		return C.MEAN, nil
 	case "meanabs":
@@ -265,8 +267,9 @@ func GetAttributeType(attribute string) (int, error) {
 		fallthrough
 	default:
 		options := []string{
-			"samplevalue", "min", "min_at", "max", "max_at", "maxabs", "mean", "meanabs", "meanpos",
-			"meanneg", "median", "rms", "var", "sd", "sumpos", "sumneg",
+			"samplevalue", "min", "min_at", "max", "max_at", "maxabs", "maxabs_at",
+			"mean", "meanabs", "meanpos", "meanneg", "median", "rms", "var", "sd",
+			"sumpos", "sumneg",
 		}
 		msg := "invalid attribute '%s', valid options are: %s"
 		return -1, NewInvalidArgument(fmt.Sprintf(

--- a/internal/core/core_attributes_test.go
+++ b/internal/core/core_attributes_test.go
@@ -306,6 +306,7 @@ func TestAttribute(t *testing.T) {
 		"max",
 		"max_at",
 		"maxabs",
+		"maxabs_at",
 		"mean",
 		"meanabs",
 		"meanpos",
@@ -324,6 +325,7 @@ func TestAttribute(t *testing.T) {
 		{1.5, 2.5, -4.5, 10.5, fillValue, -8.5, fillValue, fillValue},                         // max
 		{28, 12, 28, 28, fillValue, 12, fillValue, fillValue},                                 // max_at
 		{2.5, 2.5, 12.5, 10.5, fillValue, 24.5, fillValue, fillValue},                         // maxabs
+		{12, 12, 12, 28, fillValue, 28, fillValue, fillValue},                                 // maxabs_at
 		{-0.5, 0.5, -8.5, 6.5, fillValue, -16.5, fillValue, fillValue},                        // mean
 		{1.3, 1.3, 8.5, 6.5, fillValue, 16.5, fillValue, fillValue},                           // meanabs
 		{1, 1.5, 0, 6.5, fillValue, 0, fillValue, fillValue},                                  // meanpos
@@ -1006,6 +1008,7 @@ func TestAttributeBetweenSurfaces(t *testing.T) {
 		"max":         {2.5, 0.5, -8.5, 5.5, fillValue, -8.5, fillValue, fillValue},
 		"max_at":      {32, 20, 20, 18, fillValue, 12, fillValue, fillValue},
 		"maxabs":      {2.5, 0.5, 8.5, 5.5, fillValue, 24.5, fillValue, fillValue},
+		"maxabs_at":   {32, 20, 20, 18, fillValue, 28, fillValue, fillValue},
 		"mean":        {0.5, 0, -8.5, 5.5, fillValue, -16.5, fillValue, fillValue},
 		"meanabs":     {1.3, 0.5, 8.5, 5.5, fillValue, 16.5, fillValue, fillValue},
 		"meanpos":     {1.5, 0.5, 0, 5.5, fillValue, 0, fillValue, fillValue},

--- a/internal/core/core_attributes_test.go
+++ b/internal/core/core_attributes_test.go
@@ -304,6 +304,7 @@ func TestAttribute(t *testing.T) {
 		"min",
 		"min_at",
 		"max",
+		"max_at",
 		"maxabs",
 		"mean",
 		"meanabs",
@@ -321,6 +322,7 @@ func TestAttribute(t *testing.T) {
 		{-2.5, -1.5, -12.5, 2.5, fillValue, -24.5, fillValue, fillValue},                      // min
 		{12, 28, 12, 12, fillValue, 28, fillValue, fillValue},                                 // min_at
 		{1.5, 2.5, -4.5, 10.5, fillValue, -8.5, fillValue, fillValue},                         // max
+		{28, 12, 28, 28, fillValue, 12, fillValue, fillValue},                                 // max_at
 		{2.5, 2.5, 12.5, 10.5, fillValue, 24.5, fillValue, fillValue},                         // maxabs
 		{-0.5, 0.5, -8.5, 6.5, fillValue, -16.5, fillValue, fillValue},                        // mean
 		{1.3, 1.3, 8.5, 6.5, fillValue, 16.5, fillValue, fillValue},                           // meanabs
@@ -1002,6 +1004,7 @@ func TestAttributeBetweenSurfaces(t *testing.T) {
 		"min":         {-1.5, -0.5, -8.5, 5.5, fillValue, -24.5, fillValue, fillValue},
 		"min_at":      {16, 24, 20, 18, fillValue, 28, fillValue, fillValue},
 		"max":         {2.5, 0.5, -8.5, 5.5, fillValue, -8.5, fillValue, fillValue},
+		"max_at":      {32, 20, 20, 18, fillValue, 12, fillValue, fillValue},
 		"maxabs":      {2.5, 0.5, 8.5, 5.5, fillValue, 24.5, fillValue, fillValue},
 		"mean":        {0.5, 0, -8.5, 5.5, fillValue, -16.5, fillValue, fillValue},
 		"meanabs":     {1.3, 0.5, 8.5, 5.5, fillValue, 16.5, fillValue, fillValue},

--- a/internal/core/core_attributes_test.go
+++ b/internal/core/core_attributes_test.go
@@ -302,6 +302,7 @@ func TestAttribute(t *testing.T) {
 	targetAttributes := []string{
 		"samplevalue",
 		"min",
+		"min_at",
 		"max",
 		"maxabs",
 		"mean",
@@ -318,6 +319,7 @@ func TestAttribute(t *testing.T) {
 	expected := [][]float32{
 		{-0.5, 0.5, -8.5, 6.5, fillValue, -16.5, fillValue, fillValue},                        // samplevalue
 		{-2.5, -1.5, -12.5, 2.5, fillValue, -24.5, fillValue, fillValue},                      // min
+		{12, 28, 12, 12, fillValue, 28, fillValue, fillValue},                                 // min_at
 		{1.5, 2.5, -4.5, 10.5, fillValue, -8.5, fillValue, fillValue},                         // max
 		{2.5, 2.5, 12.5, 10.5, fillValue, 24.5, fillValue, fillValue},                         // maxabs
 		{-0.5, 0.5, -8.5, 6.5, fillValue, -16.5, fillValue, fillValue},                        // mean
@@ -998,6 +1000,7 @@ func TestAttributeBetweenSurfaces(t *testing.T) {
 	expected := map[string][]float32{
 		"samplevalue": {},
 		"min":         {-1.5, -0.5, -8.5, 5.5, fillValue, -24.5, fillValue, fillValue},
+		"min_at":      {16, 24, 20, 18, fillValue, 28, fillValue, fillValue},
 		"max":         {2.5, 0.5, -8.5, 5.5, fillValue, -8.5, fillValue, fillValue},
 		"maxabs":      {2.5, 0.5, 8.5, 5.5, fillValue, 24.5, fillValue, fillValue},
 		"mean":        {0.5, 0, -8.5, 5.5, fillValue, -16.5, fillValue, fillValue},

--- a/internal/core/cppapi_data.cpp
+++ b/internal/core/cppapi_data.cpp
@@ -341,6 +341,7 @@ void attributes(
             case MIN:     { append(attrs,   Min(dst, size)       );   break; }
             case MINAT:   { append(attrs,   MinAt(dst, size)     );   break; }
             case MAX:     { append(attrs,   Max(dst, size)       );   break; }
+            case MAXAT:   { append(attrs,   MaxAt(dst, size)     );   break; }
             case MAXABS:  { append(attrs,   MaxAbs(dst, size)    );   break; }
             case MEAN:    { append(attrs,   Mean(dst, size)      );   break; }
             case MEANABS: { append(attrs,   MeanAbs(dst, size)   );   break; }

--- a/internal/core/cppapi_data.cpp
+++ b/internal/core/cppapi_data.cpp
@@ -337,22 +337,23 @@ void attributes(
     for (int i = 0; i < nattributes; ++i) {
         void* dst = out[i];
         switch (*attributes) {
-            case VALUE:   { append(attrs,   Value(dst, size)     );   break; }
-            case MIN:     { append(attrs,   Min(dst, size)       );   break; }
-            case MINAT:   { append(attrs,   MinAt(dst, size)     );   break; }
-            case MAX:     { append(attrs,   Max(dst, size)       );   break; }
-            case MAXAT:   { append(attrs,   MaxAt(dst, size)     );   break; }
-            case MAXABS:  { append(attrs,   MaxAbs(dst, size)    );   break; }
-            case MEAN:    { append(attrs,   Mean(dst, size)      );   break; }
-            case MEANABS: { append(attrs,   MeanAbs(dst, size)   );   break; }
-            case MEANPOS: { append(attrs,   MeanPos(dst, size)   );   break; }
-            case MEANNEG: { append(attrs,   MeanNeg(dst, size)   );   break; }
-            case MEDIAN:  { append(attrs,   Median(dst, size)    );   break; }
-            case RMS:     { append(attrs,   Rms(dst, size)       );   break; }
-            case VAR:     { append(attrs,   Var(dst, size)       );   break; }
-            case SD:      { append(attrs,   Sd(dst, size)        );   break; }
-            case SUMPOS:  { append(attrs,   SumPos(dst, size)    );   break; }
-            case SUMNEG:  { append(attrs,   SumNeg(dst, size)    );   break; }
+            case VALUE:    { append(attrs,   Value(dst, size)     );   break; }
+            case MIN:      { append(attrs,   Min(dst, size)       );   break; }
+            case MINAT:    { append(attrs,   MinAt(dst, size)     );   break; }
+            case MAX:      { append(attrs,   Max(dst, size)       );   break; }
+            case MAXAT:    { append(attrs,   MaxAt(dst, size)     );   break; }
+            case MAXABS:   { append(attrs,   MaxAbs(dst, size)    );   break; }
+            case MAXABSAT: { append(attrs,   MaxAbsAt(dst, size)  );   break; }
+            case MEAN:     { append(attrs,   Mean(dst, size)      );   break; }
+            case MEANABS:  { append(attrs,   MeanAbs(dst, size)   );   break; }
+            case MEANPOS:  { append(attrs,   MeanPos(dst, size)   );   break; }
+            case MEANNEG:  { append(attrs,   MeanNeg(dst, size)   );   break; }
+            case MEDIAN:   { append(attrs,   Median(dst, size)    );   break; }
+            case RMS:      { append(attrs,   Rms(dst, size)       );   break; }
+            case VAR:      { append(attrs,   Var(dst, size)       );   break; }
+            case SD:       { append(attrs,   Sd(dst, size)        );   break; }
+            case SUMPOS:   { append(attrs,   SumPos(dst, size)    );   break; }
+            case SUMNEG:   { append(attrs,   SumNeg(dst, size)    );   break; }
 
             default:
                 throw std::runtime_error("Attribute not implemented");

--- a/internal/core/cppapi_data.cpp
+++ b/internal/core/cppapi_data.cpp
@@ -339,6 +339,7 @@ void attributes(
         switch (*attributes) {
             case VALUE:   { append(attrs,   Value(dst, size)     );   break; }
             case MIN:     { append(attrs,   Min(dst, size)       );   break; }
+            case MINAT:   { append(attrs,   MinAt(dst, size)     );   break; }
             case MAX:     { append(attrs,   Max(dst, size)       );   break; }
             case MAXABS:  { append(attrs,   MaxAbs(dst, size)    );   break; }
             case MEAN:    { append(attrs,   Mean(dst, size)      );   break; }

--- a/internal/core/ctypes.h
+++ b/internal/core/ctypes.h
@@ -36,6 +36,7 @@ enum interpolation_method {
 enum attribute {
     VALUE,
     MIN,
+    MINAT,
     MAX,
     MAXABS,
     MEAN,

--- a/internal/core/ctypes.h
+++ b/internal/core/ctypes.h
@@ -40,6 +40,7 @@ enum attribute {
     MAX,
     MAXAT,
     MAXABS,
+    MAXABSAT,
     MEAN,
     MEANABS,
     MEANPOS,

--- a/internal/core/ctypes.h
+++ b/internal/core/ctypes.h
@@ -38,6 +38,7 @@ enum attribute {
     MIN,
     MINAT,
     MAX,
+    MAXAT,
     MAXABS,
     MEAN,
     MEANABS,


### PR DESCRIPTION
Added a new attribute 'min_at' that will return the position of the minimum value in sample axes for both along the surface and between the surfaces.

Note:

This is not the final PR, but the implementation for only the minimum value position. If we agree with these changes, then I will add the rest of the attributes, which are similar to this.

closes #198 