### PR TITLE
Split e2e test_requests file

### DIFF
--- a/tests/e2e/test_edge_cases.py
+++ b/tests/e2e/test_edge_cases.py
@@ -1,0 +1,179 @@
+import http
+import os
+import json
+# import urllib.parse
+import pytest
+# import requests
+from utils.cloud import Cloud as a_cloud
+from utils import cloud as zz_cloud
+from utils.payload import PayLoad as pl
+
+STORAGE_ACCOUNT_NAME = os.getenv("STORAGE_ACCOUNT_NAME")
+STORAGE_ACCOUNT_KEY = os.getenv("STORAGE_ACCOUNT_KEY")
+ENDPOINT = os.getenv("ENDPOINT", "http://localhost:8080").rstrip("/")
+CONTAINER = "testdata"
+VDS = "well_known/well_known_default"
+STORAGE_ACCOUNT = f"https://{STORAGE_ACCOUNT_NAME}.blob.core.windows.net"
+VDS_URL = f"{STORAGE_ACCOUNT}/{CONTAINER}/{VDS}"
+
+SAMPLES10_URL = f"{STORAGE_ACCOUNT}/{CONTAINER}/10_samples/10_samples_default"
+
+payload = pl(STORAGE_ACCOUNT_NAME,
+             STORAGE_ACCOUNT_KEY,
+             ENDPOINT,
+             CONTAINER)
+
+cloud = a_cloud(STORAGE_ACCOUNT_NAME,
+                CONTAINER,
+                STORAGE_ACCOUNT_KEY)
+
+
+@pytest.mark.parametrize("_path, _payload", [
+    ("slice", payload.slice()),
+    ("fence", payload.fence()),
+    ("metadata", payload.metadata()),
+    ("attributes/surface/along", payload.attributes_along_surface()),
+    ("attributes/surface/between", payload.attributes_between_surfaces()),
+])
+@pytest.mark.parametrize("_sas, _allowed_error_messages", [
+    (
+        "something_not_sassy",
+        [
+            "409 Public access is not permitted",
+            "401 Server failed to authenticate the request"
+        ]
+    )
+])
+def test_assure_no_unauthorized_access(_path, _payload, _sas, _allowed_error_messages):
+    _payload.update({"sas": _sas})
+    res = payload.send_request(_path, "post", _payload)
+    assert res.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR
+    error_body = json.loads(res.content)['error']
+    assert any([error_msg in error_body for error_msg in _allowed_error_messages]), \
+        f'error body \'{error_body}\' does not contain any of the valid errors {_allowed_error_messages}'
+
+
+@pytest.mark.parametrize("_path, _payload", [
+    ("slice", payload.slice(vds=VDS_URL)),
+    ("fence", payload.fence(vds=VDS_URL)),
+    ("attributes/surface/along", payload.attributes_along_surface()),
+    ("attributes/surface/between", payload.attributes_between_surfaces()),
+])
+@pytest.mark.parametrize("_token, _status, _error", [
+    (cloud.generate_container_signature(permission=cloud.blob_container_sas_permissions(read=True)),
+     http.HTTPStatus.OK, None),
+    (cloud.generate_account_signature(permission=cloud.blob_account_sas_permissions(read=True),
+                                      resource_types=cloud.blob_resource_types(container=True,
+                                                                               object=True)),
+     http.HTTPStatus.OK, None),
+    (cloud.generate_blob_signature(f'{VDS}/VolumeDataLayout',
+                                   permission=cloud.blob_sas_permissions(read=True)),
+     http.HTTPStatus.INTERNAL_SERVER_ERROR, "403 Server failed to authenticate the request"),
+    pytest.param(
+        cloud.generate_directory_signature(
+            VDS, permission=cloud.storage_filedatalake.DirectorySasPermissions(read=True)),
+        http.HTTPStatus.OK, None,
+        marks=pytest.mark.skipif(
+            not cloud.is_account_datalake_gen2(VDS),
+            reason="storage account is not a datalake")
+    ),
+])
+# test makes sense if caching is enabled on the endpoint server
+def test_cached_data_access_with_various_sas(_path, _payload, _token, _status, _error):
+
+    def make_caching_call():
+        container_sas = cloud.generate_container_signature(
+            permission=cloud.blob_container_sas_permissions(read=True))
+        _payload.update({"sas": container_sas})
+        res = payload.send_request(_path, "post", _payload)
+        assert res.status_code == http.HTTPStatus.OK
+
+    make_caching_call()
+
+    _payload.update({"sas": _token})
+    res = payload.send_request(_path, "post", _payload)
+    assert res.status_code == _status
+    if _error:
+        assert _error in json.loads(res.content)['error']
+
+
+@pytest.mark.parametrize("_path, _payload", [
+    ("slice", payload.slice()),
+    ("fence", payload.fence()),
+    ("metadata", payload.metadata()),
+    ("attributes/surface/along", payload.attributes_along_surface()),
+    ("attributes/surface/between", payload.attributes_between_surfaces()),
+])
+def test_assure_only_allowed_storage_accounts(_path, _payload):
+    _payload.update({
+        "vds": "https://dummy.blob.core.windows.net/container/blob",
+    })
+    res = payload.send_request(_path, "post", _payload)
+    assert res.status_code == http.HTTPStatus.BAD_REQUEST
+    body = json.loads(res.content)
+    assert "unsupported storage account" in body['error']
+
+
+@pytest.mark.parametrize("_path, _payload, _error_code, _error", [
+    (
+        "slice",
+        payload.slice(direction="inline", lineno=4),
+        http.HTTPStatus.BAD_REQUEST,
+        "Invalid lineno: 4, valid range: [1.00:5.00:2.00]"
+    ),
+    (
+        "fence",
+        {"param": "irrelevant"},
+        http.HTTPStatus.BAD_REQUEST,
+        "Error:Field validation for"
+    ),
+    (
+        "metadata",
+        payload.metadata(vds=f'{STORAGE_ACCOUNT}/{CONTAINER}/notfound'),
+        http.HTTPStatus.INTERNAL_SERVER_ERROR,
+        "The specified blob does not exist"
+    ),
+    (
+        "attributes/surface/along",
+        payload.attributes_along_surface(surface={}),
+        http.HTTPStatus.BAD_REQUEST,
+        "Error:Field validation for"
+    ),
+    (
+        "attributes/surface/between",
+        payload.attributes_between_surfaces(
+            primaryValues=[[1]], secondaryValues=[[1], [1, 1]]),
+        http.HTTPStatus.BAD_REQUEST,
+        "Surface rows are not of the same length"
+    ),
+])
+def test_errors(_path, _payload, _error_code, _error):
+    sas = cloud.generate_container_signature()
+    _payload.update({"sas": sas})
+    res = payload.send_request(_path, "post", _payload)
+    assert res.status_code == _error_code
+
+    body = json.loads(res.content)
+    assert _error in body['error']
+
+
+@pytest.mark.parametrize("_path, _payload", [
+    ("slice",   payload.slice()),
+    ("fence",   payload.fence()),
+    ("metadata",   payload.metadata()),
+    ("attributes/surface/along", payload.attributes_along_surface()),
+    ("attributes/surface/between", payload.attributes_between_surfaces()),
+])
+@pytest.mark.parametrize("_vds, _sas, _expected", [
+    (f'{SAMPLES10_URL}?{cloud.generate_container_signature()}', '', http.HTTPStatus.OK),
+    (f'{SAMPLES10_URL}?invalid_sas',
+     cloud.generate_container_signature(), http.HTTPStatus.OK),
+    (SAMPLES10_URL, '', http.HTTPStatus.BAD_REQUEST)
+])
+def test_sas_token_in_url(_path, _payload, _vds, _sas, _expected):
+    _payload.update({
+        "vds": _vds,
+        "sas": _sas
+    })
+    res = payload.send_request(_path, "post", _payload)
+    assert res.status_code == _expected

