### PR TITLE
Difference endpoint

### DIFF
--- a/api/endpoint.go
+++ b/api/endpoint.go
@@ -277,7 +277,7 @@ func (request AttributeBetweenSurfacesRequest) execute(
 
 func parseGetRequest(ctx *gin.Context, v Normalizable) error {
 	query, status := ctx.GetQuery("query")
-	if (!status){
+	if !status {
 		return core.NewInvalidArgument(
 			"GET request to specified endpoint requires a 'query' parameter",
 		)

--- a/api/endpoint.go
+++ b/api/endpoint.go
@@ -65,12 +65,12 @@ func prepareRequestLogging(ctx *gin.Context, request Stringable) {
 
 func (e *Endpoint) metadata(ctx *gin.Context, request MetadataRequest) {
 	prepareRequestLogging(ctx, request)
-	conn, err := e.MakeVdsConnection(request.Vds, request.Sas)
+	connection, err := e.MakeVdsConnection(request.Vds, request.Sas)
 	if abortOnError(ctx, err) {
 		return
 	}
 
-	handle, err := core.NewDSHandle(conn)
+	handle, err := core.NewDSHandle(connection)
 	if abortOnError(ctx, err) {
 		return
 	}
@@ -89,7 +89,7 @@ func (e *Endpoint) makeDataRequest(
 	request DataRequest,
 ) {
 	prepareRequestLogging(ctx, request)
-	conn, err := e.MakeVdsConnection(request.credentials())
+	connection, err := e.MakeVdsConnection(request.credentials())
 	if abortOnError(ctx, err) {
 		return
 	}
@@ -100,13 +100,13 @@ func (e *Endpoint) makeDataRequest(
 	}
 
 	cacheEntry, hit := e.Cache.Get(cacheKey)
-	if hit && conn.IsAuthorizedToRead() {
+	if hit && connection.IsAuthorizedToRead() {
 		ctx.Set("cache-hit", true)
 		writeResponse(ctx, cacheEntry.Metadata(), cacheEntry.Data())
 		return
 	}
 
-	handle, err := core.NewDSHandle(conn)
+	handle, err := core.NewDSHandle(connection)
 	if abortOnError(ctx, err) {
 		return
 	}

--- a/api/endpoint.go
+++ b/api/endpoint.go
@@ -27,7 +27,7 @@ func httpStatusCode(err error) int {
 /* Call abortOnError on the context in case of an error
  *
  * This function is designed specifically for our endpoint handler functions
- * and aims at making the errorhandling as short and concise as possible.
+ * and aims at making the error handling as short and concise as possible.
  *
  * If err != nil the error will be mapped to an appropriate http status code
  * through the httpStatusCode mapper, and ctx.AbortWithError will be called
@@ -37,7 +37,7 @@ func httpStatusCode(err error) int {
  * If err == nil the ctx is left untouched and this function returns false,
  * indicating that the context was not aborted.
  *
- * The result is a oneline error handling:
+ * The result is a one line error handling:
  *
  *     err, _ := func()
  *     if abortOnError(ctx, err) { return }

--- a/api/request.go
+++ b/api/request.go
@@ -355,7 +355,7 @@ type AttributeAlongSurfaceRequest struct {
 	Above float32 `json:"above" example:"20.0"`
 
 	// Samples interval below the horizon to include in attribute calculation.
-	// Implements the same behaviour as 'above'.
+	// Implements the same behavior as 'above'.
 	//
 	// Defaults to zero
 	Below float32 `json:"below" example:"20.0"`

--- a/api/request.go
+++ b/api/request.go
@@ -291,21 +291,13 @@ func (h AttributeAlongSurfaceRequest) hash() (string, error) {
 }
 
 func (h AttributeAlongSurfaceRequest) toString() (string, error) {
-	msg := "{vds: %s, Horizon: (ncols: %d, nrows: %d), Rotation: %.2f, " +
-		"Origin: [%.2f, %.2f], Increment: [%.2f, %.2f], FillValue: %.2f, " +
+	msg := "{vds: %s, Horizon: %s " +
 		"interpolation: %s, Above: %.2f, Below: %.2f, Stepsize: %.2f, " +
 		"Attributes: %v}"
 	return fmt.Sprintf(
 		msg,
 		h.Vds,
-		len(h.Surface.Values[0]),
-		len(h.Surface.Values),
-		*h.Surface.Rotation,
-		*h.Surface.Xori,
-		*h.Surface.Yori,
-		h.Surface.Xinc,
-		h.Surface.Yinc,
-		*h.Surface.FillValue,
+		h.Surface.ToString(),
 		h.Interpolation,
 		h.Above,
 		h.Below,
@@ -354,30 +346,14 @@ func (h AttributeBetweenSurfacesRequest) hash() (string, error) {
 
 func (h AttributeBetweenSurfacesRequest) toString() (string, error) {
 	msg := "{vds: %s, " +
-		"Primary surface: Values: (ncols: %d, nrows: %d), Rotation: %.2f, " +
-		"Origin: [%.2f, %.2f], Increment: [%.2f, %.2f], FillValue: %.2f. " +
-		"Secondary surface: Values: (ncols: %d, nrows: %d), Rotation: %.2f, " +
-		"Origin: [%.2f, %.2f], Increment: [%.2f, %.2f], FillValue: %.2f. " +
+		"Primary surface: %s" +
+		"Secondary surface: %s" +
 		"Interpolation: %s, Stepsize: %.2f, Attributes: %v}"
 	return fmt.Sprintf(
 		msg,
 		h.Vds,
-		len(h.PrimarySurface.Values[0]),
-		len(h.PrimarySurface.Values),
-		*h.PrimarySurface.Rotation,
-		*h.PrimarySurface.Xori,
-		*h.PrimarySurface.Yori,
-		h.PrimarySurface.Xinc,
-		h.PrimarySurface.Yinc,
-		*h.PrimarySurface.FillValue,
-		len(h.SecondarySurface.Values[0]),
-		len(h.SecondarySurface.Values),
-		*h.SecondarySurface.Rotation,
-		*h.SecondarySurface.Xori,
-		*h.SecondarySurface.Yori,
-		h.SecondarySurface.Xinc,
-		h.SecondarySurface.Yinc,
-		*h.SecondarySurface.FillValue,
+		h.PrimarySurface.ToString(),
+		h.SecondarySurface.ToString(),
 		h.Interpolation,
 		h.Stepsize,
 		h.Attributes,

--- a/api/request_test.go
+++ b/api/request_test.go
@@ -14,8 +14,8 @@ func newSliceRequest(
 ) SliceRequest {
 	return SliceRequest{
 		RequestedResource: RequestedResource{
-			Vds: vds,
-			Sas: sas,
+			Vds: []string{vds},
+			Sas: []string{sas},
 		},
 		Direction: direction,
 		Lineno:    &lineno,
@@ -31,8 +31,8 @@ func newFenceRequest(
 ) FenceRequest {
 	return FenceRequest{
 		RequestedResource: RequestedResource{
-			Vds: vds,
-			Sas: sas,
+			Vds: []string{vds},
+			Sas: []string{sas},
 		},
 		CoordinateSystem: coordinateSystem,
 		Coordinates:      coordinates,
@@ -45,8 +45,8 @@ func newRequestedResource(
 	sas string,
 ) RequestedResource {
 	return RequestedResource{
-		Vds: vds,
-		Sas: sas,
+		Vds: []string{vds},
+		Sas: []string{sas},
 	}
 }
 
@@ -214,7 +214,7 @@ func TestExtractSasFromUrl(t *testing.T) {
 				"../../testdata/well_known/well_known_default.vds?sastoken2",
 				"sastoken1",
 			),
-			expected:    "Two sas tokens provided, only one sas token is allowed",
+			expected:    "Signed urls are not accepted when providing sas-tokens. Vds url nr 1 is signed",
 			shouldError: true,
 		},
 		{
@@ -222,7 +222,7 @@ func TestExtractSasFromUrl(t *testing.T) {
 				"../../testdata/well_known/well_known_default.vds",
 				"",
 			),
-			expected:    "No valid Sas token is found in the request",
+			expected:    "No valid Sas token found at the end of vds url nr 1",
 			shouldError: true,
 		},
 	}
@@ -233,7 +233,9 @@ func TestExtractSasFromUrl(t *testing.T) {
 			require.ErrorContains(t, err, testCase.expected)
 		} else {
 			require.NoError(t, err)
-			require.Equal(t, testCase.expected, testCase.request.Sas)
+			for i := 0; i < len(testCase.request.Sas); i++ {
+				require.Equal(t, testCase.expected, testCase.request.Sas[i])
+			}
 		}
 	}
 }
@@ -263,6 +265,8 @@ func TestPortPresenceInURL(t *testing.T) {
 	for _, testCase := range testCases {
 		err := testCase.request.NormalizeConnection()
 		require.NoError(t, err)
-		require.Equal(t, testCase.expected, testCase.request.Vds)
+		for i := 0; i < len(testCase.request.Vds); i++ {
+			require.Equal(t, testCase.expected, testCase.request.Vds[i])
+		}
 	}
 }

--- a/api/request_test.go
+++ b/api/request_test.go
@@ -214,8 +214,8 @@ func TestExtractSasFromUrl(t *testing.T) {
 				"../../testdata/well_known/well_known_default.vds?sastoken2",
 				"sastoken1",
 			),
-			expected:    "sastoken1",
-			shouldError: false,
+			expected:    "Two sas tokens provided, only one sas token is allowed",
+			shouldError: true,
 		},
 		{
 			request: newRequestedResource(

--- a/cmd/query/formats_test.go
+++ b/cmd/query/formats_test.go
@@ -29,10 +29,10 @@ func TestSupportedFormats(t *testing.T) {
 				expectedStatus: http.StatusOK,
 			},
 			testSliceRequest{
-				Vds:       fmt.Sprintf(formatFile, format),
+				Vds:       []string{fmt.Sprintf(formatFile, format)},
 				Direction: "i",
 				Lineno:    1,
-				Sas:       "n/a",
+				Sas:       []string{"n/a"},
 			},
 		}
 		fenceTest := fenceTest{
@@ -43,10 +43,10 @@ func TestSupportedFormats(t *testing.T) {
 			},
 
 			testFenceRequest{
-				Vds:              fmt.Sprintf(formatFile, format),
+				Vds:              []string{fmt.Sprintf(formatFile, format)},
 				CoordinateSystem: "ij",
 				Coordinates:      [][]float32{{1, 0}, {1, 1}},
-				Sas:              "n/a",
+				Sas:              []string{"n/a"},
 			},
 		}
 
@@ -103,9 +103,9 @@ func TestSupportedFormatsHorizon(t *testing.T) {
 			},
 
 			testAttributeAlongSurfaceRequest{
-				Vds:        fmt.Sprintf(formatFile, format),
+				Vds:        []string{fmt.Sprintf(formatFile, format)},
 				Values:     [][]float32{{20}},
-				Sas:        "n/a",
+				Sas:        []string{"n/a"},
 				Above:      8.0,
 				Below:      8.0,
 				Attributes: []string{"samplevalue", "min", "max"},

--- a/cmd/query/main.go
+++ b/cmd/query/main.go
@@ -125,7 +125,7 @@ func parseopts() opts {
 			"different port than the server itself. This allows for them to be kept\n"+
 			"private, if desirable. Defaults to 8081.\n"+
 			"Ignored if metrics are not turned on. (see --metrics)\n"+
-			"Can also be set by enviroment variable 'VDSSLICE_METRICS_PORT'",
+			"Can also be set by environment variable 'VDSSLICE_METRICS_PORT'",
 		"int",
 	)
 
@@ -199,7 +199,7 @@ func main() {
 		 * Host the /metrics endpoint on a different app instance. This is needed
 		 * in order to serve it on a different port, while also giving some benefits
 		 * such that our main app server's logs doesn't get polluted by tools that
-		 * are continually scarping the /metrics endpoint. I.e. graphana.
+		 * are continually scarping the /metrics endpoint. I.e. Grafana.
 		 */
 		metricsApp := gin.New()
 		metricsApp.SetTrustedProxies(nil)

--- a/cmd/query/main_test.go
+++ b/cmd/query/main_test.go
@@ -306,7 +306,7 @@ func TestFenceErrorHTTPResponse(t *testing.T) {
 					"\"fillValue\": -999.25," +
 					"\"coordinates\":[[0, 0]]}",
 				expectedStatus: http.StatusBadRequest,
-				expectedError:  "No valid Sas token is found",
+				expectedError:  "No valid Sas token found at the end of vds url nr 1",
 			},
 			testFenceRequest{},
 		},
@@ -472,7 +472,7 @@ func TestMetadataErrorHTTPResponse(t *testing.T) {
 				method:         http.MethodGet,
 				jsonRequest:    "{\"vds\":\"" + well_known + "\"}",
 				expectedStatus: http.StatusBadRequest,
-				expectedError:  "No valid Sas token is found",
+				expectedError:  "No valid Sas token found at the end of vds url nr 1",
 			}, testMetadataRequest{},
 		},
 		metadataTest{

--- a/cmd/query/main_test.go
+++ b/cmd/query/main_test.go
@@ -20,10 +20,10 @@ func TestSliceHappyHTTPResponse(t *testing.T) {
 				expectedStatus: http.StatusOK,
 			},
 			testSliceRequest{
-				Vds:       well_known,
+				Vds:       []string{well_known},
 				Direction: "i",
 				Lineno:    0, //side-effect assurance that 0 is accepted
-				Sas:       "n/a",
+				Sas:       []string{"n/a"},
 				Bounds: []testBound{
 					{Direction: "inline", Lower: 1, Upper: 3},
 				},
@@ -36,10 +36,10 @@ func TestSliceHappyHTTPResponse(t *testing.T) {
 				expectedStatus: http.StatusOK,
 			},
 			testSliceRequest{
-				Vds:       well_known,
+				Vds:       []string{well_known},
 				Direction: "crossline",
 				Lineno:    10,
-				Sas:       "n/a",
+				Sas:       []string{"n/a"},
 				Bounds: []testBound{
 					{Direction: "inline", Lower: 1, Upper: 3},
 				},
@@ -170,10 +170,10 @@ func TestSliceErrorHTTPResponse(t *testing.T) {
 				expectedError:  "invalid direction 'unknown', valid options are",
 			},
 			testSliceRequest{
-				Vds:       well_known,
+				Vds:       []string{well_known},
 				Direction: "unknown",
 				Lineno:    1,
-				Sas:       "n/a",
+				Sas:       []string{"n/a"},
 			},
 		},
 		sliceTest{
@@ -184,10 +184,10 @@ func TestSliceErrorHTTPResponse(t *testing.T) {
 				expectedError:  "Invalid lineno: 10, valid range: [0:2:1]",
 			},
 			testSliceRequest{
-				Vds:       well_known,
+				Vds:       []string{well_known},
 				Direction: "i",
 				Lineno:    10,
-				Sas:       "n/a",
+				Sas:       []string{"n/a"},
 			},
 		},
 		sliceTest{
@@ -198,10 +198,10 @@ func TestSliceErrorHTTPResponse(t *testing.T) {
 				expectedError:  "Could not open VDS",
 			},
 			testSliceRequest{
-				Vds:       "unknown",
+				Vds:       []string{"unknown"},
 				Direction: "i",
 				Lineno:    1,
-				Sas:       "n/a",
+				Sas:       []string{"n/a"},
 			},
 		},
 	}
@@ -218,11 +218,11 @@ func TestFenceHappyHTTPResponse(t *testing.T) {
 			},
 
 			testFenceRequest{
-				Vds:              well_known,
+				Vds:              []string{well_known},
 				CoordinateSystem: "ilxl",
 				Coordinates:      [][]float32{{3, 11}, {2, 10}},
 				FillValue:        float32(-999.25),
-				Sas:              "n/a",
+				Sas:              []string{"n/a"},
 			},
 		},
 		{
@@ -233,11 +233,11 @@ func TestFenceHappyHTTPResponse(t *testing.T) {
 			},
 
 			testFenceRequest{
-				Vds:              well_known,
+				Vds:              []string{well_known},
 				CoordinateSystem: "ij",
 				Coordinates:      [][]float32{{0, 1}, {1, 1}, {1, 0}},
 				FillValue:        float32(-999.25),
-				Sas:              "n/a",
+				Sas:              []string{"n/a"},
 			},
 		},
 	}
@@ -331,10 +331,10 @@ func TestFenceErrorHTTPResponse(t *testing.T) {
 				expectedError:  "coordinate system not recognized: 'unknown', valid options are",
 			},
 			testFenceRequest{
-				Vds:              well_known,
+				Vds:              []string{well_known},
 				CoordinateSystem: "unknown",
 				Coordinates:      [][]float32{{3, 12}, {2, 10}},
-				Sas:              "n/a",
+				Sas:              []string{"n/a"},
 			},
 		},
 		fenceTest{
@@ -345,10 +345,10 @@ func TestFenceErrorHTTPResponse(t *testing.T) {
 				expectedError:  "invalid coordinate [2 10 3 4] at position 2, expected [x y] pair",
 			},
 			testFenceRequest{
-				Vds:              well_known,
+				Vds:              []string{well_known},
 				CoordinateSystem: "cdp",
 				Coordinates:      [][]float32{{3, 1001}, {200, 10}, {2, 10, 3, 4}, {1, 1}},
-				Sas:              "n/a",
+				Sas:              []string{"n/a"},
 			},
 		},
 		fenceTest{
@@ -359,10 +359,10 @@ func TestFenceErrorHTTPResponse(t *testing.T) {
 				expectedError:  "Could not open VDS",
 			},
 			testFenceRequest{
-				Vds:              "unknown",
+				Vds:              []string{"unknown"},
 				CoordinateSystem: "ilxl",
 				Coordinates:      [][]float32{{3, 12}, {2, 10}},
-				Sas:              "n/a",
+				Sas:              []string{"n/a"},
 			},
 		},
 	}
@@ -379,8 +379,8 @@ func TestMetadataHappyHTTPResponse(t *testing.T) {
 				expectedStatus: http.StatusOK,
 			},
 			testMetadataRequest{
-				Vds: well_known,
-				Sas: "n/a",
+				Vds: []string{well_known},
+				Sas: []string{"n/a"},
 			},
 		},
 		{
@@ -390,8 +390,8 @@ func TestMetadataHappyHTTPResponse(t *testing.T) {
 				expectedStatus: http.StatusOK,
 			},
 			testMetadataRequest{
-				Vds: well_known,
-				Sas: "n/a",
+				Vds: []string{well_known},
+				Sas: []string{"n/a"},
 			},
 		},
 	}
@@ -493,8 +493,8 @@ func TestMetadataErrorHTTPResponse(t *testing.T) {
 			},
 
 			testMetadataRequest{
-				Vds: "unknown",
-				Sas: "n/a",
+				Vds: []string{"unknown"},
+				Sas: []string{"n/a"},
 			},
 		},
 	}
