### PR TITLE
Adjust float values precision in C++ error strings

### DIFF
--- a/internal/core/cppapi_data.cpp
+++ b/internal/core/cppapi_data.cpp
@@ -17,6 +17,7 @@
 #include "regularsurface.hpp"
 #include "subcube.hpp"
 #include "subvolume.hpp"
+#include "utils.hpp"
 
 namespace {
 
@@ -203,7 +204,8 @@ void fence(
             if (!axis.inrange(coordinate[voxel])) {
                 if (fillValue == nullptr) {
                     const std::string coordinate_str =
-                        "(" +std::to_string(x) + "," + std::to_string(y) + ")";
+                        "(" +utils::to_string_with_precision(x, 6) + "," +
+                        utils::to_string_with_precision(y, 6) + ")";
                     throw detail::bad_request(
                         "Coordinate " + coordinate_str + " is out of boundaries "+
                         "in dimension "+ std::to_string(voxel)+ "."
@@ -283,10 +285,10 @@ void fetch_subvolume(
                 "Vertical window is out of vertical bounds at"
                 " row: " + std::to_string(row) +
                 " col:" + std::to_string(col) +
-                ". Request: [" + std::to_string(top_sample_depth) +
-                ", " + std::to_string(bottom_sample_depth) +
-                "]. Seismic bounds: [" + std::to_string(sample.min())
-                + ", " +std::to_string(sample.max()) + "]"
+                ". Request: [" + utils::to_string_with_precision(top_sample_depth) +
+                ", " + utils::to_string_with_precision(bottom_sample_depth) +
+                "]. Seismic bounds: [" + utils::to_string_with_precision(sample.min())
+                + ", " + utils::to_string_with_precision(sample.max()) + "]"
             );
         }
 

--- a/internal/core/subcube.cpp
+++ b/internal/core/subcube.cpp
@@ -6,6 +6,7 @@
 #include "exceptions.hpp"
 #include "metadatahandle.hpp"
 #include "ctypes.h"
+#include "utils.hpp"
 
 namespace {
 
@@ -22,9 +23,9 @@ int lineno_annotation_to_voxel(
     if (lineno < min || lineno > max || std::floor(voxelline) != voxelline) {
         throw detail::bad_request(
             "Invalid lineno: " + std::to_string(lineno) +
-            ", valid range: [" + std::to_string(min) +
-            ":" + std::to_string(max) +
-            ":" + std::to_string(stepsize) + "]"
+            ", valid range: [" + utils::to_string_with_precision(min) +
+            ":" + utils::to_string_with_precision(max) +
+            ":" + utils::to_string_with_precision(stepsize) + "]"
         );
     }
 

--- a/internal/core/utils.hpp
+++ b/internal/core/utils.hpp
@@ -1,0 +1,17 @@
+#ifndef VDS_SLICE_UTILS_H
+#define VDS_SLICE_UTILS_H
+
+#include <iomanip>
+#include <sstream>
+#include <string>
+
+namespace utils {
+
+template<typename T>
+std::string to_string_with_precision(const T val, const int n = 2) {
+    std::ostringstream out;
+    out << std::fixed << std::setprecision(n) << val;
+    return out.str();
+}
+}
+#endif //VDS_SLICE_UTILS_H


### PR DESCRIPTION
When we are constructing error strings in C++, we often include coordinates or other floating point values. By default, these numbers include 6 digits, which can be unnecessary in many cases.

Therefore, setting the floating point precision to 2 decimal digits to eliminate any unnecessary noise.

closes #193 