### PR TITLE
Expose storage account in metric

### DIFF
--- a/api/endpoint.go
+++ b/api/endpoint.go
@@ -63,8 +63,16 @@ func prepareRequestLogging(ctx *gin.Context, request Stringable) {
 	ctx.Set("request", requestString)
 }
 
+func prepareMetricsLogging(ctx *gin.Context, request interface {
+	credentials() ([]string, []string, string)
+}) {
+	vds, _, _ := request.credentials()
+	ctx.Set("vds", vds)
+}
+
 func (e *Endpoint) metadata(ctx *gin.Context, request MetadataRequest) {
 	prepareRequestLogging(ctx, request)
+	prepareMetricsLogging(ctx, request.RequestedResource)
 
 	if len(request.Vds) != 1 || len(request.Sas) != 1 {
 		err := core.NewInvalidArgument("Metadata requests only accepts one VDS url and one sas token")
@@ -105,6 +113,7 @@ func (e *Endpoint) makeDataRequest(
 	request DataRequest,
 ) {
 	prepareRequestLogging(ctx, request)
+	prepareMetricsLogging(ctx, request)
 
 	vdsUrls, sasTokens, binaryOperatorString := request.credentials()
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -49,7 +49,7 @@ func NewMetrics() *Metrics {
 		}, []string{"path", "status"}),
 
 		requestCount: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "vdsslice_number_of_requests",
+			Name: "vdsslice_requests_count",
 			Help: "VDSslice number of requests.",
 		}, []string{"method", "path"}),
 	}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,9 +1,10 @@
 package metrics
 
-
 import (
-	"time"
+	"net/url"
+	"slices"
 	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
@@ -51,7 +52,7 @@ func NewMetrics() *Metrics {
 		requestCount: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "vdsslice_requests_count",
 			Help: "VDSslice number of requests.",
-		}, []string{"method", "path"}),
+		}, []string{"method", "path", "storage_account"}),
 	}
 
 	registry.MustRegister(metrics.requestDurations)
@@ -70,6 +71,7 @@ func NewGinMiddleware(metrics *Metrics) gin.HandlerFunc {
 		go func() {
 			path     := ctx.Request.URL.Path
 			method   := ctx.Request.Method
+			vdsURLs  := ctx.GetStringSlice("vds")
 			status   := strconv.Itoa(ctx.Writer.Status())
 			size     := float64(ctx.Writer.Size())
 			cachehit := strconv.FormatBool(ctx.GetBool("cache-hit"))
@@ -82,8 +84,32 @@ func NewGinMiddleware(metrics *Metrics) gin.HandlerFunc {
 			).Observe(duration)
 
 			metrics.responseSizes.WithLabelValues(path, status).Observe(size)
-			metrics.requestCount.WithLabelValues(method, path).Inc()
+			metrics.updateRequestCountMetric(method, path, vdsURLs)
 		}()
+	}
+}
+
+func extractStorageAccounts(vdsURLs []string) []string{
+	var storageAccounts []string
+	for _, vdsURL := range vdsURLs {
+		parsedURL, err := url.Parse(vdsURL)
+		if err != nil {
+			storageAccounts = append(storageAccounts, vdsURL)
+			continue
+		}
+		storageAccounts = append(storageAccounts, parsedURL.Hostname())
+	}
+
+	slices.Sort(storageAccounts)
+	storageAccounts = slices.Compact(storageAccounts)
+	return storageAccounts
+}
+
+func (metrics *Metrics) updateRequestCountMetric(method string, path string, vdsURLs []string) {
+	storageAccounts := extractStorageAccounts(vdsURLs)
+
+	for _, storageAccount := range storageAccounts {
+		metrics.requestCount.WithLabelValues(method, path, storageAccount).Inc()
 	}
 }
 

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,51 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractStorageAccounts(t *testing.T) {
+	testcases := []struct {
+		name     string
+		urls     []string
+		expected []string
+	}{
+		{
+			name:     "One good vds URL",
+			urls:     []string{"https://account.blob.core.windows.net/container/path"},
+			expected: []string{"account.blob.core.windows.net"},
+		},
+		{
+			name:     "Empty vds URL",
+			urls:     []string{""},
+			expected: []string{""},
+		},
+		{
+			name:     "Bad vds URL",
+			urls:     []string{"::??::"},
+			expected: []string{"::??::"},
+		},
+		{
+			name:     "Two same storage accounts",
+			urls:     []string{"https://example.com/path2", "http://example.com/path1"},
+			expected: []string{"example.com"},
+		},
+		{
+			name:     "Two different storage accounts",
+			urls:     []string{"https://cat2.org/path", "https://cat1.org/path"},
+			expected: []string{"cat1.org", "cat2.org"},
+		},
+		{
+			name:     "Good and bad vds URLs",
+			urls:     []string{"ht^tp://illegal.com", "https://feed.cat"},
+			expected: []string{"ht^tp://illegal.com", "feed.cat"},
+		},
+	}
+
+	for _, testcase := range testcases {
+		storageAccounts := extractStorageAccounts(testcase.urls)
+		require.ElementsMatch(t, storageAccounts, testcase.expected, "[case: %v]", testcase.name)
+	}
+}


### PR DESCRIPTION
Playground grafana is updated with respective panel, production grafana will be changed after merge (might need to discuss the need to exclude test storage account from all the metrics)