@@ -510,9 +510,9 @@ func TestAttributeOutOfBounds(t *testing.T) {
 				expectedStatus: status,
 			},
 			testAttributeAlongSurfaceRequest{
-				Vds:        samples10,
+				Vds:        []string{samples10},
 				Values:     [][]float32{{20}},
-				Sas:        "n/a",
+				Sas:        []string{"n/a"},
 				Above:      above,
 				Below:      below,
 				StepSize:   stepsize,
@@ -546,9 +546,9 @@ func TestAttributeHappyHTTPResponse(t *testing.T) {
 			},
 
 			testAttributeAlongSurfaceRequest{
-				Vds:        samples10,
+				Vds:        []string{samples10},
 				Values:     [][]float32{{20, 20}, {20, 20}, {20, 20}},
-				Sas:        "n/a",
+				Sas:        []string{"n/a"},
 				Above:      8.0,
 				Below:      4.0,
 				Attributes: []string{"samplevalue"},
@@ -562,10 +562,10 @@ func TestAttributeHappyHTTPResponse(t *testing.T) {
 			},
 
 			testAttributeBetweenSurfacesRequest{
-				Vds:             samples10,
+				Vds:             []string{samples10},
 				ValuesPrimary:   [][]float32{{20, 20}, {20, 20}, {20, 20}},
 				ValuesSecondary: [][]float32{{20, 20}, {20, 20}, {20, 20}},
-				Sas:             "n/a",
+				Sas:             []string{"n/a"},
 				Attributes:      []string{"samplevalue"},
 			},
 		},
@@ -648,9 +648,9 @@ func TestAttributeErrorHTTPResponse(t *testing.T) {
 				expectedError:  "invalid interpolation method",
 			},
 			testAttributeAlongSurfaceRequest{
-				Vds:           well_known,
+				Vds:           []string{well_known},
 				Values:        [][]float32{{4, 4}, {4, 4}, {4, 4}},
-				Sas:           "n/a",
+				Sas:           []string{"n/a"},
 				Interpolation: "unsupported",
 				Attributes:    []string{"samplevalue"},
 			},
@@ -663,10 +663,10 @@ func TestAttributeErrorHTTPResponse(t *testing.T) {
 				expectedError:  "invalid interpolation method",
 			},
 			testAttributeBetweenSurfacesRequest{
-				Vds:             well_known,
+				Vds:             []string{well_known},
 				ValuesPrimary:   [][]float32{{4, 4}, {4, 4}, {4, 4}},
 				ValuesSecondary: [][]float32{{4, 4}, {4, 4}, {4, 4}},
-				Sas:             "n/a",
+				Sas:             []string{"n/a"},
 				Interpolation:   "unsupported",
 				Attributes:      []string{"samplevalue"},
 			},
@@ -679,9 +679,9 @@ func TestAttributeErrorHTTPResponse(t *testing.T) {
 				expectedError:  "Could not open VDS",
 			},
 			testAttributeAlongSurfaceRequest{
-				Vds:        "unknown",
+				Vds:        []string{"unknown"},
 				Values:     [][]float32{{4, 4}, {4, 4}, {4, 4}},
-				Sas:        "n/a",
+				Sas:        []string{"n/a"},
 				Attributes: []string{"samplevalue"},
 			},
 		},
