### PR TITLE
Add trusted proxies option

### DIFF
--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -35,6 +35,7 @@ spec:
             VDSSLICE_CACHE_SIZE: 512 # MB
             VDSSLICE_METRICS: true
             VDSSLICE_METRICS_PORT: 8081
+            VDSSLICE_TRUSTED_PROXIES: ""
           secretRefs:
             azureKeyVaults:
               - name: S067-RadixKeyvault
@@ -57,6 +58,7 @@ spec:
             VDSSLICE_CACHE_SIZE: 0 # MB
             VDSSLICE_METRICS: true
             VDSSLICE_METRICS_PORT: 8081
+            VDSSLICE_TRUSTED_PROXIES: ""
           secretRefs:
             azureKeyVaults:
               - name: S067-RadixKeyvault

--- a/radixconfig_playground.yaml
+++ b/radixconfig_playground.yaml
@@ -28,6 +28,7 @@ spec:
             VDSSLICE_CACHE_SIZE: 0 # MB
             VDSSLICE_METRICS: true
             VDSSLICE_METRICS_PORT: 8081
+            VDSSLICE_TRUSTED_PROXIES: ""
           secretRefs:
             azureKeyVaults:
               - name: S067-RadixKeyvault


### PR DESCRIPTION
Add an option to set a list of trusted proxies when starting the server. This option will determine which IP is considered to be the source IP of a request when headers that contain alternative IP adresses are set (if the proxy is trusted the IP the request is forwarded for will be considered rthe source).

As far as we know the only part of our system
that currently will be impacted by this is the logging.