--- a/tests/e2e/test_requests.py
+++ b/tests/e2e/test_requests.py
@@ -1,15 +1,12 @@
 import http
-import requests
-import numpy as np
 import os
-import pytest
 import json
 import re
-import urllib.parse
-from utils.cloud import *
-
-from azure.storage import blob
-from azure.storage import filedatalake
+import pytest
+import numpy as np
+from utils.cloud import Cloud as a_cloud
+from utils import cloud as zz_cloud
+from utils.payload import PayLoad as pl
 
 from requests_toolbelt.multipart import decoder
 
@@ -19,130 +16,52 @@ ENDPOINT = os.getenv("ENDPOINT", "http://localhost:8080").rstrip("/")
 CONTAINER = "testdata"
 VDS = "well_known/well_known_default"
 STORAGE_ACCOUNT = f"https://{STORAGE_ACCOUNT_NAME}.blob.core.windows.net"
-VDSURL = f"{STORAGE_ACCOUNT}/{CONTAINER}/{VDS}"
+VDS_URL = f"{STORAGE_ACCOUNT}/{CONTAINER}/{VDS}"
 
 SAMPLES10_URL = f"{STORAGE_ACCOUNT}/{CONTAINER}/10_samples/10_samples_default"
 
-def gen_default_sas():
-    return generate_container_signature(STORAGE_ACCOUNT_NAME, CONTAINER, STORAGE_ACCOUNT_KEY)
+payload = pl(STORAGE_ACCOUNT_NAME,
+             STORAGE_ACCOUNT_KEY,
+             ENDPOINT,
+             CONTAINER)
 