@@ -693,10 +693,10 @@ func TestAttributeErrorHTTPResponse(t *testing.T) {
 				expectedError:  "Could not open VDS",
 			},
 			testAttributeBetweenSurfacesRequest{
-				Vds:             "unknown",
+				Vds:             []string{"unknown"},
 				ValuesPrimary:   [][]float32{{4, 4}, {4, 4}, {4, 4}},
 				ValuesSecondary: [][]float32{{4, 4}, {4, 4}, {4, 4}},
-				Sas:             "n/a",
+				Sas:             []string{"n/a"},
 				Attributes:      []string{"samplevalue"},
 			},
 		},
@@ -715,10 +715,10 @@ func TestLogHasNoSas(t *testing.T) {
 				expectedStatus: http.StatusOK,
 			},
 			testSliceRequest{
-				Vds:       well_known,
+				Vds:       []string{well_known},
 				Direction: "crossline",
 				Lineno:    10,
-				Sas:       "SPARTA...T14:43:29Z%26se=2023",
+				Sas:       []string{"SPARTA...T14:43:29Z%26se=2023"},
 			},
 		}
 
@@ -729,8 +729,8 @@ func TestLogHasNoSas(t *testing.T) {
 				expectedStatus: http.StatusInternalServerError,
 			},
 			testMetadataRequest{
-				Vds: "unknown",
-				Sas: "SPARTA...T14:43:29Z%26se=2023...",
+				Vds: []string{"unknown"},
+				Sas: []string{"SPARTA...T14:43:29Z%26se=2023..."},
 			},
 		}
 

