### PR TITLE
Remove unnecessary e2e testcase

### DIFF
--- a/tests/e2e/test_requests.py
+++ b/tests/e2e/test_requests.py
@@ -253,11 +253,6 @@ def test_attributes_between_surfaces():
             "409 Public access is not permitted",
             "401 Server failed to authenticate the request"
         ]
-    ),
-    (
-        generate_container_signature(
-            STORAGE_ACCOUNT_NAME, CONTAINER, STORAGE_ACCOUNT_KEY, permission=""),
-        ["403 Server failed to authenticate"]
     )
 ])
 def test_assure_no_unauthorized_access(path, payload, sas, allowed_error_messages):


### PR DESCRIPTION
In our e2e test case, we  download the latest version of the blob library every time we run new container. However, the recent release of azure-storage-blob 12.19.0 has made it mandatory to include the permission argument in order to generate a SAS token.

Therefore, passing an empty parameter that would lead to an exception from the blob library and break code. So that testcase is no longer relevant and its good to remove.

[ref](https://github.com/Azure/azure-sdk-for-python/commit/86759fffbae2c93771607aacd2e6e5697b5b0bda)