### PR TITLE
Make CMake search for Boost libraries in C++ tests

### DIFF
--- a/internal/core/CMakeLists.txt
+++ b/internal/core/CMakeLists.txt
@@ -23,3 +23,8 @@ target_include_directories(cppcore
 target_link_libraries(cppcore
   PUBLIC openvds::openvds
 )
+
+find_package(Boost REQUIRED)
+target_include_directories(cppcore
+  PRIVATE ${Boost_INCLUDE_DIRS}
+)


### PR DESCRIPTION
Building the tests were failing on systems where Boost is not in the default search path for include directories, e.g., if Boost was installed with Homebrew.

The change also makes the dependency on liboost more explicit as CMake will print an error message if CMake does not find Boost during the configuration stage.

## Error message without the change

```
$ cd build/ && make
[...]
[ 50%] Building CXX object internal/core/CMakeFiles/cppcore.dir/subcube.cpp.o
[ 50%] Built target gtest
[ 53%] Building CXX object internal/core/CMakeFiles/cppcore.dir/subvolume.cpp.o
/Users/AEJ/projects/github/vds-slice/internal/core/metadatahandle.cpp:6:10: fatal error: 'boost/algorithm/string/join.hpp' file not found
#include <boost/algorithm/string/join.hpp>
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
make[2]: *** [internal/core/CMakeFiles/cppcore.dir/metadatahandle.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
[ 57%] Building CXX object _deps/googletest-build/googletest/CMakeFiles/gtest_main.dir/src/gtest_main.cc.o
[ 61%] Building CXX object _deps/googletest-build/googlemock/CMakeFiles/gmock.dir/src/gmock-all.cc.o
/Users/AEJ/projects/github/vds-slice/internal/core/subvolume.cpp:7:10: fatal error: 'boost/math/interpolators/makima.hpp' file not found
#include <boost/math/interpolators/makima.hpp>
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
make[2]: *** [internal/core/CMakeFiles/cppcore.dir/subvolume.cpp.o] Error 1
make[1]: *** [internal/core/CMakeFiles/cppcore.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[ 65%] Linking CXX static library ../../../lib/libgtest_main.a
[ 65%] Built target gtest_main
cd[ 69%] Linking CXX static library ../../../lib/libgmock.a
 [ 69%] Built target gmock
make: *** [all] Error 2
```