--- a/cmd/query/main_test.go
+++ b/cmd/query/main_test.go
@@ -45,6 +45,39 @@ func TestSliceHappyHTTPResponse(t *testing.T) {
 				},
 			},
 		},
+		{
+			baseTest{
+				name:           "Valid Request Subtraction",
+				method:         http.MethodPost,
+				expectedStatus: http.StatusOK,
+			},
+			testSliceRequest{
+				Vds:            []string{well_known, well_known},
+				Direction:      "crossline",
+				Lineno:         10,
+				Sas:            []string{"n/a", "n/a"},
+				BinaryOperator: "subtraction",
+				Bounds: []testBound{
+					{Direction: "inline", Lower: 1, Upper: 3},
+				},
+			},
+		},
+		{
+			baseTest{
+				name:           "Valid Request Subtraction, sas provided as query parameter",
+				method:         http.MethodPost,
+				expectedStatus: http.StatusOK,
+			},
+			testSliceRequest{
+				Vds:            []string{well_known + "?n/a", well_known + "?n/a"},
+				Direction:      "crossline",
+				Lineno:         10,
+				BinaryOperator: "subtraction",
+				Bounds: []testBound{
+					{Direction: "inline", Lower: 1, Upper: 3},
+				},
+			},
+		},
 	}
 
 	for _, testcase := range testcases {
@@ -151,6 +184,43 @@ func TestSliceErrorHTTPResponse(t *testing.T) {
 			testSliceRequest{},
 		},
 		sliceTest{
+
+			baseTest{
+				name:           "Missing VDS parameter, POST Request",
+				method:         http.MethodPost,
+				expectedStatus: http.StatusBadRequest,
+				expectedError:  "No VDS url provided",
+			},
+			testSliceRequest{
+				Vds:       []string{},
+				Direction: "crossline",
+				Lineno:    10,
+				Sas:       []string{"n/a"},
+				Bounds: []testBound{
+					{Direction: "inline", Lower: 1, Upper: 3},
+				},
+			},
+		},
+		sliceTest{
+
+			baseTest{
+				name:           "First VDS is empty string, POST Request",
+				method:         http.MethodPost,
+				expectedStatus: http.StatusBadRequest,
+				expectedError:  "VDS url cannot be the empty string. VDS url 1 is empty",
+			},
+			testSliceRequest{
+				Vds:            []string{"", "some_url"},
+				Direction:      "crossline",
+				Lineno:         10,
+				Sas:            []string{"n/a", "n/a"},
+				BinaryOperator: "subtraction",
+				Bounds: []testBound{
+					{Direction: "inline", Lower: 1, Upper: 3},
+				},
+			},
+		},
+		sliceTest{
 			baseTest{
 				name:   "Incomplete bounds parameters POST Request",
 				method: http.MethodPost,
@@ -204,6 +274,124 @@ func TestSliceErrorHTTPResponse(t *testing.T) {
 				Sas:       []string{"n/a"},
 			},
 		},
+		sliceTest{
+			baseTest{
+				name:           "Extra sas token",
+				method:         http.MethodPost,
+				expectedStatus: http.StatusBadRequest,
+				expectedError:  "Number of VDS urls and sas tokens do not match. Vds: 1, Sas: 2",
+			},
+			testSliceRequest{
+				Vds:       []string{"unknown"},
+				Direction: "i",
+				Lineno:    1,
+				Sas:       []string{"n/a", "n/a"},
+			},
+		},
+		sliceTest{
+			baseTest{
+				name:           "Missing one sas token",
+				method:         http.MethodPost,
+				expectedStatus: http.StatusBadRequest,
+				expectedError:  "Number of VDS urls and sas tokens do not match. Vds: 2, Sas: 1",
+			},
+			testSliceRequest{
+				Vds:       []string{"unknown", "unknown"},
+				Direction: "i",
+				Lineno:    1,
+				Sas:       []string{"n/a"},
+			},
+		},
+		sliceTest{
+			baseTest{
+				name:           "Sas token provided twice",
+				method:         http.MethodPost,
+				expectedStatus: http.StatusBadRequest,
+				expectedError:  "Signed urls are not accepted when providing sas-tokens. Vds url nr 2 is signed",
+			},
+			testSliceRequest{
+				Vds:            []string{well_known, well_known + "?n/a"},
+				Direction:      "crossline",
+				Lineno:         10,
+				Sas:            []string{"n/a", "n/a"},
+				BinaryOperator: "subtraction",
+				Bounds: []testBound{
+					{Direction: "inline", Lower: 1, Upper: 3},
+				},
+			},
+		},
+		sliceTest{
+			baseTest{
+				name:           "Missing binary operator",
+				method:         http.MethodPost,
+				expectedStatus: http.StatusBadRequest,
+				expectedError:  "Binary operator must be provided when two VDS urls are provided",
+			},
+			testSliceRequest{
+				Vds:       []string{well_known, well_known},
+				Direction: "crossline",
+				Lineno:    10,
+				Sas:       []string{"n/a", "n/a"},
+				Bounds: []testBound{
+					{Direction: "inline", Lower: 1, Upper: 3},
+				},
+			},
+		},
+		sliceTest{
+			baseTest{
+				name:           "More than two VDS urls",
+				method:         http.MethodPost,
+				expectedStatus: http.StatusBadRequest,
+				expectedError:  "No endpoint accepts more than two vds urls.",
+			},
+			testSliceRequest{
+				Vds:       []string{well_known, well_known, well_known},
+				Direction: "crossline",
+				Lineno:    10,
+				Sas:       []string{"n/a", "n/a", "n/a"},
+				Bounds: []testBound{
+					{Direction: "inline", Lower: 1, Upper: 3},
+				},
+			},
+		},
+
+		sliceTest{
+			baseTest{
+				name:           "Binary operator and single vds",
+				method:         http.MethodPost,
+				expectedStatus: http.StatusBadRequest,
+				expectedError:  "Binary operator must be empty when a single VDS url is provided",
+			},
+			testSliceRequest{
+				Vds:            []string{well_known},
+				Direction:      "crossline",
+				Lineno:         10,
+				Sas:            []string{"n/a"},
+				BinaryOperator: "subtraction",
+				Bounds: []testBound{
+					{Direction: "inline", Lower: 1, Upper: 3},
+				},
+			},
+		},
+
+		sliceTest{
+			baseTest{
+				name:           "Invalid binary operator",
+				method:         http.MethodPost,
+				expectedStatus: http.StatusBadRequest,
+				expectedError:  "Binary operator not recognized: 'notsubtraction', valid options are: addition, subtraction, multiplication, division",
+			},
+			testSliceRequest{
+				Vds:            []string{well_known, well_known},
+				Direction:      "crossline",
+				Lineno:         10,
+				Sas:            []string{"n/a", "n/a"},
+				BinaryOperator: "notsubtraction",
+				Bounds: []testBound{
+					{Direction: "inline", Lower: 1, Upper: 3},
+				},
+			},
+		},
 	}
 	testErrorHTTPResponse(t, testcases)
 }