-
-def surface():
-    return {
-        "xinc": 7.2111,
-        "yinc": 3.6056,
-        "xori": 2,
-        "yori": 0,
-        "rotation": 33.69,
-    }
-
-
-def make_slice_request(vds=VDSURL, direction="inline", lineno=3, sas="sas"):
-    return {
-        "vds": vds,
-        "direction": direction,
-        "lineno": lineno,
-        "sas": sas
-    }
-
-
-def make_fence_request(vds=VDSURL, coordinate_system="ij", coordinates=[[0, 0]], sas="sas"):
-    return {
-        "vds": vds,
-        "coordinateSystem": coordinate_system,
-        "coordinates": coordinates,
-        "sas": sas
-    }
-
-
-def make_metadata_request(vds=VDSURL, sas="sas"):
-    return {
-        "vds": vds,
-        "sas": sas
-    }
-
-
-def make_attributes_along_surface_request(
-    vds=SAMPLES10_URL,
-    surface=surface(),
-    values=[[20]],
-    above=8,
-    below=8,
-    attributes=["samplevalue"],
-    sas="sas"
-):
-    regular_surface = {
-        "values": values,
-        "fillValue": -999.25,
-    }
-    regular_surface.update(surface)
-
-    request = {
-        "surface": regular_surface,
-        "interpolation": "nearest",
-        "vds": vds,
-        "sas": sas,
-        "above": above,
-        "below": below,
-        "attributes": attributes
-    }
-    return request
-
-
-def make_attributes_between_surfaces_request(
-    primaryValues=[[20]],
-    secondaryValues=[[20]],
-    vds=SAMPLES10_URL,
-    surface=surface(),
-    attributes=["max"],
-    stepsize=8,
-    sas="sas"
-):
-    fillValue = -999.25
-    primary = {
-        "values" : primaryValues,
-        "fillValue": fillValue
-    }
-    primary.update(surface)
-    secondary = {
-        "values" : secondaryValues,
-        "fillValue": fillValue
-    }
-    secondary.update(surface)
-    request = {
-        "primarySurface" : primary,
-        "secondarySurface" : secondary,
-        "interpolation": "nearest",
-        "vds": vds,
-        "sas": sas,
-        "stepsize": stepsize,
-        "attributes": attributes
-    }
-    request.update(surface)
-    return request
+cloud = a_cloud(STORAGE_ACCOUNT_NAME,
+                CONTAINER,
+                STORAGE_ACCOUNT_KEY)
 
 
 @pytest.mark.parametrize("method", [
     ("get"),
     ("post")
 ])
-def test_slice(method):
-    meta, slice = request_slice(method, 5, 'inline')
-
-    expected = np.array([[116, 117, 118, 119],
-                         [120, 121, 122, 123]])
-    assert np.array_equal(slice, expected)
-
-    expected_meta = json.loads("""
-    {
-        "x": {"annotation": "Sample", "max": 16.0, "min": 4.0, "samples" : 4, "stepsize": 4.0, "unit": "ms"},
-        "y": {"annotation": "Crossline", "max": 11.0, "min": 10.0, "samples" : 2, "stepsize": 1.0, "unit": "unitless"},
-        "shape": [ 2, 4],
-        "format": "<f4",
-        "geospatial": [[14.0, 8.0], [12.0, 11.0]]
+def test_metadata(method):
+    metadata = dict(request_metadata(method))
+    expected_metadata = {
+        "axis": [
+            {"annotation": "Inline",    "max": 5.0,  "min": 1.0,
+                "samples": 3, "stepsize": 2.0, "unit": "unitless"},
+            {"annotation": "Crossline", "max": 11.0, "min": 10.0,
+                "samples": 2, "stepsize": 1.0, "unit": "unitless"},
+            {"annotation": "Sample",    "max": 16.0, "min": 4.0,
+                "samples": 4, "stepsize": 4.0, "unit": "ms"}
+        ],
+        "boundingBox": {
+            "cdp": [[2, 0], [14, 8], [12, 11], [0, 3]],
+            "ilxl": [[1, 10], [5, 10], [5, 11], [1, 11]],
+            "ij": [[0, 0], [2, 0], [2, 1], [0, 1]]
+        },
+        "crs": "utmXX",
+        "inputFileName": "well_known.segy",
+        "importTimeStamp": "^\\d{4}-\\d{2}-\\d{2}[A-Z]\\d{2}:\\d{2}:\\d{2}\\.\\d{3}[A-Z]$"
     }
-    """)
-    assert meta == expected_meta
+
+    expected_import_ts = expected_metadata.get("importTimeStamp")
+    actual_import_ts = metadata.get("importTimeStamp")
+    assert re.compile(expected_import_ts).match(
+        actual_import_ts), f"Not a valid import Time Stamp {actual_import_ts} in metadata"
+    expected_metadata["importTimeStamp"] = "dummy"
+    metadata["importTimeStamp"] = "dummy"
+    assert expected_metadata == metadata
 
 
 @pytest.mark.parametrize("method", [
@@ -169,30 +88,23 @@ def test_fence(method):
     ("get"),
     ("post")
 ])
-def test_metadata(method):
-    metadata = dict(request_metadata(method))
-    expected_metadata = {
-        "axis": [
-            {"annotation": "Inline",    "max": 5.0,  "min": 1.0,  "samples": 3, "stepsize": 2.0, "unit": "unitless"},
-            {"annotation": "Crossline", "max": 11.0, "min": 10.0, "samples": 2, "stepsize": 1.0, "unit": "unitless"},
-            {"annotation": "Sample",    "max": 16.0, "min": 4.0,  "samples": 4, "stepsize": 4.0, "unit": "ms"}
-        ],
-        "boundingBox": {
-            "cdp" : [[2,0]  , [14,8] , [12,11] , [0,3] ],
-            "ilxl": [[1,10] , [5,10] , [5,11]  , [1,11]],
-            "ij"  : [[0,0]  , [2,0]  , [2,1]   , [0,1] ]
-        },
-        "crs"            : "utmXX",
-        "inputFileName"  : "well_known.segy",
-        "importTimeStamp": "^\\d{4}-\\d{2}-\\d{2}[A-Z]\\d{2}:\\d{2}:\\d{2}\\.\\d{3}[A-Z]$"
-    }
+def test_slice(method):
+    meta, _slice = request_slice(method, 5, 'inline')
 
