### PR TITLE
Visualize performance tests results

### DIFF
--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -92,6 +92,7 @@ jobs:
 
       - name: Run "${{ matrix.name }}" test
         env:
+          TEST_NAME: ${{ matrix.name }}
           VDS: https://${{ secrets.STORAGE_ACCOUNT_NAME }}.blob.core.windows.net/${{ matrix.vds }}
           ENDPOINT: ${{ secrets.ENDPOINT }}
           STORAGE_ACCOUNT_NAME: ${{ secrets.STORAGE_ACCOUNT_NAME }}
@@ -100,9 +101,16 @@ jobs:
           LOGPATH: "/out"
           MEDTIME: ${{ matrix.medtime }}
           MAXTIME: ${{ matrix.maxtime }}
+          K6_PROMETHEUS_RW_SERVER_URL: "http://127.0.0.1:9090/api/v1/write"
+          K6_REMOTE_RW_URL: ${{secrets.K6_REMOTE_RW_URL}}
+          TENANT_ID: ${{secrets.TENANT_ID}}
+          K6_REMOTE_RW_CLIENT_ID: ${{secrets.K6_REMOTE_RW_CLIENT_ID}}
+          K6_REMOTE_RW_CLIENT_SECRET: ${{secrets.K6_REMOTE_RW_CLIENT_SECRET}}
+          K6_PROMETHEUS_RW_PUSH_INTERVAL: "15s"
         run: |
           tag=performance_tests
           docker run \
+            -e TEST_NAME \
             -e STORAGE_ACCOUNT_NAME \
             -e STORAGE_ACCOUNT_KEY \
             -e ENDPOINT \
@@ -111,9 +119,15 @@ jobs:
             -e MEDTIME \
             -e MAXTIME \
             -e LOGPATH \
+            -e K6_PROMETHEUS_RW_SERVER_URL \
+            -e K6_REMOTE_RW_URL \
+            -e TENANT_ID \
+            -e K6_REMOTE_RW_CLIENT_ID \
+            -e K6_REMOTE_RW_CLIENT_SECRET \
+            -e K6_PROMETHEUS_RW_PUSH_INTERVAL \
             -v $(pwd)/out:/out \
             $tag \
-            /bin/sh -c 'python /tests/performance/performance.py ${{ matrix.filepath }}'
+            /bin/bash -c '/tests/performance/execute.sh ${{ matrix.filepath }}'
 
       - name: Print stderr
         if: always()

--- a/.github/workflows/performance_user_input.yaml
+++ b/.github/workflows/performance_user_input.yaml
@@ -48,6 +48,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run "${{ inputs.filepath }}" performance tests for "${{ env.VDS }}"
         env:
+          TEST_NAME: "Manual execution"
           LOGPATH: "/out"
           MEDTIME: ${{ inputs.medtime }}
           MAXTIME: ${{ inputs.maxtime }}
@@ -55,6 +56,7 @@ jobs:
           tag=performance
           docker build -f tests/performance/Dockerfile -t $tag .
           docker run \
+            -e TEST_NAME \
             -e VDS \
             -e SAS \
             -e ENDPOINT \

--- a/tests/performance/Dockerfile
+++ b/tests/performance/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.10-slim
 RUN apt-get update && apt-get install -y \
-    curl
+    curl \
+    gettext-base
 
 ARG k6_version=0.49.0
 RUN mkdir k6
@@ -11,7 +12,17 @@ RUN tar xzf k6-${k6_version}.tar.gz -C k6 --strip-components=1
 
 ENV PATH "$PATH:k6"
 
+ARG prometheus_version=2.50.1
+RUN mkdir prometheus
+RUN curl \
+    -L https://github.com/prometheus/prometheus/releases/download/v${prometheus_version}/prometheus-${prometheus_version}.linux-amd64.tar.gz \
+    -o prometheus-${prometheus_version}.tar.gz
+RUN tar xzf prometheus-${prometheus_version}.tar.gz -C prometheus --strip-components=1
+
+ENV PATH "$PATH:prometheus"
+
 COPY ./tests/utils /tests/utils
 COPY ./tests/performance /tests/performance
+RUN chmod +x /tests/performance/execute.sh
 RUN python -m pip install -r /tests/performance/requirements-dev.txt
 ENV PYTHONPATH "${PYTHONPATH}:/tests"

--- a/tests/performance/Dockerfile
+++ b/tests/performance/Dockerfile
@@ -2,12 +2,12 @@ FROM python:3.10-slim
 RUN apt-get update && apt-get install -y \
     curl
 
-ENV version 0.38.0
+ARG k6_version=0.49.0
 RUN mkdir k6
 RUN curl \
-    -L https://github.com/grafana/k6/releases/download/v$version/k6-v$version-linux-amd64.tar.gz \
-    -o k6-$version.tar.gz
-RUN tar xf k6-$version.tar.gz -C k6 --strip-components=1
+    -L https://github.com/grafana/k6/releases/download/v${k6_version}/k6-v${k6_version}-linux-amd64.tar.gz \
+    -o k6-${k6_version}.tar.gz
+RUN tar xzf k6-${k6_version}.tar.gz -C k6 --strip-components=1
 
 ENV PATH "$PATH:k6"
 