@@ -238,6 +426,22 @@ func TestFenceHappyHTTPResponse(t *testing.T) {
 				Coordinates:      [][]float32{{0, 1}, {1, 1}, {1, 0}},
 				FillValue:        float32(-999.25),
 				Sas:              []string{"n/a"},
+			},
+		},
+		{
+			baseTest{
+				name:           "Valid difference POST Request",
+				method:         http.MethodPost,
+				expectedStatus: http.StatusOK,
+			},
+
+			testFenceRequest{
+				Vds:              []string{well_known, well_known},
+				CoordinateSystem: "ij",
+				Coordinates:      [][]float32{{0, 1}, {1, 1}, {1, 0}},
+				FillValue:        float32(-999.25),
+				Sas:              []string{"n/a", "n/a"},
+				BinaryOperator:   "subtraction",
 			},
 		},
 	}
@@ -481,7 +685,7 @@ func TestMetadataErrorHTTPResponse(t *testing.T) {
 				method:         http.MethodPost,
 				jsonRequest:    "{\"sas\":\"somevalidsas\"}",
 				expectedStatus: http.StatusBadRequest,
-				expectedError:  "Error:Field validation for 'Vds'",
+				expectedError:  "Field validation for 'Vds'",
 			}, testMetadataRequest{},
 		},
 		metadataTest{
@@ -495,6 +699,47 @@ func TestMetadataErrorHTTPResponse(t *testing.T) {
 			testMetadataRequest{
 				Vds: []string{"unknown"},
 				Sas: []string{"n/a"},
+			},
+		},
+		metadataTest{
+			baseTest{
+				name:           "Single vds url and double sas token",
+				method:         http.MethodPost,
+				expectedStatus: http.StatusBadRequest,
+				expectedError:  "Number of VDS urls and sas tokens do not match",
+			},
+
+			testMetadataRequest{
+				Vds: []string{"unknown"},
+				Sas: []string{"n/a", "n/a"},
+			},
+		},
+		metadataTest{
+			baseTest{
+				name:           "Two urls to metadata request",
+				method:         http.MethodPost,
+				expectedStatus: http.StatusBadRequest,
+				expectedError:  "Metadata requests only accepts one VDS url and one sas token",
+			},
+
+			testMetadataRequest{
+				Vds: []string{"unknown", "unknown"},
+				Sas: []string{"n/a", "n/a"},
+			},
+		},
+		metadataTest{
+			baseTest{
+				name:           "Metadata request with binary operator",
+				method:         http.MethodPost,
+				expectedStatus: http.StatusBadRequest,
+				expectedError: "Metadata request does not accept binary_operator key. " +
+					"The binary_operator key must be undefined or be the empty string",
+			},
+
+			testMetadataRequest{
+				Vds:            []string{"unknown"},
+				Sas:            []string{"n/a"},
+				BinaryOperator: "subtraction",
 			},
 		},
 	}
@@ -554,6 +799,24 @@ func TestAttributeHappyHTTPResponse(t *testing.T) {
 				Attributes: []string{"samplevalue"},
 			},
 		},
