### PR TITLE
Set stepsize to 1 when one sample

### DIFF
--- a/internal/core/axis.cpp
+++ b/internal/core/axis.cpp
@@ -35,8 +35,11 @@ int Axis::dimension() const noexcept(true) {
     return this->m_dimension;
 }
 
-float Axis::stepsize() const noexcept (true) {
-    return (this->max() - this->min()) / (this->nsamples() - 1);
+float Axis::stepsize() const noexcept(true) {
+    if (this->nsamples() == 1)
+        return 1;
+    else
+        return (this->max() - this->min()) / (this->nsamples() - 1);
 }
 
 std::string Axis::name() const noexcept(true) {


### PR DESCRIPTION
When the input vds file only contains a single iline or xline the stepsize was calculated to "nan".

The problem occurred when this notebook was recreated. 
[1410_Phase/phase_and_hilbert_transform.ipynb](https://github.com/seg/tutorials-2014/blob/aab1cf917bc4b223e1061d2984aa1bce4bc41a1c/1410_Phase/phase_and_hilbert_transform.ipynb)

Following python code can be used for testing:
    import numpy as np
    import matplotlib.pyplot as plt
    from oneseismic import OneseismicClient
    
    # The oneseismic server
    server = "http://127.0.0.1:8080"
    
    # Url and sas token to a vds stored somewhere in Azure
    vds = "https://onevdstest.blob.core.windows.net/testdata/phase_data/penobscot_xl1155_test"
    sas = "?SAS"
    
    cube = OneseismicClient(server, vds, sas)
    metadata = cube.metadata()
    print(metadata)
    
    data, metadata = cube.slice('crossline', 1155)
    vrng = max(abs(np.min(data)), np.max(data))
    data_t = np.transpose(data)[500:750, :]
    
    plt.figure(figsize=(12,6))
    plt.imshow(data_t, vmin=-vrng/5, vmax=vrng/5, cmap='seismic', aspect='auto')
    _=plt.title(f"Penobscot - partial xline 1155 ({500*4}ms, {750*4}ms)")