-    expected_import_ts = expected_metadata.get("importTimeStamp")
-    actual_import_ts   = metadata.get("importTimeStamp")
-    assert re.compile(expected_import_ts).match(actual_import_ts), f"Not a valid import Time Stamp {actual_import_ts} in metadata"
-    expected_metadata["importTimeStamp"] = "dummy"
-    metadata["importTimeStamp"]          = "dummy"
-    assert expected_metadata == metadata
+    expected = np.array([[116, 117, 118, 119],
+                         [120, 121, 122, 123]])
+    assert np.array_equal(_slice, expected)
+
+    expected_meta = json.loads("""
+    {
+        "x": {"annotation": "Sample", "max": 16.0, "min": 4.0, "samples" : 4, "stepsize": 4.0, "unit": "ms"},
+        "y": {"annotation": "Crossline", "max": 11.0, "min": 10.0, "samples" : 2, "stepsize": 1.0, "unit": "unitless"},
+        "shape": [ 2, 4],
+        "format": "<f4",
+        "geospatial": [[14.0, 8.0], [12.0, 11.0]]
+    }
+    """)
+    assert meta == expected_meta
 
 
 def test_attributes_along_surface():
@@ -214,6 +126,7 @@ def test_attributes_along_surface():
     """)
     assert meta == expected_meta
 
+
 def test_attributes_between_surfaces():
     primary = [
         [12, 12],
@@ -225,7 +138,8 @@ def test_attributes_between_surfaces():
         [27.5, 29],
         [24,   12]
     ]
-    meta, data = request_attributes_between_surfaces("post", primary, secondary)
+    meta, data = request_attributes_between_surfaces(
+        "post", primary, secondary)
 
     expected = np.array([[1.5, 2.5], [-8.5, 7.5], [18.5, -8.5]])
     assert np.array_equal(data, expected)
@@ -239,252 +153,58 @@ def test_attributes_between_surfaces():
     assert meta == expected_meta
 
 
-@pytest.mark.parametrize("path, payload", [
-    ("slice", make_slice_request()),
-    ("fence", make_fence_request()),
-    ("metadata", make_metadata_request()),
-    ("attributes/surface/along", make_attributes_along_surface_request()),
-    ("attributes/surface/between", make_attributes_between_surfaces_request()),
-])
-@pytest.mark.parametrize("sas, allowed_error_messages", [
-    (
-        "something_not_sassy",
-        [
-            "409 Public access is not permitted",
-            "401 Server failed to authenticate the request"
-        ]
-    )
-])
-def test_assure_no_unauthorized_access(path, payload, sas, allowed_error_messages):
-    payload.update({"sas": sas})
-    res = send_request(path, "post", payload)
-    assert res.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR
-    error_body = json.loads(res.content)['error']
-    assert any([error_msg in error_body for error_msg in allowed_error_messages]), \
-        f'error body \'{error_body}\' does not contain any of the valid errors {allowed_error_messages}'
+def request_metadata(method):
+    sas = cloud.generate_container_signature()
+
+    _payload = payload.metadata(VDS_URL, sas)
+    _request_data = payload.send_request("metadata", method, _payload)
+    _request_data.raise_for_status()
+
+    return _request_data.json()
 
 
-@pytest.mark.parametrize("path, payload", [
-    ("slice", make_slice_request(vds=VDSURL)),
-    ("fence", make_fence_request(vds=VDSURL)),
-    ("attributes/surface/along", make_attributes_along_surface_request()),
-    ("attributes/surface/between", make_attributes_between_surfaces_request()),
-])
-@pytest.mark.parametrize("token, status, error", [
-    (generate_container_signature(
-        STORAGE_ACCOUNT_NAME, CONTAINER, STORAGE_ACCOUNT_KEY,
-        permission=blob.ContainerSasPermissions(read=True)),
-     http.HTTPStatus.OK, None),
-    (generate_account_signature(
-        STORAGE_ACCOUNT_NAME, STORAGE_ACCOUNT_KEY, permission=blob.AccountSasPermissions(
-            read=True), resource_types=blob.ResourceTypes(container=True, object=True)),
-     http.HTTPStatus.OK, None),
-    (generate_blob_signature(
-        STORAGE_ACCOUNT_NAME, CONTAINER, f'{VDS}/VolumeDataLayout', STORAGE_ACCOUNT_KEY,
-        permission=blob.BlobSasPermissions(read=True)),
-     http.HTTPStatus.INTERNAL_SERVER_ERROR, "403 Server failed to authenticate the request"),
-    pytest.param(
-        generate_directory_signature(
-            STORAGE_ACCOUNT_NAME, CONTAINER, VDS, STORAGE_ACCOUNT_KEY,
-            permission=filedatalake.DirectorySasPermissions(read=True)),
-        http.HTTPStatus.OK, None,
-        marks=pytest.mark.skipif(
-            not is_account_datalake_gen2(
-                STORAGE_ACCOUNT_NAME, CONTAINER, VDS, STORAGE_ACCOUNT_KEY),
-            reason="storage account is not a datalake")
-    ),
-])
-# test makes sense if caching is enabled on the endpoint server
-def test_cached_data_access_with_various_sas(path, payload, token, status, error):
+def proccess_data_request(_request_data):
+    _request_data.raise_for_status()
 
-    def make_caching_call():
-        container_sas = generate_container_signature(
-            STORAGE_ACCOUNT_NAME,
-            CONTAINER,
-            STORAGE_ACCOUNT_KEY,
-            permission=blob.ContainerSasPermissions(read=True))
-        payload.update({"sas": container_sas})
-        res = send_request(path, "post", payload)
-        assert res.status_code == http.HTTPStatus.OK
+    _multipart_data = decoder.MultipartDecoder.from_response(_request_data)
+    assert len(_multipart_data.parts) == 2
+    _metadata = json.loads(_multipart_data.parts[0].content)
+    _data = _multipart_data.parts[1].content
 
-    make_caching_call()
-
-    payload.update({"sas": token})
-    res = send_request(path, "post", payload)
-    assert res.status_code == status
-    if error:
-        assert error in json.loads(res.content)['error']
-
-
-@pytest.mark.parametrize("path, payload", [
-    ("slice", make_slice_request()),
-    ("fence", make_fence_request()),
-    ("metadata", make_metadata_request()),
-    ("attributes/surface/along", make_attributes_along_surface_request()),
-    ("attributes/surface/between", make_attributes_between_surfaces_request()),
-])
-def test_assure_only_allowed_storage_accounts(path, payload):
-    payload.update({
-        "vds": "https://dummy.blob.core.windows.net/container/blob",
-    })
-    res = send_request(path, "post", payload)
-    assert res.status_code == http.HTTPStatus.BAD_REQUEST
-    body = json.loads(res.content)
-    assert "unsupported storage account" in body['error']
-
-
-@pytest.mark.parametrize("path, payload, error_code, error", [
-    (
-        "slice",
-        make_slice_request(direction="inline", lineno=4),
-        http.HTTPStatus.BAD_REQUEST,
-        "Invalid lineno: 4, valid range: [1.00:5.00:2.00]"
-    ),
-    (
-        "fence",
-        {"param": "irrelevant"},
-        http.HTTPStatus.BAD_REQUEST,
-        "Error:Field validation for"
-    ),
-    (
-        "metadata",
-        make_metadata_request(vds=f'{STORAGE_ACCOUNT}/{CONTAINER}/notfound'),
-        http.HTTPStatus.INTERNAL_SERVER_ERROR,
-        "The specified blob does not exist"
-    ),
-    (
-        "attributes/surface/along",
-        make_attributes_along_surface_request(surface={}),
-        http.HTTPStatus.BAD_REQUEST,
-        "Error:Field validation for"
-    ),
-    (
-        "attributes/surface/between",
-        make_attributes_between_surfaces_request(
-            primaryValues=[[1]], secondaryValues=[[1], [1, 1]]),
-        http.HTTPStatus.BAD_REQUEST,
-        "Surface rows are not of the same length"
-    ),
-])
-def test_errors(path, payload, error_code, error):
-    sas = generate_container_signature(
-        STORAGE_ACCOUNT_NAME, CONTAINER, STORAGE_ACCOUNT_KEY)
-    payload.update({"sas": sas})
-    res = send_request(path, "post", payload)
-    assert res.status_code == error_code
-
-    body = json.loads(res.content)
-    assert error in body['error']
-
-
-def send_request(path, method, payload):
-    if method == "get":
-        json_payload = json.dumps(payload)
-        encoded_payload = urllib.parse.quote(json_payload)
-        data = requests.get(f'{ENDPOINT}/{path}?query={encoded_payload}')
-    elif method == "post":
-        data = requests.post(f'{ENDPOINT}/{path}', json=payload)
-    else:
-        raise ValueError(f'Unknown method {method}')
-    return data
+    _data = np.ndarray(_metadata['shape'], _metadata['format'], _data)
+    return _metadata, _data
 
 
 def request_slice(method, lineno, direction):
-    sas = generate_container_signature(
-        STORAGE_ACCOUNT_NAME, CONTAINER, STORAGE_ACCOUNT_KEY)
+    sas = cloud.generate_container_signature()
 
-    payload = make_slice_request(VDSURL, direction, lineno, sas)
-    rdata = send_request("slice", method, payload)
-    rdata.raise_for_status()
-
-    multipart_data = decoder.MultipartDecoder.from_response(rdata)
-    assert len(multipart_data.parts) == 2
-    metadata = json.loads(multipart_data.parts[0].content)
-    data = multipart_data.parts[1].content
-
-    data = np.ndarray(metadata['shape'], metadata['format'], data)
-    return metadata, data
+    _payload = payload.slice(VDS_URL, direction, lineno, sas)
+    _request_data = payload.send_request("slice", method, _payload)
+    return proccess_data_request(_request_data)
 
 
 def request_fence(method, coordinates, coordinate_system):
-    sas = generate_container_signature(
-        STORAGE_ACCOUNT_NAME, CONTAINER, STORAGE_ACCOUNT_KEY)
+    sas = cloud.generate_container_signature()
 
-    payload = make_fence_request(VDSURL, coordinate_system, coordinates, sas)
-    rdata = send_request("fence", method, payload)
-    rdata.raise_for_status()
-
-    multipart_data = decoder.MultipartDecoder.from_response(rdata)
-    assert len(multipart_data.parts) == 2
-    metadata = json.loads(multipart_data.parts[0].content)
-    data = multipart_data.parts[1].content
-
-    data = np.ndarray(metadata['shape'], metadata['format'], data)
-    return metadata, data
-
-
-def request_metadata(method):
-    sas = generate_container_signature(
-        STORAGE_ACCOUNT_NAME, CONTAINER, STORAGE_ACCOUNT_KEY)
-
-    payload = make_metadata_request(VDSURL, sas)
-    rdata = send_request("metadata", method, payload)
-    rdata.raise_for_status()
-
-    return rdata.json()
+    _payload = payload.fence(VDS_URL, coordinate_system, coordinates, sas)
+    _request_data = payload.send_request("fence", method, _payload)
+    return proccess_data_request(_request_data)
 
 
 def request_attributes_along_surface(method, values):
-    sas = generate_container_signature(
-        STORAGE_ACCOUNT_NAME, CONTAINER, STORAGE_ACCOUNT_KEY)
+    sas = cloud.generate_container_signature()
 
-    payload = make_attributes_along_surface_request(values=values, sas=sas)
-    rdata = send_request("attributes/surface/along", method, payload)
-    rdata.raise_for_status()
+    _payload = payload.attributes_along_surface(values=values, sas=sas)
+    _request_data = payload.send_request(
+        "attributes/surface/along", method, _payload)
+    return proccess_data_request(_request_data)
 
-    multipart_data = decoder.MultipartDecoder.from_response(rdata)
-    assert len(multipart_data.parts) == 2
-    metadata = json.loads(multipart_data.parts[0].content)
-    data = multipart_data.parts[1].content
-
-    data = np.ndarray(metadata['shape'], metadata['format'], data)
-    return metadata, data
 
 def request_attributes_between_surfaces(method, primary, secondary):
-    sas = generate_container_signature(
-        STORAGE_ACCOUNT_NAME, CONTAINER, STORAGE_ACCOUNT_KEY)
+    sas = cloud.generate_container_signature()
 
-    payload = make_attributes_between_surfaces_request(primary, secondary, sas=sas)
-    rdata = send_request("attributes/surface/between", method, payload)
-    rdata.raise_for_status()
-
-    multipart_data = decoder.MultipartDecoder.from_response(rdata)
-    assert len(multipart_data.parts) == 2
-    metadata = json.loads(multipart_data.parts[0].content)
-    data = multipart_data.parts[1].content
-
-    data = np.ndarray(metadata['shape'], metadata['format'], data)
-    return metadata, data
-
-
-
-@pytest.mark.parametrize("path, payload", [
-    ("slice",   make_slice_request()),
-    ("fence",   make_fence_request()),
-    ("metadata",   make_metadata_request()),
-    ("attributes/surface/along", make_attributes_along_surface_request()),
-    ("attributes/surface/between", make_attributes_between_surfaces_request()),
-])
-@pytest.mark.parametrize("vds, sas, expected", [
-    ( f'{SAMPLES10_URL}?{gen_default_sas()}' , ''                , http.HTTPStatus.OK            ),
-    ( f'{SAMPLES10_URL}?invalid_sas'         , gen_default_sas() , http.HTTPStatus.OK            ),
-    ( SAMPLES10_URL                          , ''                , http.HTTPStatus.BAD_REQUEST   )
-])
-def test_sas_token_in_url(path, payload, vds, sas, expected):
-    payload.update({
-        "vds": vds,
-        "sas": sas
-    })
-    res = send_request(path, "post", payload)
-    assert res.status_code == expected
-    gen_default_sas()
+    _payload = payload.attributes_between_surfaces(
+        primary, secondary, sas=sas)
+    _request_data = payload.send_request(
+        "attributes/surface/between", method, _payload)
+    return proccess_data_request(_request_data)

--- a/tests/utils/cloud.py
+++ b/tests/utils/cloud.py
@@ -1,125 +1,168 @@
-from azure.storage import blob
-from azure.core import exceptions
 import datetime
+from azure.storage import blob
+from azure.storage import filedatalake
+from azure.core import exceptions
 
+class Cloud:
 
-def generate_account_signature(
-    account_name,
-    account_key,
-    lifespan=120,
-    permission=None,
-    resource_types=None,
-):
-    """
-    Create account signature for azure request
-    """
-    expiry = datetime.datetime.utcnow() + datetime.timedelta(seconds=lifespan)
-    if permission == None:
-        permission = blob.AccountSasPermissions(read=True)
-    if resource_types == None:
-        resource_types = blob.ResourceTypes(container=True, object=True)
+    def __init__(self,
+                 _account_name,
+                 _container_name,
+                 _account_key,
+                 ) -> None:
+        self.account_name = _account_name
+        self.container_name = _container_name
+        self.account_key = _account_key
+        self.blob_sas_permissions = blob.BlobSasPermissions
+        self.blob_container_sas_permissions = blob.ContainerSasPermissions
+        self.blob_account_sas_permissions = blob.AccountSasPermissions
+        self.blob_resource_types = blob.ResourceTypes
+        self.storage_filedatalake = filedatalake
 
-    return blob.generate_account_sas(
-        account_name=account_name,
-        account_key=account_key,
-        resource_types=resource_types,
-        permission=permission,
-        expiry=expiry)
+    def generate_account_signature(
+        self,
+        account_name=None,
+        account_key=None,
+        lifespan=120,
+        permission=None,
+        resource_types=None,
+    ):
+        """
+        Create account signature for azure request
+        """
+        expiry = datetime.datetime.utcnow() + datetime.timedelta(seconds=lifespan)
+        if account_name is None:
+            account_name = self.account_name
+        if account_key is None:
+            account_key = self.account_key
+        if permission is None:
+            permission = blob.AccountSasPermissions(read=True)
+        if resource_types is None:
+            resource_types = blob.ResourceTypes(container=True, object=True)
 
+        return blob.generate_account_sas(
+            account_name=account_name,
+            account_key=account_key,
+            resource_types=resource_types,
+            permission=permission,
+            expiry=expiry)
 
-def generate_container_signature(
-    account_name,
-    container_name,
-    account_key,
-    lifespan=120,
-    permission=None
-):
-    """
-    Create container signature for azure request
-    """
-    expiry = datetime.datetime.utcnow() + datetime.timedelta(seconds=lifespan)
-    if permission == None:
-        permission = blob.ContainerSasPermissions(read=True)
+    def generate_container_signature(
+        self,
+        account_name=None,
+        container_name=None,
+        account_key=None,
+        lifespan=120,
+        permission=None
+    ):
+        """
+        Create container signature for azure request
+        """
+        expiry = datetime.datetime.utcnow() + datetime.timedelta(seconds=lifespan)
+        if account_name is None:
+            account_name = self.account_name
+        if container_name is None:
+            container_name = self.container_name
+        if account_key is None:
+            account_key = self.account_key
+        if permission is None:
+            permission = blob.ContainerSasPermissions(read=True)
 
-    return blob.generate_container_sas(
-        account_name=account_name,
-        container_name=container_name,
-        account_key=account_key,
-        permission=permission,
-        expiry=expiry)
+        return blob.generate_container_sas(
+            account_name=account_name,
+            container_name=container_name,
+            account_key=account_key,
+            permission=permission,
+            expiry=expiry)
 
+    def generate_directory_signature(
+        self,
+        file_system_name,
+        account_name=None,
+        directory_name=None,
+        account_key=None,
+        lifespan=120,
+        permission=None
+    ):
+        """
+        Create directory signature for azure request
+        """
+        expiry = datetime.datetime.utcnow() + datetime.timedelta(seconds=lifespan)
+        if account_name is None:
+            account_name = self.account_name
+        if directory_name is None:
+            directory_name = self.container_name
+        if account_key is None:
+            account_key = self.account_key
+        if permission is None:
+            permission = filedatalake.FileSasPermissions(read=True)
 
-def generate_directory_signature(
-    account_name,
-    file_system_name,
-    directory_name,
-    account_key,
-    lifespan=120,
-    permission=None
-):
-    """
-    Create directory signature for azure request
-    """
-    from azure.storage import filedatalake
-    expiry = datetime.datetime.utcnow() + datetime.timedelta(seconds=lifespan)
-    if permission == None:
-        permission = filedatalake.FileSasPermissions(read=True)
+        return filedatalake.generate_directory_sas(
+            account_name=account_name,
+            file_system_name=file_system_name,
+            directory_name=directory_name,
+            credential=account_key,
+            permission=permission,
+            expiry=expiry)
 
-    return filedatalake.generate_directory_sas(
-        account_name=account_name,
-        file_system_name=file_system_name,
-        directory_name=directory_name,
-        credential=account_key,
-        permission=permission,
-        expiry=expiry)
+    def generate_blob_signature(
+        self,
+        blob_name,
+        account_name=None,
+        container_name=None,
+        account_key=None,
+        lifespan=120,
+        permission=None
+    ):
+        """
+        Create blob signature for azure request
+        """
+        expiry = datetime.datetime.utcnow() + datetime.timedelta(seconds=lifespan)
+        if account_name is None:
+            account_name = self.account_name
+        if container_name is None:
+            container_name = self.container_name
+        if account_key is None:
+            account_key = self.account_key
+        if permission is None:
+            permission = blob.BlobSasPermissions(read=True)
 
+        return blob.generate_blob_sas(
+            account_name=account_name,
+            container_name=container_name,
+            blob_name=blob_name,
+            account_key=account_key,
+            permission=permission,
+            expiry=expiry)
 
-def generate_blob_signature(
-    account_name,
-    container_name,
-    blob_name,
-    account_key,
-    lifespan=120,
-    permission=None
-):
-    """
-    Create blob signature for azure request
-    """
-    expiry = datetime.datetime.utcnow() + datetime.timedelta(seconds=lifespan)
-    if permission == None:
-        permission = blob.BlobSasPermissions(read=True)
+    def is_account_datalake_gen2(
+        self,
+        directory_name,
+        account_name=None,
+        container_or_filesystem_name=None,
+        account_key=None,
+    ):
+        """
+        For the moment datalake gen2 is not our primary storage,
+        but as we aim to support it too, we want to allow
+        additional tests to be run on it
+        """
 
-    return blob.generate_blob_sas(
-        account_name=account_name,
-        container_name=container_name,
-        blob_name=blob_name,
-        account_key=account_key,
-        permission=permission,
-        expiry=expiry)
+        if account_name is None:
+            account_name = self.account_name
+        if container_or_filesystem_name is None:
+            container_or_filesystem_name = self.container_name
+        if account_key is None:
+            account_key = self.account_key
 
-
-def is_account_datalake_gen2(
-    account_name,
-    container_or_filesystem_name,
-    directory_name,
-    account_key,
-):
-    """
-    For the moment datalake gen2 is not our primary storage,
-    but as we aim to support it too, we want to allow
-    additional tests to be run on it
-    """
-
-    from azure.storage import filedatalake
-
-    service_client = filedatalake.DataLakeServiceClient(
-        account_url=f"https://{account_name}.dfs.core.windows.net", credential=account_key)
-    file_system_client = service_client.get_file_system_client(
-        file_system=container_or_filesystem_name)
-    directory_client = file_system_client.get_directory_client(directory_name)
-    try:
-        directory_client.get_directory_properties()
-    except exceptions.ResourceNotFoundError:
-        return False
-    else:
+        service_client = filedatalake.DataLakeServiceClient(
+            account_url=f"https://{account_name}.dfs.core.windows.net", credential=account_key)
+        file_system_client = service_client.get_file_system_client(
+            file_system=container_or_filesystem_name)
+        directory_client = file_system_client.get_directory_client(
+            directory_name)
+        try:
+            directory_client.get_directory_properties()
+        except exceptions.ResourceNotFoundError:
+            return False
         return True

--- a/tests/utils/payload.py
+++ b/tests/utils/payload.py
@@ -1,0 +1,153 @@
+import json
+import urllib
+import requests
+
+class PayLoad:
+
+    def __init__(self,
+                 _storage_account_name,
+                 _storage_account_key,
+                 _endpoint,
+                 _container) -> None:
+
+        self.storage_account_name = _storage_account_name
+        self.storage_account_key = _storage_account_key
+        self.endpoint = _endpoint
+        self.container = _container
+        self.vds = "well_known/well_known_default"
+        self.storage_account = f"https://{self.storage_account_name}.blob.core.windows.net"
+        self.vds_url = f"{self.storage_account}/{self.container}/{self.vds}"
+        self.samples10_url = f"{self.storage_account}/{self.container}/10_samples/10_samples_default"
+
+    def send_request(self, _path: str, _method: str, _payload: str):
+        """Send a request to the API
+
+        Args:
+            _path (str): URL path
+            _method (str): get or post
+            _payload (str): Input parameters
+
+        Raises:
+            ValueError: _description_
+
+        Returns:
+            _type_: _description_
+        """
+
+        if _method == "get":
+            json_payload = json.dumps(_payload)
+            encoded_payload = urllib.parse.quote(json_payload)
+            data = requests.get(
+                f'{self.endpoint}/{_path}?query={encoded_payload}',
+                timeout=10)
+        elif _method == "post":
+            data = requests.post(f'{self.endpoint}/{_path}', json=_payload,
+                                 timeout=10)
+        else:
+            raise ValueError(f'Unknown method {_method}')
+        return data
+
+    def slice(self, vds=None, direction="inline", lineno=3, sas="sas"):
+        if vds is None:
+            vds = self.vds_url
+        return {
+            "vds": vds,
+            "direction": direction,
+            "lineno": lineno,
+            "sas": sas
+        }
+
+    def fence(self, vds=None, coordinate_system="ij", coordinates=[[0, 0]], sas="sas"):
+        if vds is None:
+            vds = self.vds_url
+        return {
+            "vds": vds,
+            "coordinateSystem": coordinate_system,
+            "coordinates": coordinates,
+            "sas": sas
+        }
+
+    def metadata(self, vds=None, sas="sas"):
+        if vds is None:
+            vds = self.vds_url
+        return {
+            "vds": vds,
+            "sas": sas
+        }
+
+    def surface(self):
+        return {
+            "xinc": 7.2111,
+            "yinc": 3.6056,
+            "xori": 2,
+            "yori": 0,
+            "rotation": 33.69,
+        }
+
+    def attributes_along_surface(
+        self,
+        vds=None,
+        surface=None,
+        values=[[20]],
+        above=8,
+        below=8,
+        attributes=["samplevalue"],
+        sas="sas"
+    ):
+        if vds is None:
+            vds = self.samples10_url
+        if surface is None:
+            surface = self.surface()
+        regular_surface = {
+            "values": values,
+            "fillValue": -999.25,
+        }
+        regular_surface.update(surface)
+
+        request = {
+            "surface": regular_surface,
+            "interpolation": "nearest",
+            "vds": vds,
+            "sas": sas,
+            "above": above,
+            "below": below,
+            "attributes": attributes
+        }
+        return request
+
+    def attributes_between_surfaces(
+        self,
+        primaryValues=[[20]],
+        secondaryValues=[[20]],
+        vds=None,
+        surface=None,
+        attributes=["max"],
+        stepsize=8,
+        sas="sas"
+    ):
+        if vds is None:
+            vds = self.samples10_url
+        if surface is None:
+            surface = self.surface()
+        fillValue = -999.25
+        primary = {
+            "values": primaryValues,
+            "fillValue": fillValue
+        }
+        primary.update(surface)
+        secondary = {
+            "values": secondaryValues,
+            "fillValue": fillValue
+        }
+        secondary.update(surface)
+        request = {
+            "primarySurface": primary,
+            "secondarySurface": secondary,
+            "interpolation": "nearest",
+            "vds": vds,
+            "sas": sas,
+            "stepsize": stepsize,
+            "attributes": attributes
+        }
+        request.update(surface)
+        return request


### PR DESCRIPTION
Refactor the python end to end tests of the endpoint requests. 

1. All Azure cloud references moved to tests/utils/cloud.py
2. Endpoint payload creation moved to tests/utils/payload.py
3. Tests in test_requests are split into test_edge_cases and test_requests
4. Repeated coded is moved out into separate function. 