### PR TITLE
Difference api

### DIFF
--- a/api/endpoint.go
+++ b/api/endpoint.go
@@ -27,7 +27,7 @@ func httpStatusCode(err error) int {
 /* Call abortOnError on the context in case of an error
  *
  * This function is designed specifically for our endpoint handler functions
- * and aims at making the errorhandling as short and concise as possible.
+ * and aims at making the error handling as short and concise as possible.
  *
  * If err != nil the error will be mapped to an appropriate http status code
  * through the httpStatusCode mapper, and ctx.AbortWithError will be called
@@ -37,7 +37,7 @@ func httpStatusCode(err error) int {
  * If err == nil the ctx is left untouched and this function returns false,
  * indicating that the context was not aborted.
  *
- * The result is a oneline error handling:
+ * The result is a one line error handling:
  *
  *     err, _ := func()
  *     if abortOnError(ctx, err) { return }

--- a/api/endpoint.go
+++ b/api/endpoint.go
@@ -65,12 +65,17 @@ func prepareRequestLogging(ctx *gin.Context, request Stringable) {
 
 func (e *Endpoint) metadata(ctx *gin.Context, request MetadataRequest) {
 	prepareRequestLogging(ctx, request)
-	conn, err := e.MakeVdsConnection(request.Vds, request.Sas)
-	if abortOnError(ctx, err) {
-		return
+	vds_url, sas_key := request.credentials()
+	var conn []core.Connection
+	for i := 0; i < len(vds_url); i++ {
+		conn_t, err := e.MakeVdsConnection(vds_url[i], sas_key[i])
+		conn = append(conn, conn_t)
+		if abortOnError(ctx, err) {
+			return
+		}
 	}
 
-	handle, err := core.NewDSHandle([]core.Connection{conn}, "")
+	handle, err := core.NewDSHandle(conn, "")
 	if abortOnError(ctx, err) {
 		return
 	}
@@ -94,7 +99,7 @@ func (e *Endpoint) makeDataRequest(
 	var conn []core.Connection
 
 	for i := 0; i < len(vds_url); i++ {
-		fmt.Println(vds_url[i])
+		fmt.Println(i, vds_url[i])
 		conn_t, err := e.MakeVdsConnection(vds_url[i], sas_key[i])
 		conn = append(conn, conn_t)
 		if abortOnError(ctx, err) {

--- a/api/request.go
+++ b/api/request.go
@@ -34,15 +34,16 @@ type RequestedResource struct {
 	Sas string `json:"sas,omitempty" example:"sp=r&st=2022-09-12T09:44:17Z&se=2022-09-12T17:44:17Z&spr=https&sv=2021-06-08&sr=c&sig=..."`
 }
 
-func (r RequestedResource) credentials() (string, string) {
-	return r.Vds, r.Sas
+func (r RequestedResource) credentials() ([]string, []string) {
+	return []string{r.Vds}, []string{r.Sas}
 }
 
 type DataRequest interface {
 	toString() (string, error)
 	hash() (string, error)
-	credentials() (string, string)
+	credentials() ([]string, []string)
 	execute(handle core.DSHandle) (data [][]byte, metadata []byte, err error)
+	cubeFunction() string
 }
 
 type Stringable interface {
@@ -149,6 +150,10 @@ func (f FenceRequest) hash() (string, error) {
 	return cache.Hash(f)
 }
 
+func (f FenceRequest) cubeFunction() string {
+	return ""
+}
+
 // Query for slice endpoints
 // @Description Query payload for slice endpoint /slice.
 type SliceRequest struct {
@@ -204,6 +209,10 @@ func (s SliceRequest) hash() (string, error) {
 	// Strip the sas token before computing hash
 	s.Sas = ""
 	return cache.Hash(s)
+}
+
+func (s SliceRequest) cubeFunction() string {
+	return ""
 }
 
 func (s SliceRequest) toString() (string, error) {
@@ -290,6 +299,10 @@ func (h AttributeAlongSurfaceRequest) hash() (string, error) {
 	return cache.Hash(h)
 }
 
+func (s AttributeAlongSurfaceRequest) cubeFunction() string {
+	return ""
+}
+
 func (h AttributeAlongSurfaceRequest) toString() (string, error) {
 	msg := "{vds: %s, Horizon: (ncols: %d, nrows: %d), Rotation: %.2f, " +
 		"Origin: [%.2f, %.2f], Increment: [%.2f, %.2f], FillValue: %.2f, " +
@@ -350,6 +363,10 @@ func (h AttributeBetweenSurfacesRequest) hash() (string, error) {
 	// Strip the sas token before computing hash
 	h.Sas = ""
 	return cache.Hash(h)
+}
+
+func (s AttributeBetweenSurfacesRequest) cubeFunction() string {
+	return ""
 }
 
 func (h AttributeBetweenSurfacesRequest) toString() (string, error) {

--- a/api/request.go
+++ b/api/request.go
@@ -321,7 +321,7 @@ type AttributeAlongRequest struct {
 	Above float32 `json:"above" example:"20.0"`
 
 	// Samples interval below the horizon to include in attribute calculation.
-	// Implements the same behaviour as 'above'.
+	// Implements the same behavior as 'above'.
 	//
 	// Defaults to zero
 	Below float32 `json:"below" example:"20.0"`

--- a/api/request_test.go
+++ b/api/request_test.go
@@ -17,8 +17,10 @@ func newSliceRequest(
 			Vds: []string{vds},
 			Sas: []string{sas},
 		},
-		Direction: direction,
-		Lineno:    &lineno,
+		GenericSliceRequest: GenericSliceRequest{
+			Direction: direction,
+			Lineno:    &lineno,
+		},
 	}
 }
 
@@ -34,9 +36,11 @@ func newFenceRequest(
 			Vds: []string{vds},
 			Sas: []string{sas},
 		},
-		CoordinateSystem: coordinateSystem,
-		Coordinates:      coordinates,
-		Interpolation:    interpolation,
+		GenericFenceRequest: GenericFenceRequest{
+			CoordinateSystem: coordinateSystem,
+			Coordinates:      coordinates,
+			Interpolation:    interpolation,
+		},
 	}
 }
 

--- a/api/request_test.go
+++ b/api/request_test.go
@@ -14,8 +14,8 @@ func newSliceRequest(
 ) SliceRequest {
 	return SliceRequest{
 		RequestedResource: RequestedResource{
-			Vds: vds,
-			Sas: sas,
+			Vds: []string{vds},
+			Sas: []string{sas},
 		},
 		Direction: direction,
 		Lineno:    &lineno,
@@ -31,8 +31,8 @@ func newFenceRequest(
 ) FenceRequest {
 	return FenceRequest{
 		RequestedResource: RequestedResource{
-			Vds: vds,
-			Sas: sas,
+			Vds: []string{vds},
+			Sas: []string{sas},
 		},
 		CoordinateSystem: coordinateSystem,
 		Coordinates:      coordinates,
@@ -45,8 +45,8 @@ func newRequestedResource(
 	sas string,
 ) RequestedResource {
 	return RequestedResource{
-		Vds: vds,
-		Sas: sas,
+		Vds: []string{vds},
+		Sas: []string{sas},
 	}
 }
 
@@ -233,7 +233,9 @@ func TestExtractSasFromUrl(t *testing.T) {
 			require.ErrorContains(t, err, testCase.expected)
 		} else {
 			require.NoError(t, err)
-			require.Equal(t, testCase.expected, testCase.request.Sas)
+			for i := 0; i < len(testCase.request.Sas); i++ {
+				require.Equal(t, testCase.expected, testCase.request.Sas[i])
+			}
 		}
 	}
 }
@@ -263,6 +265,8 @@ func TestPortPresenceInURL(t *testing.T) {
 	for _, testCase := range testCases {
 		err := testCase.request.NormalizeConnection()
 		require.NoError(t, err)
-		require.Equal(t, testCase.expected, testCase.request.Vds)
+		for i := 0; i < len(testCase.request.Sas); i++ {
+			require.Equal(t, testCase.expected, testCase.request.Vds[i])
+		}
 	}
 }

--- a/cmd/query/formats_test.go
+++ b/cmd/query/formats_test.go
@@ -29,10 +29,10 @@ func TestSupportedFormats(t *testing.T) {
 				expectedStatus: http.StatusOK,
 			},
 			testSliceRequest{
-				Vds:       fmt.Sprintf(formatFile, format),
+				Vds:       []string{fmt.Sprintf(formatFile, format)},
 				Direction: "i",
 				Lineno:    1,
-				Sas:       "n/a",
+				Sas:       []string{"n/a"},
 			},
 		}
 		fenceTest := fenceTest{
@@ -43,10 +43,10 @@ func TestSupportedFormats(t *testing.T) {
 			},
 
 			testFenceRequest{
-				Vds:              fmt.Sprintf(formatFile, format),
+				Vds:              []string{fmt.Sprintf(formatFile, format)},
 				CoordinateSystem: "ij",
 				Coordinates:      [][]float32{{1, 0}, {1, 1}},
-				Sas:              "n/a",
+				Sas:              []string{"n/a"},
 			},
 		}
 
@@ -103,9 +103,9 @@ func TestSupportedFormatsHorizon(t *testing.T) {
 			},
 
 			testAttributeAlongSurfaceRequest{
-				Vds:        fmt.Sprintf(formatFile, format),
+				Vds:        []string{fmt.Sprintf(formatFile, format)},
 				Values:     [][]float32{{20}},
-				Sas:        "n/a",
+				Sas:        []string{"n/a"},
 				Above:      8.0,
 				Below:      8.0,
 				Attributes: []string{"samplevalue", "min", "max"},

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -125,7 +125,7 @@ func parseopts() opts {
 			"different port than the server itself. This allows for them to be kept\n"+
 			"private, if desirable. Defaults to 8081.\n"+
 			"Ignored if metrics are not turned on. (see --metrics)\n"+
-			"Can also be set by enviroment variable 'VDSSLICE_METRICS_PORT'",
+			"Can also be set by environment variable 'VDSSLICE_METRICS_PORT'",
 		"int",
 	)
 
@@ -199,7 +199,7 @@ func main() {
 		 * Host the /metrics endpoint on a different app instance. This is needed
 		 * in order to serve it on a different port, while also giving some benefits
 		 * such that our main app server's logs doesn't get polluted by tools that
-		 * are continually scarping the /metrics endpoint. I.e. graphana.
+		 * are continually scarping the /metrics endpoint. I.e. Grafana.
 		 */
 		metricsApp := gin.New()
 		metricsApp.SetTrustedProxies(nil)

--- a/cmd/query/main_test.go
+++ b/cmd/query/main_test.go
@@ -20,10 +20,10 @@ func TestSliceHappyHTTPResponse(t *testing.T) {
 				expectedStatus: http.StatusOK,
 			},
 			testSliceRequest{
-				Vds:       well_known,
+				Vds:       []string{well_known},
 				Direction: "i",
 				Lineno:    0, //side-effect assurance that 0 is accepted
-				Sas:       "n/a",
+				Sas:       []string{"n/a"},
 				Bounds: []testBound{
 					{Direction: "inline", Lower: 1, Upper: 3},
 				},
@@ -36,10 +36,10 @@ func TestSliceHappyHTTPResponse(t *testing.T) {
 				expectedStatus: http.StatusOK,
 			},
 			testSliceRequest{
-				Vds:       well_known,
+				Vds:       []string{well_known},
 				Direction: "crossline",
 				Lineno:    10,
-				Sas:       "n/a",
+				Sas:       []string{"n/a"},
 				Bounds: []testBound{
 					{Direction: "inline", Lower: 1, Upper: 3},
 				},
@@ -132,8 +132,8 @@ func TestSliceErrorHTTPResponse(t *testing.T) {
 			baseTest{
 				name:   "Missing parameters GET request",
 				method: http.MethodGet,
-				jsonRequest: "{\"vds\":\"" + well_known +
-					"\", \"direction\":\"i\", \"sas\": \"n/a\"}",
+				jsonRequest: "{\"vds\":[\"" + well_known +
+					"\"], \"direction\":\"i\", \"sas\": [\"n/a\"]}",
 				expectedStatus: http.StatusBadRequest,
 				expectedError:  "Error:Field validation for 'Lineno'",
 			},
@@ -143,8 +143,8 @@ func TestSliceErrorHTTPResponse(t *testing.T) {
 			baseTest{
 				name:   "Missing parameters POST Request",
 				method: http.MethodPost,
-				jsonRequest: "{\"vds\":\"" + well_known +
-					"\", \"lineno\":1, \"sas\": \"n/a\"}",
+				jsonRequest: "{\"vds\":[\"" + well_known +
+					"\"], \"lineno\":1, \"sas\": [\"n/a\"]}",
 				expectedStatus: http.StatusBadRequest,
 				expectedError:  "Error:Field validation for 'Direction'",
 			},
@@ -154,8 +154,8 @@ func TestSliceErrorHTTPResponse(t *testing.T) {
 			baseTest{
 				name:   "Incomplete bounds parameters POST Request",
 				method: http.MethodPost,
-				jsonRequest: "{\"vds\":\"" + well_known +
-					"\", \"lineno\":1, \"direction\": \"i\", \"sas\": \"n/a\", " +
+				jsonRequest: "{\"vds\":[\"" + well_known +
+					"\"], \"lineno\":1, \"direction\": \"i\", \"sas\": [\"n/a\"], " +
 					"\"bounds\": [{\"Upper\": 2 }]}",
 				expectedStatus: http.StatusBadRequest,
 				expectedError:  "Error:Field validation for 'Direction'",
@@ -170,10 +170,10 @@ func TestSliceErrorHTTPResponse(t *testing.T) {
 				expectedError:  "invalid direction 'unknown', valid options are",
 			},
 			testSliceRequest{
-				Vds:       well_known,
+				Vds:       []string{well_known},
 				Direction: "unknown",
 				Lineno:    1,
-				Sas:       "n/a",
+				Sas:       []string{"n/a"},
 			},
 		},
 		sliceTest{
@@ -184,10 +184,10 @@ func TestSliceErrorHTTPResponse(t *testing.T) {
 				expectedError:  "Invalid lineno: 10, valid range: [0:2:1]",
 			},
 			testSliceRequest{
-				Vds:       well_known,
+				Vds:       []string{well_known},
 				Direction: "i",
 				Lineno:    10,
-				Sas:       "n/a",
+				Sas:       []string{"n/a"},
 			},
 		},
 		sliceTest{
@@ -198,10 +198,10 @@ func TestSliceErrorHTTPResponse(t *testing.T) {
 				expectedError:  "Could not open VDS",
 			},
 			testSliceRequest{
-				Vds:       "unknown",
+				Vds:       []string{"unknown"},
 				Direction: "i",
 				Lineno:    1,
-				Sas:       "n/a",
+				Sas:       []string{"n/a"},
 			},
 		},
 	}
@@ -218,11 +218,11 @@ func TestFenceHappyHTTPResponse(t *testing.T) {
 			},
 
 			testFenceRequest{
-				Vds:              well_known,
+				Vds:              []string{well_known},
 				CoordinateSystem: "ilxl",
 				Coordinates:      [][]float32{{3, 11}, {2, 10}},
 				FillValue:        float32(-999.25),
-				Sas:              "n/a",
+				Sas:              []string{"n/a"},
 			},
 		},
 		{
@@ -233,11 +233,11 @@ func TestFenceHappyHTTPResponse(t *testing.T) {
 			},
 
 			testFenceRequest{
-				Vds:              well_known,
+				Vds:              []string{well_known},
 				CoordinateSystem: "ij",
 				Coordinates:      [][]float32{{0, 1}, {1, 1}, {1, 0}},
 				FillValue:        float32(-999.25),
-				Sas:              "n/a",
+				Sas:              []string{"n/a"},
 			},
 		},
 	}
@@ -301,9 +301,10 @@ func TestFenceErrorHTTPResponse(t *testing.T) {
 			baseTest{
 				name:   "Missing parameters GET request",
 				method: http.MethodGet,
-				jsonRequest: "{\"vds\":\"" + well_known +
-					"\", \"coordinateSystem\":\"ilxl\"," +
+				jsonRequest: "{\"vds\":[\"" + well_known +
+					"\"], \"coordinateSystem\":\"ilxl\"," +
 					"\"fillValue\": -999.25," +
+					"\"sas\": [\"\"], " +
 					"\"coordinates\":[[0, 0]]}",
 				expectedStatus: http.StatusBadRequest,
 				expectedError:  "No valid Sas token is found",
@@ -314,10 +315,10 @@ func TestFenceErrorHTTPResponse(t *testing.T) {
 			baseTest{
 				name:   "Missing parameters POST Request",
 				method: http.MethodPost,
-				jsonRequest: "{\"vds\":\"" + well_known +
-					"\", \"coordinateSystem\":\"ilxl\"," +
+				jsonRequest: "{\"vds\":[\"" + well_known +
+					"\"], \"coordinateSystem\":\"ilxl\"," +
 					"\"fillValue\": -999.25," +
-					"\"sas\": \"n/a\"}",
+					"\"sas\": [\"n/a\"]}",
 				expectedStatus: http.StatusBadRequest,
 				expectedError:  "Error:Field validation for 'Coordinates'",
 			},
@@ -331,10 +332,10 @@ func TestFenceErrorHTTPResponse(t *testing.T) {
 				expectedError:  "coordinate system not recognized: 'unknown', valid options are",
 			},
 			testFenceRequest{
-				Vds:              well_known,
+				Vds:              []string{well_known},
 				CoordinateSystem: "unknown",
 				Coordinates:      [][]float32{{3, 12}, {2, 10}},
-				Sas:              "n/a",
+				Sas:              []string{"n/a"},
 			},
 		},
 		fenceTest{
@@ -345,10 +346,10 @@ func TestFenceErrorHTTPResponse(t *testing.T) {
 				expectedError:  "invalid coordinate [2 10 3 4] at position 2, expected [x y] pair",
 			},
 			testFenceRequest{
-				Vds:              well_known,
+				Vds:              []string{well_known},
 				CoordinateSystem: "cdp",
 				Coordinates:      [][]float32{{3, 1001}, {200, 10}, {2, 10, 3, 4}, {1, 1}},
-				Sas:              "n/a",
+				Sas:              []string{"n/a"},
 			},
 		},
 		fenceTest{
@@ -359,10 +360,10 @@ func TestFenceErrorHTTPResponse(t *testing.T) {
 				expectedError:  "Could not open VDS",
 			},
 			testFenceRequest{
-				Vds:              "unknown",
+				Vds:              []string{"unknown"},
 				CoordinateSystem: "ilxl",
 				Coordinates:      [][]float32{{3, 12}, {2, 10}},
-				Sas:              "n/a",
+				Sas:              []string{"n/a"},
 			},
 		},
 	}
@@ -379,8 +380,8 @@ func TestMetadataHappyHTTPResponse(t *testing.T) {
 				expectedStatus: http.StatusOK,
 			},
 			testMetadataRequest{
-				Vds: well_known,
-				Sas: "n/a",
+				Vds: []string{well_known},
+				Sas: []string{"n/a"},
 			},
 		},
 		{
@@ -390,8 +391,8 @@ func TestMetadataHappyHTTPResponse(t *testing.T) {
 				expectedStatus: http.StatusOK,
 			},
 			testMetadataRequest{
-				Vds: well_known,
-				Sas: "n/a",
+				Vds: []string{well_known},
+				Sas: []string{"n/a"},
 			},
 		},
 	}
@@ -470,7 +471,7 @@ func TestMetadataErrorHTTPResponse(t *testing.T) {
 			baseTest{
 				name:           "Missing parameters GET request",
 				method:         http.MethodGet,
-				jsonRequest:    "{\"vds\":\"" + well_known + "\"}",
+				jsonRequest:    "{\"vds\":[\"" + well_known + "\"], \"sas\":[\"\"]}",
 				expectedStatus: http.StatusBadRequest,
 				expectedError:  "No valid Sas token is found",
 			}, testMetadataRequest{},
@@ -479,7 +480,7 @@ func TestMetadataErrorHTTPResponse(t *testing.T) {
 			baseTest{
 				name:           "Missing parameters POST Request",
 				method:         http.MethodPost,
-				jsonRequest:    "{\"sas\":\"somevalidsas\"}",
+				jsonRequest:    "{\"sas\":[\"somevalidsas\"]}",
 				expectedStatus: http.StatusBadRequest,
 				expectedError:  "Error:Field validation for 'Vds'",
 			}, testMetadataRequest{},
@@ -493,8 +494,8 @@ func TestMetadataErrorHTTPResponse(t *testing.T) {
 			},
 
 			testMetadataRequest{
-				Vds: "unknown",
-				Sas: "n/a",
+				Vds: []string{"unknown"},
+				Sas: []string{"n/a"},
 			},
 		},
 	}
@@ -510,9 +511,9 @@ func TestAttributeOutOfBounds(t *testing.T) {
 				expectedStatus: status,
 			},
 			testAttributeAlongSurfaceRequest{
-				Vds:        samples10,
+				Vds:        []string{samples10},
 				Values:     [][]float32{{20}},
-				Sas:        "n/a",
+				Sas:        []string{"n/a"},
 				Above:      above,
 				Below:      below,
 				StepSize:   stepsize,
@@ -546,9 +547,9 @@ func TestAttributeHappyHTTPResponse(t *testing.T) {
 			},
 
 			testAttributeAlongSurfaceRequest{
-				Vds:        samples10,
+				Vds:        []string{samples10},
 				Values:     [][]float32{{20, 20}, {20, 20}, {20, 20}},
-				Sas:        "n/a",
+				Sas:        []string{"n/a"},
 				Above:      8.0,
 				Below:      4.0,
 				Attributes: []string{"samplevalue"},
@@ -562,10 +563,10 @@ func TestAttributeHappyHTTPResponse(t *testing.T) {
 			},
 
 			testAttributeBetweenSurfacesRequest{
-				Vds:             samples10,
+				Vds:             []string{samples10},
 				ValuesPrimary:   [][]float32{{20, 20}, {20, 20}, {20, 20}},
 				ValuesSecondary: [][]float32{{20, 20}, {20, 20}, {20, 20}},
-				Sas:             "n/a",
+				Sas:             []string{"n/a"},
 				Attributes:      []string{"samplevalue"},
 			},
 		},
@@ -622,8 +623,8 @@ func TestAttributeErrorHTTPResponse(t *testing.T) {
 			baseTest{
 				name:   "Along: Missing parameters POST Request",
 				method: http.MethodPost,
-				jsonRequest: "{\"vds\":\"" + well_known +
-					"\", \"interpolation\":\"cubic\", \"sas\": \"n/a\"}",
+				jsonRequest: "{\"vds\":[\"" + well_known +
+					"\"], \"interpolation\":\"cubic\", \"sas\": [\"n/a\"]}",
 				expectedStatus: http.StatusBadRequest,
 				expectedError:  "Error:Field validation for",
 			},
@@ -633,8 +634,8 @@ func TestAttributeErrorHTTPResponse(t *testing.T) {
 			baseTest{
 				name:   "Between: Missing parameters POST Request",
 				method: http.MethodPost,
-				jsonRequest: "{\"vds\":\"" + well_known +
-					"\", \"interpolation\":\"cubic\", \"sas\": \"n/a\"}",
+				jsonRequest: "{\"vds\":[\"" + well_known +
+					"\"], \"interpolation\":\"cubic\", \"sas\": [\"n/a\"]}",
 				expectedStatus: http.StatusBadRequest,
 				expectedError:  "Error:Field validation for",
 			},
@@ -648,9 +649,9 @@ func TestAttributeErrorHTTPResponse(t *testing.T) {
 				expectedError:  "invalid interpolation method",
 			},
 			testAttributeAlongSurfaceRequest{
-				Vds:           well_known,
+				Vds:           []string{well_known},
 				Values:        [][]float32{{4, 4}, {4, 4}, {4, 4}},
-				Sas:           "n/a",
+				Sas:           []string{"n/a"},
 				Interpolation: "unsupported",
 				Attributes:    []string{"samplevalue"},
 			},
@@ -663,10 +664,10 @@ func TestAttributeErrorHTTPResponse(t *testing.T) {
 				expectedError:  "invalid interpolation method",
 			},
 			testAttributeBetweenSurfacesRequest{
-				Vds:             well_known,
+				Vds:             []string{well_known},
 				ValuesPrimary:   [][]float32{{4, 4}, {4, 4}, {4, 4}},
 				ValuesSecondary: [][]float32{{4, 4}, {4, 4}, {4, 4}},
-				Sas:             "n/a",
+				Sas:             []string{"n/a"},
 				Interpolation:   "unsupported",
 				Attributes:      []string{"samplevalue"},
 			},
@@ -679,9 +680,9 @@ func TestAttributeErrorHTTPResponse(t *testing.T) {
 				expectedError:  "Could not open VDS",
 			},
 			testAttributeAlongSurfaceRequest{
-				Vds:        "unknown",
+				Vds:        []string{"unknown"},
 				Values:     [][]float32{{4, 4}, {4, 4}, {4, 4}},
-				Sas:        "n/a",
+				Sas:        []string{"n/a"},
 				Attributes: []string{"samplevalue"},
 			},
 		},
@@ -693,10 +694,10 @@ func TestAttributeErrorHTTPResponse(t *testing.T) {
 				expectedError:  "Could not open VDS",
 			},
 			testAttributeBetweenSurfacesRequest{
-				Vds:             "unknown",
+				Vds:             []string{"unknown"},
 				ValuesPrimary:   [][]float32{{4, 4}, {4, 4}, {4, 4}},
 				ValuesSecondary: [][]float32{{4, 4}, {4, 4}, {4, 4}},
-				Sas:             "n/a",
+				Sas:             []string{"n/a"},
 				Attributes:      []string{"samplevalue"},
 			},
 		},
@@ -715,10 +716,10 @@ func TestLogHasNoSas(t *testing.T) {
 				expectedStatus: http.StatusOK,
 			},
 			testSliceRequest{
-				Vds:       well_known,
+				Vds:       []string{well_known},
 				Direction: "crossline",
 				Lineno:    10,
-				Sas:       "SPARTA...T14:43:29Z%26se=2023",
+				Sas:       []string{"SPARTA...T14:43:29Z%26se=2023"},
 			},
 		}
 
@@ -729,8 +730,8 @@ func TestLogHasNoSas(t *testing.T) {
 				expectedStatus: http.StatusInternalServerError,
 			},
 			testMetadataRequest{
-				Vds: "unknown",
-				Sas: "SPARTA...T14:43:29Z%26se=2023...",
+				Vds: []string{"unknown"},
+				Sas: []string{"SPARTA...T14:43:29Z%26se=2023..."},
 			},
 		}
 

--- a/cmd/query/utils_main_test.go
+++ b/cmd/query/utils_main_test.go
@@ -229,29 +229,29 @@ type testBound struct {
 }
 
 type testSliceRequest struct {
-	Vds       string      `json:"vds"`
+	Vds       []string    `json:"vds"`
 	Direction string      `json:"direction"`
 	Lineno    int         `json:"lineno"`
-	Sas       string      `json:"sas"`
+	Sas       []string    `json:"sas"`
 	Bounds    []testBound `json:"bounds"`
 }
 
 type testFenceRequest struct {
-	Vds              string      `json:"vds"`
+	Vds              []string    `json:"vds"`
 	CoordinateSystem string      `json:"coordinateSystem"`
 	Coordinates      [][]float32 `json:"coordinates"`
 	FillValue        float32     `json:"fillValue"`
-	Sas              string      `json:"sas"`
+	Sas              []string    `json:"sas"`
 }
 
 type testMetadataRequest struct {
-	Vds string `json:"vds"`
-	Sas string `json:"sas"`
+	Vds []string `json:"vds"`
+	Sas []string `json:"sas"`
 }
 
 type testAttributeAlongSurfaceRequest struct {
-	Vds           string
-	Sas           string
+	Vds           []string
+	Sas           []string
 	Values        [][]float32
 	Interpolation string
 	Above         float32
@@ -261,8 +261,8 @@ type testAttributeAlongSurfaceRequest struct {
 }
 
 type testAttributeBetweenSurfacesRequest struct {
-	Vds             string
-	Sas             string
+	Vds             []string
+	Sas             []string
 	ValuesPrimary   [][]float32
 	ValuesSecondary [][]float32
 	Interpolation   string

--- a/internal/core/capi.cpp
+++ b/internal/core/capi.cpp
@@ -67,6 +67,34 @@ int single_datasource_new(
     }
 }
 
+int double_datasource_new(
+    Context* ctx,
+    const char* url_A,
+    const char* credentials_A,
+    const char* url_B,
+    const char* credentials_B,
+    const char* function,
+    DataSource** datasource
+){
+    try {
+        if (not datasource) throw detail::nullptr_error("Invalid out pointer");
+
+        void (*binary_operator)(float*, const float*, size_t) noexcept(true);
+
+        if (function == nullptr) throw detail::nullptr_error("Invalid function");
+        else if (strcmp(function, "SUBTRACTION") == 0) binary_operator = &inplace_subtraction;
+        else if (strcmp(function, "ADDITION") == 0) binary_operator = &inplace_addition;
+        else if (strcmp(function, "MULTIPLICATION") == 0) binary_operator = &inplace_multiplication;
+        else if (strcmp(function, "DIVISION") == 0) binary_operator = &inplace_division;
+        else throw detail::bad_request("Invalid function");
+
+        *datasource = make_double_datasource(url_A, credentials_A, url_B, credentials_B, binary_operator);
+        return STATUS_OK;
+    } catch (...) {
+        return handle_exception(ctx, std::current_exception());
+    }
+}
+
 int datasource_free(Context* ctx, DataSource* ds){
     try {
         if (not ds) return STATUS_OK;

--- a/internal/core/capi.h
+++ b/internal/core/capi.h
@@ -19,7 +19,7 @@ enum status_code {
  *
  * Any function that accepts a context as one of its input parameters can use
  * it to write additional information that might be of use to the caller. This
- * includes, but is not limited, to writting error messages into the context if
+ * includes, but is not limited, to writing error messages into the context if
  * the function should fail. In that case the caller can call errmsg(Context*
  * ctx) to retrieve the error message.
  */

--- a/internal/core/capi.h
+++ b/internal/core/capi.h
@@ -51,6 +51,15 @@ int single_datasource_new(
     DataSource** ds_out
 );
 
+int double_datasource_new(
+    Context* ctx,
+    const char* url_A,
+    const char* credentials_A,
+    const char* url_B,
+    const char* credentials_B,
+    const char* function,
+    DataSource** ds_out
+);
 
 int datasource_free(Context* ctx, DataSource* f);
 

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -55,7 +55,7 @@ type Axis struct {
 	Unit string `json:"unit" example:"ms"`
 } // @name Axis
 
-// @Description Geometrical plane with depth/time datapoints
+// @Description Geometrical plane with depth/time data points
 type RegularSurface struct {
 	// Values / height-map
 	Values [][]float32 `json:"values" binding:"required"`
@@ -95,7 +95,7 @@ type BoundingBox struct {
 } //@name BoundingBox
 
 type Array struct {
-	// Data format is represented by numpy-style formatcodes. Currently the
+	// Data format is represented by numpy-style format codes. Currently the
 	// format is always 4-byte floats, little endian (<f4).
 	Format string `json:"format" example:"<f4"`
 

--- a/internal/core/core_attributes_test.go
+++ b/internal/core/core_attributes_test.go
@@ -151,9 +151,9 @@ func TestSurfaceWindowVerticalBounds(t *testing.T) {
 }
 
 /**
- * The goal of this test is to test that the boundschecking in the horizontal
+ * The goal of this test is to test that the bounds checking in the horizontal
  * plane is correct - i.e. that we correctly populate the output array with
- * fillvalues. To acheive this we create horizons that are based on the VDS's
+ * fillvalues. To achieve this we create horizons that are based on the VDS's
  * bingrid and then translated them in the XY-domain (by moving around the
  * origin of the horizon).
  *

--- a/internal/core/core_attributes_test.go
+++ b/internal/core/core_attributes_test.go
@@ -46,7 +46,7 @@ func TestSurfaceUnalignedWithSeismic(t *testing.T) {
 
 	interpolationMethod, _ := GetInterpolationMethod("nearest")
 
-	handle, _ := NewDSHandle(samples10)
+	handle, _ := NewDSHandle(samples10, "")
 	defer handle.Close()
 	buf, err := handle.GetAttributesAlongSurface(
 		surface,
@@ -120,7 +120,7 @@ func TestSurfaceWindowVerticalBounds(t *testing.T) {
 	for _, testcase := range testcases {
 		surface := samples10Surface(testcase.values)
 		interpolationMethod, _ := GetInterpolationMethod("nearest")
-		handle, _ := NewDSHandle(samples10)
+		handle, _ := NewDSHandle(samples10, "")
 		defer handle.Close()
 		_, boundsErr := handle.GetAttributesAlongSurface(
 			surface,
@@ -267,7 +267,7 @@ func TestSurfaceHorizontalBounds(t *testing.T) {
 			Yinc:      float32(yinc),
 			FillValue: &fillValue,
 		}
-		handle, _ := NewDSHandle(samples10)
+		handle, _ := NewDSHandle(samples10, "")
 		defer handle.Close()
 		buf, err := handle.GetAttributesAlongSurface(
 			surface,
@@ -352,7 +352,7 @@ func TestAttribute(t *testing.T) {
 	const below = float32(8.0)
 	const stepsize = float32(4.0)
 
-	handle, _ := NewDSHandle(samples10)
+	handle, _ := NewDSHandle(samples10, "")
 	defer handle.Close()
 	buf, err := handle.GetAttributesAlongSurface(
 		surface,
@@ -404,7 +404,7 @@ func TestAttributeMedianForEvenSampleValue(t *testing.T) {
 	const below = float32(4.0)
 	const stepsize = float32(4.0)
 
-	handle, _ := NewDSHandle(samples10)
+	handle, _ := NewDSHandle(samples10, "")
 	defer handle.Close()
 	buf, err := handle.GetAttributesAlongSurface(
 		surface,
@@ -478,7 +478,7 @@ func TestAttributesAboveBelowStepSizeIgnoredForSampleValue(t *testing.T) {
 	surface := samples10Surface(values)
 
 	for _, testCase := range testCases {
-		handle, _ := NewDSHandle(samples10)
+		handle, _ := NewDSHandle(samples10, "")
 		defer handle.Close()
 		buf, err := handle.GetAttributesAlongSurface(
 			surface,
@@ -599,7 +599,7 @@ func TestAttributeSubsamplingAligned(t *testing.T) {
 	surface := samples10Surface(values)
 
 	for _, testCase := range testCases {
-		handle, _ := NewDSHandle(samples10)
+		handle, _ := NewDSHandle(samples10, "")
 		defer handle.Close()
 		buf, err := handle.GetAttributesAlongSurface(
 			surface,
@@ -685,7 +685,7 @@ func TestAttributesUnalignedAndSubsampled(t *testing.T) {
 
 	surface := samples10Surface(values)
 
-	handle, _ := NewDSHandle(samples10)
+	handle, _ := NewDSHandle(samples10, "")
 	defer handle.Close()
 	buf, err := handle.GetAttributesAlongSurface(
 		surface,
@@ -794,7 +794,7 @@ func TestAttributesUnaligned(t *testing.T) {
 
 		surface := samples10Surface(values)
 
-		handle, _ := NewDSHandle(samples10)
+		handle, _ := NewDSHandle(samples10, "")
 		defer handle.Close()
 		buf, err := handle.GetAttributesAlongSurface(
 			surface,
@@ -847,7 +847,7 @@ func TestAttributesSupersampling(t *testing.T) {
 
 	surface := samples10Surface(values)
 
-	handle, _ := NewDSHandle(samples10)
+	handle, _ := NewDSHandle(samples10, "")
 	defer handle.Close()
 	buf, err := handle.GetAttributesAlongSurface(
 		surface,
@@ -896,7 +896,7 @@ func TestAttributesEverythingUnaligned(t *testing.T) {
 
 	surface := samples10Surface(values)
 
-	handle, _ := NewDSHandle(samples10)
+	handle, _ := NewDSHandle(samples10, "")
 	defer handle.Close()
 	buf, err := handle.GetAttributesAlongSurface(
 		surface,
@@ -953,7 +953,7 @@ func TestInvalidAboveBelow(t *testing.T) {
 	for _, testcase := range testcases {
 		surface := samples10Surface(values)
 		interpolationMethod, _ := GetInterpolationMethod("nearest")
-		handle, _ := NewDSHandle(samples10)
+		handle, _ := NewDSHandle(samples10, "")
 		defer handle.Close()
 		_, boundsErr := handle.GetAttributesAlongSurface(
 			surface,
@@ -986,7 +986,7 @@ func TestAttributeMetadata(t *testing.T) {
 		},
 	}
 
-	handle, _ := NewDSHandle(well_known)
+	handle, _ := NewDSHandle(well_known, "")
 	defer handle.Close()
 	buf, err := handle.GetAttributeMetadata(values)
 	require.NoErrorf(t, err, "Failed to retrieve attribute metadata, err %v", err)
@@ -1063,7 +1063,7 @@ func TestAttributeBetweenSurfaces(t *testing.T) {
 
 	interpolationMethod, _ := GetInterpolationMethod("nearest")
 
-	handle, _ := NewDSHandle(samples10)
+	handle, _ := NewDSHandle(samples10, "")
 	defer handle.Close()
 
 	for _, testcase := range testcases {
@@ -1114,7 +1114,7 @@ func TestAttributesInconsistentLength(t *testing.T) {
 	goodSurface := samples10Surface(goodValues)
 	badSurface := samples10Surface(badValues)
 
-	handle, _ := NewDSHandle(samples10)
+	handle, _ := NewDSHandle(samples10, "")
 	defer handle.Close()
 
 	_, err := handle.GetAttributesAlongSurface(
@@ -1157,7 +1157,7 @@ func TestAttributesAllFill(t *testing.T) {
 	fillSurface := samples10Surface(fillValues)
 	expected := []float32{fillValue, fillValue, fillValue, fillValue, fillValue, fillValue}
 
-	handle, _ := NewDSHandle(samples10)
+	handle, _ := NewDSHandle(samples10, "")
 	defer handle.Close()
 
 	bufAlong, err := handle.GetAttributesAlongSurface(

--- a/internal/core/core_fence_test.go
+++ b/internal/core/core_fence_test.go
@@ -275,7 +275,7 @@ func TestInvalidFence(t *testing.T) {
 // interpolation method. So we have to trust openvds on this.
 //
 // But we can check that we use openvds correctly by checking interpolated data
-// at known datapoints. Openvds claims that data would still be the same for all
+// at known data points. Openvds claims that data would still be the same for all
 // interpolation algorithms [1].
 //
 // We had a bug that caused cubic and linear return incorrect values. So this is
@@ -308,7 +308,7 @@ func TestFenceInterpolationSameAtDataPoints(t *testing.T) {
 	}
 }
 
-// Also, as we can't check interpolation properly, check that beyond datapoints
+// Also, as we can't check interpolation properly, check that beyond data points
 // different values are returned by each algorithm
 func TestFenceInterpolationDifferentBeyondDatapoints(t *testing.T) {
 	fence := [][]float32{{3.2, 3}, {3.2, 6.3}, {1, 3}, {3.2, 3}, {5.4, 3}}

--- a/internal/core/core_fence_test.go
+++ b/internal/core/core_fence_test.go
@@ -39,7 +39,7 @@ func TestFence(t *testing.T) {
 	interpolationMethod, _ := GetInterpolationMethod("nearest")
 
 	for _, testcase := range testcases {
-		handle, _ := NewDSHandle(well_known)
+		handle, _ := NewDSHandle(well_known, "")
 		defer handle.Close()
 		buf, err := handle.GetFence(
 			testcase.coordinate_system,
@@ -103,7 +103,7 @@ func TestFenceBorders(t *testing.T) {
 
 	for _, testcase := range testcases {
 		interpolationMethod, _ := GetInterpolationMethod("linear")
-		handle, _ := NewDSHandle(well_known)
+		handle, _ := NewDSHandle(well_known, "")
 		defer handle.Close()
 		_, err := handle.GetFence(testcase.coordinate_system, testcase.coordinates, interpolationMethod, nil)
 
@@ -154,7 +154,7 @@ func TestFenceBordersWithFillValue(t *testing.T) {
 	var fillValue float32 = -999.25
 	for _, testcase := range testcases {
 		interpolationMethod, _ := GetInterpolationMethod("linear")
-		handle, _ := NewDSHandle(well_known)
+		handle, _ := NewDSHandle(well_known, "")
 		defer handle.Close()
 		buf, err := handle.GetFence(
 			testcase.crd_system,
@@ -233,7 +233,7 @@ func TestFenceNearestInterpolationSnap(t *testing.T) {
 	interpolationMethod, _ := GetInterpolationMethod("nearest")
 
 	for _, testcase := range testcases {
-		handle, _ := NewDSHandle(well_known)
+		handle, _ := NewDSHandle(well_known, "")
 		defer handle.Close()
 		buf, err := handle.GetFence(
 			testcase.coordinate_system,
@@ -261,7 +261,7 @@ func TestInvalidFence(t *testing.T) {
 
 	var fillValue float32 = -999.25
 	interpolationMethod, _ := GetInterpolationMethod("nearest")
-	handle, _ := NewDSHandle(well_known)
+	handle, _ := NewDSHandle(well_known, "")
 	defer handle.Close()
 	_, err := handle.GetFence(CoordinateSystemIndex, fence, interpolationMethod, &fillValue)
 
@@ -290,7 +290,7 @@ func TestFenceInterpolationSameAtDataPoints(t *testing.T) {
 	expected := []float32{25.5, 4.5, 8.5, 12.5, 16.5, 20.5, 24.5, 20.5, 16.5, 8.5}
 	interpolationMethods := []string{"nearest", "linear", "cubic", "triangular"}
 
-	handle, _ := NewDSHandle(samples10)
+	handle, _ := NewDSHandle(samples10, "")
 	defer handle.Close()
 	var fillValue float32 = -999.25
 	for _, interpolation := range interpolationMethods {
@@ -316,7 +316,7 @@ func TestFenceInterpolationDifferentBeyondDatapoints(t *testing.T) {
 	interpolationMethods := []string{"nearest", "linear", "cubic", "triangular", "angular"}
 	for i, v1 := range interpolationMethods {
 		interpolationMethod, _ := GetInterpolationMethod(v1)
-		handle, _ := NewDSHandle(well_known)
+		handle, _ := NewDSHandle(well_known, "")
 		defer handle.Close()
 		buf1, _ := handle.GetFence(CoordinateSystemCdp, fence, interpolationMethod, &fillValue)
 		for _, v2 := range interpolationMethods[i+1:] {
@@ -364,7 +364,7 @@ func TestFenceMetadata(t *testing.T) {
 		},
 	}
 
-	handle, _ := NewDSHandle(well_known)
+	handle, _ := NewDSHandle(well_known, "")
 	defer handle.Close()
 	buf, err := handle.GetFenceMetadata(coordinates)
 	require.NoErrorf(t, err, "Failed to retrieve fence metadata, err %v", err)

--- a/internal/core/core_general_test.go
+++ b/internal/core/core_general_test.go
@@ -62,7 +62,7 @@ func samples10Surface(data [][]float32) RegularSurface {
 func toFloat32(buf []byte) (*[]float32, error) {
 	fsize := 4 // sizeof(float32)
 	if len(buf)%fsize != 0 {
-		return nil, errors.New("Invalid buffersize")
+		return nil, errors.New("Invalid buffer size")
 	}
 
 	outlen := len(buf) / 4

--- a/internal/core/core_general_test.go
+++ b/internal/core/core_general_test.go
@@ -16,11 +16,11 @@ func make_connection(name string) Connection {
 	return NewFileConnection(path)
 }
 
-var well_known_custom_axis_order = make_connection("well_known/well_known_custom_axis_order.vds")
-var invalid_axes_names = make_connection("invalid_data/invalid_axes_names.vds")
-var well_known = make_connection("well_known/well_known_default.vds")
-var samples10 = make_connection("10_samples/10_samples_default.vds")
-var prestack = make_connection("prestack/prestack_default.vds")
+var well_known_custom_axis_order = []Connection{make_connection("well_known/well_known_custom_axis_order.vds")}
+var invalid_axes_names = []Connection{make_connection("invalid_data/invalid_axes_names.vds")}
+var well_known = []Connection{make_connection("well_known/well_known_default.vds")}
+var samples10 = []Connection{make_connection("10_samples/10_samples_default.vds")}
+var prestack = []Connection{make_connection("prestack/prestack_default.vds")}
 
 var fillValue = float32(-999.25)
 
@@ -78,7 +78,7 @@ func toFloat32(buf []byte) (*[]float32, error) {
 }
 
 func TestOnly3DSupported(t *testing.T) {
-	handle, err := NewDSHandle(prestack)
+	handle, err := NewDSHandle(prestack, "")
 	if err != nil {
 		handle.Close()
 	}

--- a/internal/core/core_metadata_test.go
+++ b/internal/core/core_metadata_test.go
@@ -24,7 +24,7 @@ func TestMetadata(t *testing.T) {
 		ImportTimeStamp: `^\d{4}-\d{2}-\d{2}[A-Z]\d{2}:\d{2}:\d{2}\.\d{3}[A-Z]$`,
 	}
 
-	handle, _ := NewDSHandle(well_known)
+	handle, _ := NewDSHandle(well_known, "")
 	defer handle.Close()
 	buf, err := handle.GetMetadata()
 	require.NoErrorf(t, err, "Failed to retrieve metadata, err %v", err)
@@ -47,7 +47,7 @@ func TestMetadataCustomAxisOrder(t *testing.T) {
 		{Annotation: "Crossline", Min: 10, Max: 11, Samples: 2, StepSize: 1, Unit: "unitless"},
 		{Annotation: "Sample", Min: 4, Max: 16, Samples: 4, StepSize: 4, Unit: "ms"},
 	}
-	handle, err := NewDSHandle(well_known_custom_axis_order)
+	handle, err := NewDSHandle(well_known_custom_axis_order, "")
 	require.NoErrorf(t, err, "Failed to open vds file")
 
 	defer handle.Close()
@@ -62,6 +62,6 @@ func TestMetadataCustomAxisOrder(t *testing.T) {
 
 func TestMetadataAxesNames(t *testing.T) {
 	expected := "Requested axis not found under names "
-	_, err := NewDSHandle(invalid_axes_names)
+	_, err := NewDSHandle(invalid_axes_names, "")
 	require.ErrorContains(t, err, expected)
 }

--- a/internal/core/core_slice_test.go
+++ b/internal/core/core_slice_test.go
@@ -42,7 +42,7 @@ func TestSliceData(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		handle, _ := NewDSHandle(well_known)
+		handle, _ := NewDSHandle(well_known, "")
 		defer handle.Close()
 		buf, err := handle.GetSlice(
 			testcase.lineno,
@@ -83,7 +83,7 @@ func TestSliceOutOfBounds(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		handle, _ := NewDSHandle(well_known)
+		handle, _ := NewDSHandle(well_known, "")
 		defer handle.Close()
 		_, err := handle.GetSlice(
 			testcase.lineno,
@@ -107,7 +107,7 @@ func TestSliceStepSizedLineno(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		handle, _ := NewDSHandle(well_known)
+		handle, _ := NewDSHandle(well_known, "")
 		defer handle.Close()
 		_, err := handle.GetSlice(
 			testcase.lineno,
@@ -129,7 +129,7 @@ func TestSliceInvalidAxis(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		handle, _ := NewDSHandle(well_known)
+		handle, _ := NewDSHandle(well_known, "")
 		defer handle.Close()
 		_, err := handle.GetSlice(0, testcase.direction, []Bound{})
 
@@ -369,7 +369,7 @@ func TestSliceBounds(t *testing.T) {
 		direction, err := GetAxis(testCase.direction)
 		require.NoError(t, err)
 
-		handle, _ := NewDSHandle(well_known)
+		handle, _ := NewDSHandle(well_known, "")
 		defer handle.Close()
 		buf, err := handle.GetSlice(
 			testCase.lineno,
@@ -448,7 +448,7 @@ func TestDepthAxis(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		handle, _ := NewDSHandle(well_known)
+		handle, _ := NewDSHandle(well_known, "")
 		defer handle.Close()
 		_, err := handle.GetSlice(0, testcase.direction, []Bound{})
 
@@ -468,7 +468,7 @@ func TestSliceMetadata(t *testing.T) {
 		Geospatial: [][]float64{{0, 3}, {12, 11}},
 		Shape:      []int{3, 4},
 	}
-	handle, _ := NewDSHandle(well_known)
+	handle, _ := NewDSHandle(well_known, "")
 	defer handle.Close()
 	buf, err := handle.GetSliceMetadata(lineno, direction, []Bound{})
 	require.NoErrorf(t, err, "Failed to retrieve slice metadata, err %v", err)
@@ -529,7 +529,7 @@ func TestSliceMetadataAxisOrdering(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		handle, _ := NewDSHandle(well_known)
+		handle, _ := NewDSHandle(well_known, "")
 		defer handle.Close()
 		buf, err := handle.GetSliceMetadata(
 			testcase.lineno,
@@ -602,7 +602,7 @@ func TestSliceGeospatial(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		handle, _ := NewDSHandle(well_known)
+		handle, _ := NewDSHandle(well_known, "")
 		defer handle.Close()
 		buf, err := handle.GetSliceMetadata(
 			testcase.lineno,

--- a/tests/e2e/shared_test_functions.py
+++ b/tests/e2e/shared_test_functions.py
@@ -34,26 +34,26 @@ def surface():
 
 def slice_payload(vds=VDS_URL, direction="inline", lineno=3, sas="sas"):
     return {
-        "vds": vds,
+        "vds": [vds],
         "direction": direction,
         "lineno": lineno,
-        "sas": sas
+        "sas": [sas]
     }
 
 
 def fence_payload(vds=VDS_URL, coordinate_system="ij", coordinates=[[0, 0]], sas="sas"):
     return {
-        "vds": vds,
+        "vds": [vds],
         "coordinateSystem": coordinate_system,
         "coordinates": coordinates,
-        "sas": sas
+        "sas": [sas]
     }
 
 
 def metadata_payload(vds=VDS_URL, sas="sas"):
     return {
-        "vds": vds,
-        "sas": sas
+        "vds": [vds],
+        "sas": [sas]
     }
 
 
@@ -75,8 +75,8 @@ def attributes_along_surface_payload(
     request = {
         "surface": regular_surface,
         "interpolation": "nearest",
-        "vds": vds,
-        "sas": sas,
+        "vds": [vds],
+        "sas": [sas],
         "above": above,
         "below": below,
         "attributes": attributes
@@ -108,8 +108,8 @@ def attributes_between_surfaces_payload(
         "primarySurface": primary,
         "secondarySurface": secondary,
         "interpolation": "nearest",
-        "vds": vds,
-        "sas": sas,
+        "vds": [vds],
+        "sas": [sas],
         "stepsize": stepsize,
         "attributes": attributes
     }

--- a/tests/e2e/shared_test_functions.py
+++ b/tests/e2e/shared_test_functions.py
@@ -22,6 +22,17 @@ SAMPLES10_URL = f"{STORAGE_ACCOUNT}/{CONTAINER}/10_samples/10_samples_default"
 def gen_default_sas():
     return generate_container_signature(STORAGE_ACCOUNT_NAME, CONTAINER, STORAGE_ACCOUNT_KEY)
 
+def assert_binary_operation(data:np.ndarray, expected:np.ndarray, binary_operator:str):
+    if binary_operator == "subtraction":
+        assert np.array_equal(data, np.subtract(expected, expected))
+    elif binary_operator == "addition":
+        assert np.array_equal(data, np.add(expected, expected))
+    elif binary_operator == "multiplication":
+        assert np.allclose(data, np.multiply(expected, expected), rtol=1e-05)
+    elif binary_operator == "division":
+        assert np.array_equal(data, np.divide(expected, expected))
+    else:
+        assert np.array_equal(data, expected)
 
 def surface():
     return {
@@ -148,37 +159,37 @@ def request_metadata(method):
     return response_data.json()
 
 
-def request_slice(method, lineno, direction):
+def request_slice(method, lineno, direction, binary_operator=None):
     sas = generate_container_signature(
         STORAGE_ACCOUNT_NAME, CONTAINER, STORAGE_ACCOUNT_KEY)
-    payload = connection_payload(sas=[sas])
+    payload = connection_payload(sas=[sas], binary_operator=binary_operator)
     payload.update(slice_payload(direction, lineno))
     response = send_request("slice", method, payload)
     return process_data_response(response)
 
 
-def request_fence(method: str, coordinate_system: str = "ij", coordinates: list = [[0, 0]]):
+def request_fence(method: str, coordinate_system: str = "ij", coordinates: list = [[0, 0]], binary_operator=None):
     sas = generate_container_signature(
         STORAGE_ACCOUNT_NAME, CONTAINER, STORAGE_ACCOUNT_KEY)
-    payload = connection_payload(sas=[sas])
+    payload = connection_payload(sas=[sas], binary_operator=binary_operator)
     payload.update(fence_payload(coordinate_system, coordinates))
     response = send_request("fence", method, payload)
     return process_data_response(response)
 
 
-def request_attributes_along_surface(method, values):
+def request_attributes_along_surface(method, values, binary_operator=None):
     sas = generate_container_signature(
         STORAGE_ACCOUNT_NAME, CONTAINER, STORAGE_ACCOUNT_KEY)
-    payload = connection_payload(vds=[SAMPLES10_URL], sas=[sas])
+    payload = connection_payload(vds=[SAMPLES10_URL], sas=[sas], binary_operator=binary_operator)
     payload.update(attributes_along_surface_payload(values=values))
     response = send_request("attributes/surface/along", method, payload)
     return process_data_response(response)
 
 
-def request_attributes_between_surfaces(method, primary, secondary):
+def request_attributes_between_surfaces(method, primary, secondary, binary_operator):
     sas = generate_container_signature(
         STORAGE_ACCOUNT_NAME, CONTAINER, STORAGE_ACCOUNT_KEY)
-    payload = connection_payload(vds=[SAMPLES10_URL], sas=[sas])
+    payload = connection_payload(vds=[SAMPLES10_URL], sas=[sas], binary_operator=binary_operator)
     payload.update(attributes_between_surfaces_payload(primary, secondary))
     response = send_request("attributes/surface/between", method, payload)
     return process_data_response(response)

--- a/tests/e2e/test_error_propagation.py
+++ b/tests/e2e/test_error_propagation.py
@@ -43,7 +43,7 @@ from shared_test_functions import *
 def test_errors(path, payload, error_code, error):
     sas = generate_container_signature(
         STORAGE_ACCOUNT_NAME, CONTAINER, STORAGE_ACCOUNT_KEY)
-    payload.update({"sas": sas})
+    payload.update({"sas": [sas]})
     res = send_request(path, "post", payload)
     assert res.status_code == error_code
 

--- a/tests/e2e/test_error_propagation.py
+++ b/tests/e2e/test_error_propagation.py
@@ -10,7 +10,7 @@ from shared_test_functions import *
 @pytest.mark.parametrize("path, payload, error_code, error", [
     (
         "slice",
-        slice_payload(direction="inline", lineno=4),
+        payload_merge(connection_payload(), slice_payload(direction="inline", lineno=4)),
         http.HTTPStatus.BAD_REQUEST,
         "Invalid lineno: 4, valid range: [1.00:5.00:2.00]"
     ),
@@ -22,20 +22,20 @@ from shared_test_functions import *
     ),
     (
         "metadata",
-        metadata_payload(vds=f'{STORAGE_ACCOUNT}/{CONTAINER}/notfound'),
+        connection_payload(vds=[f'{STORAGE_ACCOUNT}/{CONTAINER}/notfound']),
         http.HTTPStatus.INTERNAL_SERVER_ERROR,
         "The specified blob does not exist"
     ),
     (
         "attributes/surface/along",
-        attributes_along_surface_payload(surface={}),
+        payload_merge(connection_payload(), attributes_along_surface_payload(surface={})),
         http.HTTPStatus.BAD_REQUEST,
         "Error:Field validation for"
     ),
     (
         "attributes/surface/between",
-        attributes_between_surfaces_payload(
-            primaryValues=[[1]], secondaryValues=[[1], [1, 1]]),
+        payload_merge(connection_payload(), attributes_between_surfaces_payload(
+            primaryValues=[[1]], secondaryValues=[[1], [1, 1]])),
         http.HTTPStatus.BAD_REQUEST,
         "Surface rows are not of the same length"
     ),

--- a/tests/e2e/test_happy_requests.py
+++ b/tests/e2e/test_happy_requests.py
@@ -68,7 +68,7 @@ def test_slice(method):
     ("post")
 ])
 def test_fence(method):
-    meta, fence = request_fence(method, [[3, 10], [1, 11]], 'ilxl')
+    meta, fence = request_fence(method, 'ilxl', [[3, 10], [1, 11]])
 
     expected = np.array([[108, 109, 110, 111],
                          [104, 105, 106, 107]])

--- a/tests/e2e/test_happy_requests.py
+++ b/tests/e2e/test_happy_requests.py
@@ -44,12 +44,20 @@ def test_metadata(method):
     ("get"),
     ("post")
 ])
-def test_slice(method):
-    meta, slice = request_slice(method, 5, 'inline')
+@pytest.mark.parametrize("binary_operator", [
+    (None),
+    ("subtraction"),
+    ("addition"),
+    ("multiplication"),
+    ("division"),
+])
+def test_slice(method, binary_operator):
+    meta, data = request_slice(method, 5, 'inline', binary_operator)
 
     expected = np.array([[116, 117, 118, 119],
                          [120, 121, 122, 123]])
-    assert np.array_equal(slice, expected)
+
+    assert_binary_operation(data, expected, binary_operator)
 
     expected_meta = json.loads("""
     {
@@ -67,12 +75,21 @@ def test_slice(method):
     ("get"),
     ("post")
 ])
-def test_fence(method):
-    meta, fence = request_fence(method, 'ilxl', [[3, 10], [1, 11]])
+@pytest.mark.parametrize("binary_operator", [
+    (None),
+    ("subtraction"),
+    ("addition"),
+    ("multiplication"),
+    ("division"),
+])
+def test_fence(method, binary_operator):
+    meta, data = request_fence(
+        method, 'ilxl', [[3, 10], [1, 11]], binary_operator)
 
     expected = np.array([[108, 109, 110, 111],
                          [104, 105, 106, 107]])
-    assert np.array_equal(fence, expected)
+
+    assert_binary_operation(data, expected, binary_operator)
 
     expected_meta = json.loads("""
     {
@@ -83,16 +100,25 @@ def test_fence(method):
     assert meta == expected_meta
 
 
-def test_attributes_along_surface():
+@pytest.mark.parametrize("binary_operator", [
+    (None),
+    ("subtraction"),
+    ("addition"),
+    ("multiplication"),
+    ("division"),
+])
+def test_attributes_along_surface(binary_operator):
     values = [
         [20, 20],
         [20, 20],
         [20, 20]
     ]
-    meta, data = request_attributes_along_surface("post", values)
+    meta, data = request_attributes_along_surface(
+        "post", values, binary_operator)
 
     expected = np.array([[-0.5, 0.5], [-8.5, 6.5], [16.5, -16.5]])
-    assert np.array_equal(data, expected)
+
+    assert_binary_operation(data, expected, binary_operator)
 
     expected_meta = json.loads("""
     {
@@ -103,7 +129,14 @@ def test_attributes_along_surface():
     assert meta == expected_meta
 
 
-def test_attributes_between_surfaces():
+@pytest.mark.parametrize("binary_operator", [
+    (None),
+    ("subtraction"),
+    ("addition"),
+    ("multiplication"),
+    ("division"),
+])
+def test_attributes_between_surfaces(binary_operator):
     primary = [
         [12, 12],
         [12, 14],
@@ -115,10 +148,19 @@ def test_attributes_between_surfaces():
         [24,   12]
     ]
     meta, data = request_attributes_between_surfaces(
-        "post", primary, secondary)
+        "post", primary, secondary, binary_operator)
 
     expected = np.array([[1.5, 2.5], [-8.5, 7.5], [18.5, -8.5]])
-    assert np.array_equal(data, expected)
+
+    # Max attribute behaves weird on multiplication.
+    # Taking the square may changes the max point.
+    if binary_operator == "multiplication":
+
+        expected = np.array([[2.5,  2.5],
+                             [12.5,  7.49850595],
+                             [18.50966912,  8.5]])
+
+    assert_binary_operation(data, expected, binary_operator)
 
     expected_meta = json.loads("""
     {

--- a/tests/e2e/test_security.py
+++ b/tests/e2e/test_security.py
@@ -9,11 +9,11 @@ from azure.storage import filedatalake
 
 
 @pytest.mark.parametrize("path, payload", [
-    ("slice", slice_payload()),
-    ("fence", fence_payload()),
-    ("metadata", metadata_payload()),
-    ("attributes/surface/along", attributes_along_surface_payload()),
-    ("attributes/surface/between", attributes_between_surfaces_payload()),
+    ("slice", payload_merge(connection_payload(), slice_payload())),
+    ("fence", payload_merge(connection_payload(), fence_payload())),
+    ("metadata", connection_payload()),
+    ("attributes/surface/along", payload_merge(connection_payload(), attributes_along_surface_payload())),
+    ("attributes/surface/between", payload_merge(connection_payload(), attributes_between_surfaces_payload())),
 ])
 @pytest.mark.parametrize("sas, allowed_error_messages", [
     (
@@ -34,10 +34,10 @@ def test_assure_no_unauthorized_access(path, payload, sas, allowed_error_message
 
 
 @pytest.mark.parametrize("path, payload", [
-    ("slice", slice_payload(vds=VDS_URL)),
-    ("fence", fence_payload(vds=VDS_URL)),
-    ("attributes/surface/along", attributes_along_surface_payload()),
-    ("attributes/surface/between", attributes_between_surfaces_payload()),
+    ("slice", payload_merge(connection_payload(vds=[VDS_URL]), slice_payload())),
+    ("fence", payload_merge(connection_payload(vds=[VDS_URL]), fence_payload())),
+    ("attributes/surface/along", payload_merge(connection_payload([SAMPLES10_URL]), attributes_along_surface_payload())),
+    ("attributes/surface/between", payload_merge(connection_payload([SAMPLES10_URL]), attributes_between_surfaces_payload())),
 ])
 @pytest.mark.parametrize("token, status, error", [
     (generate_container_signature(
@@ -86,11 +86,11 @@ def test_cached_data_access_with_various_sas(path, payload, token, status, error
 
 
 @pytest.mark.parametrize("path, payload", [
-    ("slice", slice_payload()),
-    ("fence", fence_payload()),
-    ("metadata", metadata_payload()),
-    ("attributes/surface/along", attributes_along_surface_payload()),
-    ("attributes/surface/between", attributes_between_surfaces_payload()),
+    ("slice",payload_merge(connection_payload(), slice_payload())),
+    ("fence", payload_merge(connection_payload(), fence_payload())),
+    ("metadata", connection_payload()),
+    ("attributes/surface/along", payload_merge(connection_payload([SAMPLES10_URL]), attributes_along_surface_payload())),
+    ("attributes/surface/between", payload_merge(connection_payload([SAMPLES10_URL]), attributes_between_surfaces_payload())),
 ])
 def test_assure_only_allowed_storage_accounts(path, payload):
     payload.update({
@@ -103,11 +103,11 @@ def test_assure_only_allowed_storage_accounts(path, payload):
 
 
 @pytest.mark.parametrize("path, payload", [
-    ("slice",   slice_payload()),
-    ("fence",   fence_payload()),
-    ("metadata",   metadata_payload()),
-    ("attributes/surface/along", attributes_along_surface_payload()),
-    ("attributes/surface/between", attributes_between_surfaces_payload()),
+    ("slice", payload_merge(connection_payload(), slice_payload())),
+    ("fence",   payload_merge(connection_payload(), fence_payload())),
+    ("metadata",   connection_payload()),
+    ("attributes/surface/along", payload_merge(connection_payload([SAMPLES10_URL]), attributes_along_surface_payload())),
+    ("attributes/surface/between", payload_merge(connection_payload([SAMPLES10_URL]), attributes_between_surfaces_payload())),
 ])
 @pytest.mark.parametrize("vds, sas, expected", [
     (f'{SAMPLES10_URL}?{gen_default_sas()}', '', http.HTTPStatus.OK),

--- a/tests/e2e/test_security.py
+++ b/tests/e2e/test_security.py
@@ -25,7 +25,7 @@ from azure.storage import filedatalake
     )
 ])
 def test_assure_no_unauthorized_access(path, payload, sas, allowed_error_messages):
-    payload.update({"sas": sas})
+    payload.update({"sas": [sas]})
     res = send_request(path, "post", payload)
     assert res.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR
     error_body = json.loads(res.content)['error']
@@ -72,13 +72,13 @@ def test_cached_data_access_with_various_sas(path, payload, token, status, error
             CONTAINER,
             STORAGE_ACCOUNT_KEY,
             permission=blob.ContainerSasPermissions(read=True))
-        payload.update({"sas": container_sas})
+        payload.update({"sas": [container_sas]})
         res = send_request(path, "post", payload)
         assert res.status_code == http.HTTPStatus.OK
 
     make_caching_call()
 
-    payload.update({"sas": token})
+    payload.update({"sas": [token]})
     res = send_request(path, "post", payload)
     assert res.status_code == status
     if error:
@@ -94,7 +94,7 @@ def test_cached_data_access_with_various_sas(path, payload, token, status, error
 ])
 def test_assure_only_allowed_storage_accounts(path, payload):
     payload.update({
-        "vds": "https://dummy.blob.core.windows.net/container/blob",
+        "vds": ["https://dummy.blob.core.windows.net/container/blob"],
     })
     res = send_request(path, "post", payload)
     assert res.status_code == http.HTTPStatus.BAD_REQUEST
@@ -116,8 +116,8 @@ def test_assure_only_allowed_storage_accounts(path, payload):
 ])
 def test_sas_token_in_url(path, payload, vds, sas, expected):
     payload.update({
-        "vds": vds,
-        "sas": sas
+        "vds": [vds],
+        "sas": [sas]
     })
     res = send_request(path, "post", payload)
     assert res.status_code == expected


### PR DESCRIPTION
Current endpoints are generalised to accept a list of blob URL´s and corresponding SAS keys and a binary_operator. If two blobs are provided the  binary_operator defines how these are combined into a single data source. Typical example here is to take the difference between two blobs. With the exception of providing blob URL´s and SAS keys in a list the existing functionality is identical. 

G-tests and e2e tests are added to test the new functionality using the binary_operator.