### PR TITLE
Prepare radixconfig for production

### DIFF
--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -1,15 +1,19 @@
+#radixconfig production
 apiVersion: radix.equinor.com/v1
 kind: RadixApplication
 metadata:
-  name: oneseismictest
+  name: oneseismic
 spec:
   environments:
-    - name: dev
+    # stable production branch users are supposed to use
+    - name: prod
       build:
         from: radix
+    # environment that can be used for performance testing
+    # environment must be stopped when not needed
     - name: test
       build:
-        from: test
+        from: radix_test
   components:
     - name: server
       dockerfileName: Dockerfile
@@ -25,7 +29,7 @@ spec:
         azure:
           clientId: fd162526-89a0-448a-979f-655c0717db52
       environmentConfig:
-        - environment: dev
+        - environment: prod
           variables:
             VDSSLICE_PORT: 8080
             VDSSLICE_CACHE_SIZE: 512 # MB
@@ -36,20 +40,21 @@ spec:
               - name: S067-RadixKeyvault
                 useAzureIdentity: true
                 items:
-                  - name: playground-dev-allowlist
+                  - name: prod-allowlist
                     envVar: VDSSLICE_STORAGE_ACCOUNTS
           monitoring: true
           resources:
             requests:
-              memory: "6144Mi"
-              cpu: "4000m"
+              memory: "8192Mi"
+              cpu: "2000m"
           horizontalScaling:
             minReplicas: 1
-            maxReplicas: 3
+            maxReplicas: 1
         - environment: test
+          replicas: 0
           variables:
             VDSSLICE_PORT: 8080
-            VDSSLICE_CACHE_SIZE: 256 # MB
+            VDSSLICE_CACHE_SIZE: 0 # MB
             VDSSLICE_METRICS: true
             VDSSLICE_METRICS_PORT: 8081
           secretRefs:
@@ -57,13 +62,13 @@ spec:
               - name: S067-RadixKeyvault
                 useAzureIdentity: true
                 items:
-                  - name: playground-test-allowlist
+                  - name: test-allowlist
                     envVar: VDSSLICE_STORAGE_ACCOUNTS
           monitoring: true
           resources:
             requests:
-              memory: "6144Mi"
+              memory: "8192Mi"
               cpu: "2000m"
           horizontalScaling:
             minReplicas: 1
-            maxReplicas: 3
+            maxReplicas: 1

--- a/radixconfig_playground.yaml
+++ b/radixconfig_playground.yaml
@@ -1,0 +1,45 @@
+apiVersion: radix.equinor.com/v1
+kind: RadixApplication
+metadata:
+  name: oneseismictest
+spec:
+  environments:
+    - name: test
+      build:
+        from: radix_playground
+  components:
+    - name: server
+      dockerfileName: Dockerfile
+      ports:
+        - name: http
+          port: 8080
+        - name: metrics
+          port: 8081
+      publicPort: http
+      monitoringConfig:
+        portName: metrics
+      identity:
+        azure:
+          clientId: fd162526-89a0-448a-979f-655c0717db52
+      environmentConfig:
+        - environment: test
+          variables:
+            VDSSLICE_PORT: 8080
+            VDSSLICE_CACHE_SIZE: 0 # MB
+            VDSSLICE_METRICS: true
+            VDSSLICE_METRICS_PORT: 8081
+          secretRefs:
+            azureKeyVaults:
+              - name: S067-RadixKeyvault
+                useAzureIdentity: true
+                items:
+                  - name: playground-test-allowlist
+                    envVar: VDSSLICE_STORAGE_ACCOUNTS
+          monitoring: true
+          resources:
+            requests:
+              memory: "500Mi"
+              cpu: "200m"
+          horizontalScaling:
+            minReplicas: 1
+            maxReplicas: 1


### PR DESCRIPTION
Some production app is partly created from test branches containing this PR code, but it will be set up properly during/after this PR merge.

Note: We can't have 0 replicas. If we set it like so, it is impossible to start the component. So it seems like we need to push to test environments only when we need to and stop them explicitly once we don't need them.
Alternative is to talk to Radix team and ask them to implement containers in stopped state.