+
+		attributeAlongSurfaceTest{
+			baseTest{
+				name:           "Valid difference POST Request along surface",
+				method:         http.MethodPost,
+				expectedStatus: http.StatusOK,
+			},
+
+			testAttributeAlongSurfaceRequest{
+				Vds:            []string{samples10, samples10},
+				Values:         [][]float32{{20, 20}, {20, 20}, {20, 20}},
+				Sas:            []string{"n/a", "n/a"},
+				BinaryOperator: "subtraction",
+				Above:          8.0,
+				Below:          4.0,
+				Attributes:     []string{"samplevalue"},
+			},
+		},
 		attributeBetweenSurfacesTest{
 			baseTest{
 				name:           "Valid json POST Request between surfaces",
@@ -566,6 +829,22 @@ func TestAttributeHappyHTTPResponse(t *testing.T) {
 				ValuesPrimary:   [][]float32{{20, 20}, {20, 20}, {20, 20}},
 				ValuesSecondary: [][]float32{{20, 20}, {20, 20}, {20, 20}},
 				Sas:             []string{"n/a"},
+				Attributes:      []string{"samplevalue"},
+			},
+		},
+		attributeBetweenSurfacesTest{
+			baseTest{
+				name:           "Valid difference POST Request along surface",
+				method:         http.MethodPost,
+				expectedStatus: http.StatusOK,
+			},
+
+			testAttributeBetweenSurfacesRequest{
+				Vds:             []string{samples10, samples10},
+				ValuesPrimary:   [][]float32{{20, 20}, {20, 20}, {20, 20}},
+				ValuesSecondary: [][]float32{{20, 20}, {20, 20}, {20, 20}},
+				Sas:             []string{"n/a", "n/a"},
+				BinaryOperator:  "subtraction",
 				Attributes:      []string{"samplevalue"},
 			},
 		},

--- a/cmd/query/utils_main_test.go
+++ b/cmd/query/utils_main_test.go
@@ -249,8 +249,9 @@ type testFenceRequest struct {
 }
 
 type testMetadataRequest struct {
-	Vds []string `json:"vds"`
-	Sas []string `json:"sas"`
+	Vds            []string `json:"vds"`
+	Sas            []string `json:"sas"`
+	BinaryOperator string   `json:"binary_operator"`
 }
 
 type testAttributeAlongSurfaceRequest struct {

--- a/cmd/query/utils_main_test.go
+++ b/cmd/query/utils_main_test.go
@@ -137,6 +137,7 @@ func (h attributeAlongSurfaceTest) requestAsJSON() (string, error) {
 
 	out["vds"] = h.attribute.Vds
 	out["sas"] = h.attribute.Sas
+	out["binary_operator"] = h.attribute.BinaryOperator
 	surface := map[string]interface{}{}
 	surface["values"] = h.attribute.Values
 	surface["rotation"] = 33.69
@@ -184,6 +185,7 @@ func (h attributeBetweenSurfacesTest) requestAsJSON() (string, error) {
 
 	out["vds"] = h.attribute.Vds
 	out["sas"] = h.attribute.Sas
+	out["binary_operator"] = h.attribute.BinaryOperator
 
 	primary := map[string]interface{}{}
 	primary["values"] = h.attribute.ValuesPrimary
@@ -229,40 +231,44 @@ type testBound struct {
 }
 
 type testSliceRequest struct {
-	Vds       string      `json:"vds"`
-	Direction string      `json:"direction"`
-	Lineno    int         `json:"lineno"`
-	Sas       string      `json:"sas"`
-	Bounds    []testBound `json:"bounds"`
+	Vds            []string    `json:"vds"`
+	Direction      string      `json:"direction"`
+	Lineno         int         `json:"lineno"`
+	Sas            []string    `json:"sas"`
+	BinaryOperator string      `json:"binary_operator"`
+	Bounds         []testBound `json:"bounds"`
 }
 
 type testFenceRequest struct {
-	Vds              string      `json:"vds"`
+	Vds              []string    `json:"vds"`
 	CoordinateSystem string      `json:"coordinateSystem"`
 	Coordinates      [][]float32 `json:"coordinates"`
 	FillValue        float32     `json:"fillValue"`
-	Sas              string      `json:"sas"`
+	Sas              []string    `json:"sas"`
+	BinaryOperator   string      `json:"binary_operator"`
 }
 
 type testMetadataRequest struct {
-	Vds string `json:"vds"`
-	Sas string `json:"sas"`
+	Vds []string `json:"vds"`
+	Sas []string `json:"sas"`
 }
 
 type testAttributeAlongSurfaceRequest struct {
-	Vds           string
-	Sas           string
-	Values        [][]float32
-	Interpolation string
-	Above         float32
-	Below         float32
-	StepSize      float32
-	Attributes    []string
+	Vds            []string
+	Sas            []string
+	BinaryOperator string
+	Values         [][]float32
+	Interpolation  string
+	Above          float32
+	Below          float32
+	StepSize       float32
+	Attributes     []string
 }
 
 type testAttributeBetweenSurfacesRequest struct {
-	Vds             string
-	Sas             string
+	Vds             []string
+	Sas             []string
+	BinaryOperator  string
 	ValuesPrimary   [][]float32
 	ValuesSecondary [][]float32
 	Interpolation   string

--- a/internal/core/capi.cpp
+++ b/internal/core/capi.cpp
@@ -67,7 +67,42 @@ int single_datasource_new(
     }
 }
 
-int datasource_free(Context* ctx, DataSource* ds){
+int double_datasource_new(
+    Context* ctx,
+    const char* url_A,
+    const char* credentials_A,
+    const char* url_B,
+    const char* credentials_B,
+    enum binary_operator bin_operator,
+    DataSource** datasource
+) {
+    try {
+        if (not datasource)
+            throw detail::nullptr_error("Invalid datasource pointer");
+
+        std::function<void(float*, const float*, size_t)> binary_operator_function;
+
+        if (bin_operator == NO_OPERATOR)
+            throw detail::bad_request("Invalid function");
+        else if (bin_operator == ADDITION)
+            binary_operator_function = &inplace_addition;
+        else if (bin_operator == SUBTRACTION)
+            binary_operator_function = &inplace_subtraction;
+        else if (bin_operator == MULTIPLICATION)
+            binary_operator_function = &inplace_multiplication;
+        else if (bin_operator == DIVISION)
+            binary_operator_function = &inplace_division;
+        else
+            throw detail::bad_request("Invalid binary_operator string");
+
+        *datasource = make_double_datasource(url_A, credentials_A, url_B, credentials_B, binary_operator_function);
+        return STATUS_OK;
+    } catch (...) {
+        return handle_exception(ctx, std::current_exception());
+    }
+}
+
+int datasource_free(Context* ctx, DataSource* ds) {
     try {
         if (not ds) return STATUS_OK;
 

--- a/internal/core/capi.h
+++ b/internal/core/capi.h
@@ -51,6 +51,15 @@ int single_datasource_new(
     DataSource** ds_out
 );
 
+int double_datasource_new(
+    Context* ctx,
+    const char* url_A,
+    const char* credentials_A,
+    const char* url_B,
+    const char* credentials_B,
+    enum binary_operator bin_operator,
+    DataSource** ds_out
+);
 
 int datasource_free(Context* ctx, DataSource* f);
 

--- a/internal/core/capi.h
+++ b/internal/core/capi.h
@@ -19,7 +19,7 @@ enum status_code {
  *
  * Any function that accepts a context as one of its input parameters can use
  * it to write additional information that might be of use to the caller. This
- * includes, but is not limited, to writting error messages into the context if
+ * includes, but is not limited, to writing error messages into the context if
  * the function should fail. In that case the caller can call errmsg(Context*
  * ctx) to retrieve the error message.
  */

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -61,7 +61,7 @@ type Axis struct {
 	Unit string `json:"unit" example:"ms"`
 } // @name Axis
 
-// @Description Geometrical plane with depth/time datapoints
+// @Description Geometrical plane with depth/time data points
 type RegularSurface struct {
 	// Values / height-map
 	Values [][]float32 `json:"values" binding:"required"`
@@ -101,7 +101,7 @@ type BoundingBox struct {
 } //@name BoundingBox
 
 type Array struct {
-	// Data format is represented by numpy-style formatcodes. Currently the
+	// Data format is represented by numpy-style format codes. Currently the
 	// format is always 4-byte floats, little endian (<f4).
 	Format string `json:"format" example:"<f4"`
 

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -347,6 +347,19 @@ func (surface *RegularSurface) toCdata(shift float32) ([]C.float, error) {
 	return cdata, nil
 }
 
+func (s *RegularSurface) ToString() string {
+	return fmt.Sprintf("{(ncols: %d, nrows: %d), Rotation: %.2f, "+
+		"Origin: [%.2f, %.2f], Increment: [%.2f, %.2f], FillValue: %.2f}, ",
+		len(s.Values[0]),
+		len(s.Values),
+		*s.Rotation,
+		*s.Xori,
+		*s.Yori,
+		s.Xinc,
+		s.Yinc,
+		*s.FillValue)
+}
+
 func (surface *RegularSurface) toCRegularSurface(cdata []C.float) (cRegularSurface, error) {
 	nrows := len(surface.Values)
 	ncols := len(surface.Values[0])

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -401,11 +401,11 @@ func (v DSHandle) Close() error {
 	return toError(cerr, v.ctx)
 }
 
-func NewDSHandle(conn Connection) (DSHandle, error) {
-	curl := C.CString(conn.Url())
+func NewDSHandle(connection Connection) (DSHandle, error) {
+	curl := C.CString(connection.Url())
 	defer C.free(unsafe.Pointer(curl))
 
-	ccred := C.CString(conn.ConnectionString())
+	ccred := C.CString(connection.ConnectionString())
 	defer C.free(unsafe.Pointer(ccred))
 
 	var cctx = C.context_new()

--- a/internal/core/core_attributes_test.go
+++ b/internal/core/core_attributes_test.go
@@ -151,9 +151,9 @@ func TestSurfaceWindowVerticalBounds(t *testing.T) {
 }
 
 /**
- * The goal of this test is to test that the boundschecking in the horizontal
+ * The goal of this test is to test that the bounds checking in the horizontal
  * plane is correct - i.e. that we correctly populate the output array with
- * fillvalues. To acheive this we create horizons that are based on the VDS's
+ * fillvalues. To achieve this we create horizons that are based on the VDS's
  * bingrid and then translated them in the XY-domain (by moving around the
  * origin of the horizon).
  *

--- a/internal/core/core_fence_test.go
+++ b/internal/core/core_fence_test.go
@@ -275,7 +275,7 @@ func TestInvalidFence(t *testing.T) {
 // interpolation method. So we have to trust openvds on this.
 //
 // But we can check that we use openvds correctly by checking interpolated data
-// at known datapoints. Openvds claims that data would still be the same for all
+// at known data points. Openvds claims that data would still be the same for all
 // interpolation algorithms [1].
 //
 // We had a bug that caused cubic and linear return incorrect values. So this is
@@ -308,7 +308,7 @@ func TestFenceInterpolationSameAtDataPoints(t *testing.T) {
 	}
 }
 
-// Also, as we can't check interpolation properly, check that beyond datapoints
+// Also, as we can't check interpolation properly, check that beyond data points
 // different values are returned by each algorithm
 func TestFenceInterpolationDifferentBeyondDatapoints(t *testing.T) {
 	fence := [][]float32{{3.2, 3}, {3.2, 6.3}, {1, 3}, {3.2, 3}, {5.4, 3}}

--- a/internal/core/core_general_test.go
+++ b/internal/core/core_general_test.go
@@ -62,7 +62,7 @@ func samples10Surface(data [][]float32) RegularSurface {
 func toFloat32(buf []byte) (*[]float32, error) {
 	fsize := 4 // sizeof(float32)
 	if len(buf)%fsize != 0 {
-		return nil, errors.New("Invalid buffersize")
+		return nil, errors.New("Invalid buffer size")
 	}
 
 	outlen := len(buf) / 4

--- a/internal/core/ctypes.h
+++ b/internal/core/ctypes.h
@@ -25,6 +25,14 @@ enum coordinate_system {
     CDP        = 2,
 };
 
+enum binary_operator {
+    NO_OPERATOR    = 0,
+    ADDITION       = 1,
+    SUBTRACTION    = 2,
+    MULTIPLICATION = 3,
+    DIVISION       = 4,
+};
+
 enum interpolation_method {
     NEAREST,
     LINEAR,

--- a/tests/e2e/shared_test_functions.py
+++ b/tests/e2e/shared_test_functions.py
@@ -159,7 +159,7 @@ def request_slice(method, lineno, direction):
     return process_data_response(response)
 
 
-def request_fence(method, coordinates, coordinate_system):
+def request_fence(method, coordinate_system, coordinates):
     sas = generate_container_signature(
         STORAGE_ACCOUNT_NAME, CONTAINER, STORAGE_ACCOUNT_KEY)
 

--- a/tests/e2e/test_error_propagation.py
+++ b/tests/e2e/test_error_propagation.py
@@ -10,7 +10,7 @@ from shared_test_functions import *
 @pytest.mark.parametrize("path, payload, error_code, error", [
     (
         "slice",
-        slice_payload(direction="inline", lineno=4),
+        payload_merge(connection_payload(vds=[VDS_URL], sas=[DUMMY_SAS]), slice_payload(direction="inline", lineno=4)),
         http.HTTPStatus.BAD_REQUEST,
         "Invalid lineno: 4, valid range: [1.00:5.00:2.00]"
     ),
@@ -22,20 +22,20 @@ from shared_test_functions import *
     ),
     (
         "metadata",
-        metadata_payload(vds=f'{STORAGE_ACCOUNT}/{CONTAINER}/notfound'),
+        connection_payload(vds=[f'{STORAGE_ACCOUNT}/{CONTAINER}/notfound'], sas=[DUMMY_SAS]),
         http.HTTPStatus.INTERNAL_SERVER_ERROR,
         "The specified blob does not exist"
     ),
     (
         "attributes/surface/along",
-        attributes_along_surface_payload(surface={}),
+        payload_merge(connection_payload(vds=[VDS_URL], sas=[DUMMY_SAS]), attributes_along_surface_payload(surface={})),
         http.HTTPStatus.BAD_REQUEST,
         "Error:Field validation for"
     ),
     (
         "attributes/surface/between",
-        attributes_between_surfaces_payload(
-            primaryValues=[[1]], secondaryValues=[[1], [1, 1]]),
+        payload_merge(connection_payload(vds=[VDS_URL], sas=[DUMMY_SAS]), attributes_between_surfaces_payload(
+            primaryValues=[[1]], secondaryValues=[[1], [1, 1]])),
         http.HTTPStatus.BAD_REQUEST,
         "Surface rows are not of the same length"
     ),

--- a/tests/e2e/test_happy_requests.py
+++ b/tests/e2e/test_happy_requests.py
@@ -6,6 +6,19 @@ from utils.cloud import *
 from shared_test_functions import *
 
 
+def assert_result(data: np.ndarray, expected: np.ndarray, binary_operator: str):
+    if binary_operator == "subtraction":
+        np.testing.assert_array_equal(data, np.subtract(expected, expected))
+    elif binary_operator == "addition":
+        np.testing.assert_array_equal(data, np.add(expected, expected))
+    elif binary_operator == "multiplication":
+        np.testing.assert_array_equal(data, np.multiply(expected, expected))
+    elif binary_operator == "division":
+        np.testing.assert_array_equal(data, np.divide(expected, expected))
+    else:
+        np.testing.assert_array_equal(data, expected)
+
+
 @pytest.mark.parametrize("method", [
     ("get"),
     ("post")
@@ -44,12 +57,17 @@ def test_metadata(method):
     ("get"),
     ("post")
 ])
-def test_slice(method):
-    meta, slice = request_slice(method, 5, 'inline')
+@pytest.mark.parametrize("binary_operator", [
+    (None),
+    ("subtraction"),
+])
+def test_slice(method, binary_operator):
+    meta, data = request_slice(method, 5, 'inline', binary_operator)
 
     expected = np.array([[116, 117, 118, 119],
                          [120, 121, 122, 123]])
-    assert np.array_equal(slice, expected)
+
+    assert_result(data, expected, binary_operator)
 
     expected_meta = json.loads("""
     {
@@ -67,12 +85,18 @@ def test_slice(method):
     ("get"),
     ("post")
 ])
-def test_fence(method):
-    meta, fence = request_fence(method, 'ilxl', [[3, 10], [1, 11]])
+@pytest.mark.parametrize("binary_operator", [
+    (None),
+    ("subtraction"),
+])
+def test_fence(method, binary_operator):
+    meta, data = request_fence(
+        method, 'ilxl', [[3, 10], [1, 11]], binary_operator)
 
     expected = np.array([[108, 109, 110, 111],
                          [104, 105, 106, 107]])
-    assert np.array_equal(fence, expected)
+
+    assert_result(data, expected, binary_operator)
 
     expected_meta = json.loads("""
     {
@@ -83,16 +107,22 @@ def test_fence(method):
     assert meta == expected_meta
 
 
-def test_attributes_along_surface():
+@pytest.mark.parametrize("binary_operator", [
+    (None),
+    ("subtraction"),
+])
+def test_attributes_along_surface(binary_operator):
     values = [
         [20, 20],
         [20, 20],
         [20, 20]
     ]
-    meta, data = request_attributes_along_surface("post", values)
+    meta, data = request_attributes_along_surface(
+        "post", values, binary_operator)
 
     expected = np.array([[-0.5, 0.5], [-8.5, 6.5], [16.5, -16.5]])
-    assert np.array_equal(data, expected)
+
+    assert_result(data, expected, binary_operator)
 
     expected_meta = json.loads("""
     {
@@ -103,7 +133,11 @@ def test_attributes_along_surface():
     assert meta == expected_meta
 
 
-def test_attributes_between_surfaces():
+@pytest.mark.parametrize("binary_operator", [
+    (None),
+    ("subtraction"),
+])
+def test_attributes_between_surfaces(binary_operator):
     primary = [
         [12, 12],
         [12, 14],
@@ -115,10 +149,11 @@ def test_attributes_between_surfaces():
         [24,   12]
     ]
     meta, data = request_attributes_between_surfaces(
-        "post", primary, secondary)
+        "post", primary, secondary, binary_operator)
 
     expected = np.array([[1.5, 2.5], [-8.5, 7.5], [18.5, -8.5]])
-    assert np.array_equal(data, expected)
+
+    assert_result(data, expected, binary_operator)
 
     expected_meta = json.loads("""
     {

--- a/tests/e2e/test_happy_requests.py
+++ b/tests/e2e/test_happy_requests.py
@@ -68,7 +68,7 @@ def test_slice(method):
     ("post")
 ])
 def test_fence(method):
-    meta, fence = request_fence(method, [[3, 10], [1, 11]], 'ilxl')
+    meta, fence = request_fence(method, 'ilxl', [[3, 10], [1, 11]])
 
     expected = np.array([[108, 109, 110, 111],
                          [104, 105, 106, 107]])

--- a/tests/e2e/test_security.py
+++ b/tests/e2e/test_security.py
@@ -111,6 +111,7 @@ def test_assure_only_allowed_storage_accounts(path, payload):
 ])
 @pytest.mark.parametrize("vds, sas, expected", [
     (f'{SAMPLES10_URL}?{gen_default_sas()}', '', http.HTTPStatus.OK),
+    (f'{SAMPLES10_URL}?{gen_default_sas()}', None, http.HTTPStatus.OK),
     (f'{SAMPLES10_URL}?invalid_sas', gen_default_sas(), http.HTTPStatus.BAD_REQUEST),
     (SAMPLES10_URL, '', http.HTTPStatus.BAD_REQUEST)
 ])

--- a/tests/e2e/test_security.py
+++ b/tests/e2e/test_security.py
@@ -111,7 +111,7 @@ def test_assure_only_allowed_storage_accounts(path, payload):
 ])
 @pytest.mark.parametrize("vds, sas, expected", [
     (f'{SAMPLES10_URL}?{gen_default_sas()}', '', http.HTTPStatus.OK),
-    (f'{SAMPLES10_URL}?invalid_sas', gen_default_sas(), http.HTTPStatus.OK),
+    (f'{SAMPLES10_URL}?invalid_sas', gen_default_sas(), http.HTTPStatus.BAD_REQUEST),
     (SAMPLES10_URL, '', http.HTTPStatus.BAD_REQUEST)
 ])
 def test_sas_token_in_url(path, payload, vds, sas, expected):

--- a/tests/e2e/test_security.py
+++ b/tests/e2e/test_security.py
@@ -9,11 +9,11 @@ from azure.storage import filedatalake
 
 
 @pytest.mark.parametrize("path, payload", [
-    ("slice", slice_payload()),
-    ("fence", fence_payload()),
-    ("metadata", metadata_payload()),
-    ("attributes/surface/along", attributes_along_surface_payload()),
-    ("attributes/surface/between", attributes_between_surfaces_payload()),
+    ("slice", payload_merge(connection_payload(VDS_URL, DUMMY_SAS), slice_payload())),
+    ("fence", payload_merge(connection_payload(VDS_URL, DUMMY_SAS), fence_payload())),
+    ("metadata", connection_payload(VDS_URL, DUMMY_SAS)),
+    ("attributes/surface/along", payload_merge(connection_payload(VDS_URL, DUMMY_SAS), attributes_along_surface_payload())),
+    ("attributes/surface/between", payload_merge(connection_payload(VDS_URL, DUMMY_SAS), attributes_between_surfaces_payload())),
 ])
 @pytest.mark.parametrize("sas, allowed_error_messages", [
     (
@@ -34,10 +34,10 @@ def test_assure_no_unauthorized_access(path, payload, sas, allowed_error_message
 
 
 @pytest.mark.parametrize("path, payload", [
-    ("slice", slice_payload(vds=VDS_URL)),
-    ("fence", fence_payload(vds=VDS_URL)),
-    ("attributes/surface/along", attributes_along_surface_payload()),
-    ("attributes/surface/between", attributes_between_surfaces_payload()),
+    ("slice", payload_merge(connection_payload(vds=[VDS_URL], sas=[DUMMY_SAS]), slice_payload())),
+    ("fence", payload_merge(connection_payload(vds=[VDS_URL], sas=[DUMMY_SAS]), fence_payload())),
+    ("attributes/surface/along", payload_merge(connection_payload([SAMPLES10_URL], sas=[DUMMY_SAS]), attributes_along_surface_payload())),
+    ("attributes/surface/between", payload_merge(connection_payload([SAMPLES10_URL], sas=[DUMMY_SAS]), attributes_between_surfaces_payload())),
 ])
 @pytest.mark.parametrize("token, status, error", [
     (generate_container_signature(
@@ -86,11 +86,11 @@ def test_cached_data_access_with_various_sas(path, payload, token, status, error
 
 
 @pytest.mark.parametrize("path, payload", [
-    ("slice", slice_payload()),
-    ("fence", fence_payload()),
-    ("metadata", metadata_payload()),
-    ("attributes/surface/along", attributes_along_surface_payload()),
-    ("attributes/surface/between", attributes_between_surfaces_payload()),
+    ("slice",payload_merge(connection_payload(VDS_URL, DUMMY_SAS), slice_payload())),
+    ("fence", payload_merge(connection_payload(VDS_URL, DUMMY_SAS), fence_payload())),
+    ("metadata", connection_payload(VDS_URL, DUMMY_SAS)),
+    ("attributes/surface/along", payload_merge(connection_payload([SAMPLES10_URL], [DUMMY_SAS] ), attributes_along_surface_payload())),
+    ("attributes/surface/between", payload_merge(connection_payload([SAMPLES10_URL], [DUMMY_SAS]), attributes_between_surfaces_payload())),
 ])
 def test_assure_only_allowed_storage_accounts(path, payload):
     payload.update({
@@ -103,11 +103,11 @@ def test_assure_only_allowed_storage_accounts(path, payload):
 
 
 @pytest.mark.parametrize("path, payload", [
-    ("slice",   slice_payload()),
-    ("fence",   fence_payload()),
-    ("metadata",   metadata_payload()),
-    ("attributes/surface/along", attributes_along_surface_payload()),
-    ("attributes/surface/between", attributes_between_surfaces_payload()),
+    ("slice", payload_merge(connection_payload(VDS_URL, DUMMY_SAS), slice_payload())),
+    ("fence",   payload_merge(connection_payload(VDS_URL, DUMMY_SAS), fence_payload())),
+    ("metadata",   connection_payload(VDS_URL, DUMMY_SAS)),
+    ("attributes/surface/along", payload_merge(connection_payload([SAMPLES10_URL], [DUMMY_SAS] ), attributes_along_surface_payload())),
+    ("attributes/surface/between", payload_merge(connection_payload([SAMPLES10_URL], [DUMMY_SAS] ), attributes_between_surfaces_payload())),
 ])
 @pytest.mark.parametrize("vds, sas, expected", [
     (f'{SAMPLES10_URL}?{gen_default_sas()}', '', http.HTTPStatus.OK),


### PR DESCRIPTION
Introduce difference between two cubes as an option for fence, slice and attribute end points. 

There are no breaking changes with requests to previous version of the API. By proving the a list of VDS URLs, SAS tokens and a binary operator the user can make the request on the resulting data set. For instance a fence request to the subtraction of one cube from another only calculate the difference on traces in the fence request. 