--- a/tests/performance/execute.sh
+++ b/tests/performance/execute.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# for some reason direct remote write from k6 to azure monitor doesn't work,
+# hence local write to prometheus is used as a workaround. It could be removed
+# if k6 -> Azure monitor begins to work
+
+# prometheus doesn't use environment variables, so there is no other way to set
+# secrets other then replace them in the file. Secret file path is also not
+# implemented for azure at the moment
+envsubst < /tests/performance/prometheus-template.yml > /tests/performance/prometheus.yml
+
+prometheus --config.file=/tests/performance/prometheus.yml --web.enable-remote-write-receiver &
+
+python /tests/performance/performance.py "$1"
+

--- a/tests/performance/helpers/metrics-helper.js
+++ b/tests/performance/helpers/metrics-helper.js
@@ -2,7 +2,7 @@ import { Trend } from "k6/metrics";
 
 export const responseLengthTrend = new Trend("response_length");
 export const requestTimeTrend = new Trend(
-  `request_time_med_${request_time_med_threshold()}_p95_${request_time_p95_threshold()}`,
+  `request_time_${__ENV.TEST_NAME.replace(/[^a-zA-Z0-9_]/g, '_').substring(0, 127)}`,
   true
 );
 

--- a/tests/performance/helpers/report-helpers.js
+++ b/tests/performance/helpers/report-helpers.js
@@ -2,7 +2,7 @@ import { textSummary } from "https://jslib.k6.io/k6-summary/0.0.1/index.js";
 import * as metrics from "./metrics-helper.js";
 
 const basicThresholds = {
-  "checks{status checks:query}": [{ threshold: "rate == 1.00" }],
+  "checks{status_checks:query}": [{ threshold: "rate == 1.00" }],
 };
 
 export function thresholds() {

--- a/tests/performance/helpers/request-helpers.js
+++ b/tests/performance/helpers/request-helpers.js
@@ -76,7 +76,7 @@ export function sendRequest(path, payload) {
     {
       "query response: status must be 200": (r) => r.status === 200,
     },
-    { "status checks": "query" }
+    { "status_checks": "query" }
   );
   if (!queryResStatusCheck) {
     fail(`Wrong 'query' response status: ${res.status}`);

--- a/tests/performance/prometheus-template.yml
+++ b/tests/performance/prometheus-template.yml
@@ -1,0 +1,23 @@
+global:
+  scrape_interval: "${K6_PROMETHEUS_RW_PUSH_INTERVAL}"
+  evaluation_interval: "${K6_PROMETHEUS_RW_PUSH_INTERVAL}"
+
+scrape_configs:
+  - job_name: "vdsslice_performance"
+    track_timestamps_staleness: true
+    static_configs:
+      - targets: ["localhost:9090"]
+
+remote_write:
+- name: "azure_monitor"
+  url: "${K6_REMOTE_RW_URL}"
+  azuread:
+    cloud: 'AzurePublic'
+    oauth:
+      client_id: "${K6_REMOTE_RW_CLIENT_ID}"
+      client_secret: "${K6_REMOTE_RW_CLIENT_SECRET}"
+      tenant_id: "${TENANT_ID}"
+
+  metadata_config:
+    send_interval: "${K6_PROMETHEUS_RW_PUSH_INTERVAL}"
+

--- a/tests/performance/script-constant-fence.js
+++ b/tests/performance/script-constant-fence.js
@@ -5,7 +5,7 @@ import { createSummary, thresholds, summaryTrendStats } from "./helpers/report-h
 
 export const options = {
   scenarios: {
-    constantSlice: {
+    constantFence: {
       executor: "constant-vus",
       vus: 1,
       duration: "1m",

--- a/tests/performance/script-constant-timeslice.js
+++ b/tests/performance/script-constant-timeslice.js
@@ -8,7 +8,7 @@ import { createSummary, thresholds, summaryTrendStats } from "./helpers/report-h
 
 export const options = {
   scenarios: {
-    constantSlice: {
+    constantTimeSlice: {
       executor: "constant-vus",
       vus: 1,
       duration: "1m",

--- a/tests/performance/script-random-fence.js
+++ b/tests/performance/script-random-fence.js
@@ -5,7 +5,7 @@ import { createSummary, thresholds, summaryTrendStats } from "./helpers/report-h
 
 export const options = {
   scenarios: {
-    constantSlice: {
+    randomFence: {
       executor: "constant-vus",
       vus: 1,
       duration: "30s",

--- a/tests/performance/script-random-inlineslice.js
+++ b/tests/performance/script-random-inlineslice.js
@@ -4,7 +4,7 @@ import { createSummary, thresholds, summaryTrendStats } from "./helpers/report-h
 
 export const options = {
   scenarios: {
-    constantSlice: {
+    randomInlineSlice: {
       executor: "constant-vus",
       vus: 1,
       duration: "2m",

--- a/tests/performance/script-sequential-inlineslice.js
+++ b/tests/performance/script-sequential-inlineslice.js
@@ -11,7 +11,7 @@ import exec from "k6/execution";
 
 export const options = {
   scenarios: {
-    constantSlice: {
+    sequentialInlineSlice: {
       executor: "constant-vus",
       vus: 1,
       duration: "2m",


### PR DESCRIPTION
Sends data to the Azure Monitor service via local prometheus.

What tests we want to run, what configurations we need, what we want to show in grafana is a different topic, but if you have any immediate improvement suggestions - comment straight away.

`Performance tests` workflow would be configured the way so every run over provided ENDPOINT secret sends data to the azure monitor instance. We'd need to decide whether we want to run that on schedule on not, also against which endpoint.
Currently runs can be found on my fork and tests results should be visible in grafana.

`Performance (manual)` workflow doesn't send anything anywhere.

Resources (Azure Monitor and Grafana) can be found in our Azure test resource group with prefix performance.