### PR TITLE
Index to annotation in cube intersection gtests

### DIFF
--- a/tests/gtest/CMakeLists.txt
+++ b/tests/gtest/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(cppcoretests
   datahandle_test.cpp
   regularsurface_test.cpp
   subvolume_test.cpp
+  test_utils.cpp
 )
 
 target_link_libraries(cppcoretests

--- a/tests/gtest/datahandle_attribute_test.cpp
+++ b/tests/gtest/datahandle_attribute_test.cpp
@@ -3,6 +3,8 @@
 #include <iostream>
 #include <sstream>
 
+#include "test_utils.hpp"
+
 #include "attribute.hpp"
 #include "metadatahandle.hpp"
 #include "subvolume.hpp"
@@ -12,172 +14,46 @@
 
 namespace {
 
-/// Each value in the test files has the positional information encoded in little-endian.
-/// Byte 0: Sample position
-/// Byte 1: CrossLine position
-/// Byte 2: InLine position
-const std::string REGULAR_DATA = "file://regular_8x2_cube.vds";
-const std::string SHIFT_4_DATA = "file://shift_4_8x2_cube.vds";
-const std::string SHIFT_8_32_DATA = "file://shift_8_32x3_cube.vds";
+/**
+ * @brief Get the grid object
+ *
+ * @param datahandle
+ * @param origin_steps_shift_iline Integer number of steps in iline direction to shift origin by
+ * @param origin_steps_shift_xline Integer number of steps in xline direction to shift origin by
+ * @return Grid
+ */
+Grid get_grid(DataHandle& datahandle, int origin_steps_shift_iline, int origin_steps_shift_xline) {
+    const MetadataHandle& metadata = datahandle.get_metadata();
 
-const std::string CREDENTIALS = "";
+    auto cdp = metadata.bounding_box().world();
 
+    auto nsteps_iline = metadata.iline().nsamples() - 1;
+    auto nsteps_xline = metadata.xline().nsamples() - 1;
 
-class DatahandleAttributeTest : public ::testing::Test {
-protected:
-    DatahandleAttributeTest() : single_datahandle(make_single_datahandle(REGULAR_DATA.c_str(), CREDENTIALS.c_str())),
-                                double_datahandle(make_double_datahandle(
-                                    REGULAR_DATA.c_str(),
-                                    CREDENTIALS.c_str(),
-                                    SHIFT_4_DATA.c_str(),
-                                    CREDENTIALS.c_str(),
-                                    binary_operator::ADDITION
-                                )),
-                                double_reverse_datahandle(make_double_datahandle(
-                                    SHIFT_4_DATA.c_str(),
-                                    CREDENTIALS.c_str(),
-                                    REGULAR_DATA.c_str(),
-                                    CREDENTIALS.c_str(),
-                                    binary_operator::ADDITION
-                                )),
-                                double_different_size(make_double_datahandle(
-                                    SHIFT_4_DATA.c_str(),
-                                    CREDENTIALS.c_str(),
-                                    SHIFT_8_32_DATA.c_str(),
-                                    CREDENTIALS.c_str(),
-                                    binary_operator::ADDITION
-                                )) {}
+    auto iline_distance_x = cdp[1].first - cdp[0].first;
+    auto iline_distance_y = cdp[1].second - cdp[0].second;
+    auto xline_distance_x = cdp[3].first - cdp[0].first;
+    auto xline_distance_y = cdp[3].second - cdp[0].second;
 
-    void SetUp() override {
+    double xori = cdp[0].first;
+    double yori = cdp[0].second;
+    const double xinc = std::hypot(iline_distance_x, iline_distance_y) / nsteps_iline;
+    const double yinc = std::hypot(xline_distance_x, xline_distance_y) / nsteps_xline;
+    const double rotation = std::atan2(iline_distance_y, iline_distance_x) * 180 / M_PI;
 
-        iline_array = std::vector<int>(32);
-        xline_array = std::vector<int>(32);
-        sample_array = std::vector<int>(32);
+    xori += iline_distance_x * origin_steps_shift_iline / nsteps_iline +
+            xline_distance_x * origin_steps_shift_xline / nsteps_xline;
+    yori += iline_distance_y * origin_steps_shift_iline / nsteps_iline +
+            xline_distance_y * origin_steps_shift_xline / nsteps_xline;
 
-        for (int i = 0; i < iline_array.size(); i++) {
-            iline_array[i] = 3 + i * 3;
-            xline_array[i] = 2 + i * 2;
-        }
+    return Grid(xori, yori, xinc, yinc, rotation);
+}
 
-        for (int i = 0; i < sample_array.size(); i++) {
-            sample_array[i] = 4 + i * 4;
-        }
-    }
+Grid get_grid(DataHandle& datahandle) {
+    return get_grid(datahandle, 0, 0);
+}
 
-public:
-    std::vector<int> iline_array;
-    std::vector<int> xline_array;
-    std::vector<int> sample_array;
-
-    std::vector<Bound> slice_bounds;
-
-    SingleDataHandle single_datahandle;
-    DoubleDataHandle double_datahandle;
-    DoubleDataHandle double_reverse_datahandle;
-    DoubleDataHandle double_different_size;
-
-    static constexpr float fill = -999.25;
-
-    Grid get_grid(DataHandle& datahandle) {
-        return get_grid(datahandle, 0, 0);
-    }
-
-    /**
-     * @brief Get the grid object
-     *
-     * @param datahandle
-     * @param origin_steps_shift_iline Integer number of steps in iline direction to shift origin by
-     * @param origin_steps_shift_xline Integer number of steps in xline direction to shift origin by
-     * @return Grid
-     */
-    Grid get_grid(DataHandle& datahandle, int origin_steps_shift_iline, int origin_steps_shift_xline) {
-        const MetadataHandle& metadata = datahandle.get_metadata();
-
-        auto cdp = metadata.bounding_box().world();
-
-        auto nsteps_iline = metadata.iline().nsamples() - 1;
-        auto nsteps_xline = metadata.xline().nsamples() - 1;
-
-        auto iline_distance_x = cdp[1].first - cdp[0].first;
-        auto iline_distance_y = cdp[1].second - cdp[0].second;
-        auto xline_distance_x = cdp[3].first - cdp[0].first;
-        auto xline_distance_y = cdp[3].second - cdp[0].second;
-
-        double xori = cdp[0].first;
-        double yori = cdp[0].second;
-        const double xinc = std::hypot(iline_distance_x, iline_distance_y) / nsteps_iline;
-        const double yinc = std::hypot(xline_distance_x, xline_distance_y) / nsteps_xline;
-        const double rotation = std::atan2(iline_distance_y, iline_distance_x) * 180 / M_PI;
-
-        xori += iline_distance_x * origin_steps_shift_iline / nsteps_iline +
-                xline_distance_x * origin_steps_shift_xline / nsteps_xline;
-        yori += iline_distance_y * origin_steps_shift_iline / nsteps_iline +
-                xline_distance_y * origin_steps_shift_xline / nsteps_xline;
-
-        return Grid(xori, yori, xinc, yinc, rotation);
-    }
-
-    void check_attribute(SurfaceBoundedSubVolume& subvolume, int low[], int high[], float factor) {
-        return check_attribute(subvolume, low, high, low, high, factor);
-    }
-
-    /**
-     * @brief Check attribute values against expected values
-     *
-     * @param subvolume
-     * @param requested_low Low limit on axis for requested data. Array contains
-     * 3 values corresponding to indicies in iline_array, xline_array,
-     * sample_array.
-     * @param requested_high High limit on axis for requested data. Exclusive
-     * @param expected_low Low limit on axis for expected returned data.
-     * @param expected_high High limit on axis for expected returned data. Exclusive
-     * @param factor multiplicative factor (expected value * factor = actual
-     * value). Expected value comes from rules used in file creation
-     */
-    void check_attribute(
-        SurfaceBoundedSubVolume& subvolume, int requested_low[], int requested_high[],
-        int expected_low[], int expected_high[], float factor
-    ) {
-
-        std::size_t nr_of_values = subvolume.nsamples(
-            0, (requested_high[0] - requested_low[0]) * (requested_high[1] - requested_low[1])
-        );
-        EXPECT_EQ(
-            nr_of_values,
-            (expected_high[0] - expected_low[0]) *
-                (expected_high[1] - expected_low[1]) *
-                (expected_high[2] - expected_low[2])
-        );
-
-        int counter = 0;
-        for (int il = requested_low[0]; il < requested_high[0]; ++il) {
-            for (int xl = requested_low[1]; xl < requested_high[1]; ++xl) {
-                RawSegment rs = subvolume.vertical_segment(counter);
-                counter += 1;
-                if (il < expected_low[0] || il >= expected_high[0] ||
-                    xl < expected_low[1] || xl >= expected_high[1]) {
-                    EXPECT_EQ(rs.size(), 0);
-                    continue;
-                }
-                int s = expected_low[2];
-                for (auto it = rs.begin(); it != rs.end(); ++it) {
-                    int value = int(*it / factor + 0.5f);
-                    int sample = value & 0xFF;
-                    int xline = (value & 0xFF00) >> 8;
-                    int iline = (value & 0xFF0000) >> 16;
-
-                    EXPECT_EQ(iline, iline_array[il]) << "at iline " << il << " xline " << xl << " sample " << s;
-                    EXPECT_EQ(xline, xline_array[xl]) << "at iline " << il << " xline " << xl << " sample " << s;
-                    EXPECT_EQ(sample, sample_array[s]) << "at iline " << il << " xline " << xl << " sample " << s;
-                    s += 1;
-                }
-                EXPECT_EQ(s, expected_high[2]);
-            }
-        }
-    }
-};
-
-TEST_F(DatahandleAttributeTest, Attribute_Single) {
+TEST_F(DatahandleCubeIntersectionTest, Attribute_Single) {
 
     DataHandle& datahandle = single_datahandle;
     Grid grid = get_grid(datahandle);
@@ -195,14 +71,14 @@ TEST_F(DatahandleAttributeTest, Attribute_Single) {
 
     cppapi::fetch_subvolume(single_datahandle, *subvolume, NEAREST, 0, nrows * ncols);
 
-    int low[3] = {0, 0, 4};
-    int high[3] = {8, 8, 15};
+    int low[3] = {3, 2, 28};
+    int high[3] = {24, 16, 52};
     check_attribute(*subvolume, low, high, 1);
 
     delete subvolume;
 }
 
-TEST_F(DatahandleAttributeTest, Attribute_Double) {
+TEST_F(DatahandleCubeIntersectionTest, Attribute_Double) {
 
     DoubleDataHandle& datahandle = double_datahandle;
     Grid grid = get_grid(datahandle);
@@ -220,14 +96,14 @@ TEST_F(DatahandleAttributeTest, Attribute_Double) {
 
     cppapi::fetch_subvolume(datahandle, *subvolume, NEAREST, 0, nrows * ncols);
 
-    int low[3] = {4, 4, 4};
-    int high[3] = {8, 8, 15};
+    int low[3] = {15, 10, 28};
+    int high[3] = {24, 16, 52};
     check_attribute(*subvolume, low, high, 2);
 
     delete subvolume;
 }
 
-TEST_F(DatahandleAttributeTest, Attribute_Reverse_Double) {
+TEST_F(DatahandleCubeIntersectionTest, Attribute_Reverse_Double) {
 
     DataHandle& datahandle = double_reverse_datahandle;
     Grid grid = get_grid(datahandle);
@@ -245,14 +121,14 @@ TEST_F(DatahandleAttributeTest, Attribute_Reverse_Double) {
 
     cppapi::fetch_subvolume(datahandle, *subvolume, NEAREST, 0, nrows * ncols);
 
-    int low[3] = {4, 4, 4};
-    int high[3] = {8, 8, 15};
+    int low[3] = {15, 10, 28};
+    int high[3] = {24, 16, 52};
     check_attribute(*subvolume, low, high, 2);
 
     delete subvolume;
 }
 
-TEST_F(DatahandleAttributeTest, Attribute_Different_Size_Double) {
+TEST_F(DatahandleCubeIntersectionTest, Attribute_Different_Size_Double) {
 
     DataHandle& datahandle = double_different_size;
     Grid grid = get_grid(datahandle);
@@ -270,15 +146,14 @@ TEST_F(DatahandleAttributeTest, Attribute_Different_Size_Double) {
 
     cppapi::fetch_subvolume(datahandle, *subvolume, NEAREST, 0, nrows * ncols);
 
-    int low[3] = {8, 8, 8};
-    int high[3] = {12, 12, 20};
+    int low[3] = {27, 18, 44};
+    int high[3] = {36, 24, 72};
     check_attribute(*subvolume, low, high, 2);
 
     delete subvolume;
 }
 
-
-TEST_F(DatahandleAttributeTest, Attribute_Double_Data_Outside_Intersection_Horizontal_Plane) {
+TEST_F(DatahandleCubeIntersectionTest, Attribute_Double_Data_Outside_Intersection_Horizontal_Plane) {
     DoubleDataHandle& datahandle = double_datahandle;
 
     /**
@@ -310,18 +185,26 @@ TEST_F(DatahandleAttributeTest, Attribute_Double_Data_Outside_Intersection_Horiz
 
     cppapi::fetch_subvolume(datahandle, *subvolume, NEAREST, 0, nrows * ncols);
 
-    int expected_low[3] = {4, 4, 4};
-    int expected_high[3] = {8, 8, 15};
+    int expected_low[3] = {15, 10, 28};
+    int expected_high[3] = {24, 16, 52};
 
-    int requested_low[3] = {expected_low[0] - preceding_ilines, expected_low[1] - preceding_xlines, expected_low[2]};
-    int requested_high[3] = {expected_high[0] + succeeding_ilines, expected_high[1] + succeeding_xlines, expected_high[2]};
+    int requested_low[3] = {
+        expected_low[0] - preceding_ilines * ILINE_STEP,
+        expected_low[1] - preceding_xlines * XLINE_STEP,
+        expected_low[2]
+    };
+    int requested_high[3] = {
+        expected_high[0] + succeeding_ilines * ILINE_STEP,
+        expected_high[1] + succeeding_xlines * XLINE_STEP,
+        expected_high[2]
+    };
 
     check_attribute(*subvolume, requested_low, requested_high, expected_low, expected_high, 2);
 
     delete subvolume;
 }
 
-TEST_F(DatahandleAttributeTest, Attribute_Double_Data_Outside_Intersection_Vertical_Plane) {
+TEST_F(DatahandleCubeIntersectionTest, Attribute_Double_Data_Outside_Intersection_Vertical_Plane) {
 
     DoubleDataHandle& datahandle = double_datahandle;
     Grid grid = get_grid(datahandle);
@@ -345,7 +228,7 @@ TEST_F(DatahandleAttributeTest, Attribute_Double_Data_Outside_Intersection_Verti
     );
 }
 
-TEST_F(DatahandleAttributeTest, Attribute_Double_Different_Number_Of_Samples_To_Border_Per_Dimension) {
+TEST_F(DatahandleCubeIntersectionTest, Attribute_Double_Different_Number_Of_Samples_To_Border_Per_Dimension) {
     const std::string INNER_CUBE = "file://inner_4x2_cube.vds";
 
     DoubleDataHandle datahandle = make_double_datahandle(
@@ -362,9 +245,9 @@ TEST_F(DatahandleAttributeTest, Attribute_Double_Different_Number_Of_Samples_To_
 
     std::size_t nrows = metadata->iline().nsamples();
     std::size_t ncols = metadata->xline().nsamples();
-    static std::vector<float> top_surface_data(nrows * ncols, 12.0f);
+    static std::vector<float> top_surface_data(nrows * ncols, 16.0f);
     static std::vector<float> pri_surface_data(nrows * ncols, 20.0f);
-    static std::vector<float> bot_surface_data(nrows * ncols, 36.0f);
+    static std::vector<float> bot_surface_data(nrows * ncols, 28.0f);
     RegularSurface pri_surface = RegularSurface(pri_surface_data.data(), nrows, ncols, grid, fill);
     RegularSurface top_surface = RegularSurface(top_surface_data.data(), nrows, ncols, grid, fill);
     RegularSurface bot_surface = RegularSurface(bot_surface_data.data(), nrows, ncols, grid, fill);
@@ -372,15 +255,15 @@ TEST_F(DatahandleAttributeTest, Attribute_Double_Different_Number_Of_Samples_To_
 
     cppapi::fetch_subvolume(datahandle, *subvolume, NEAREST, 0, nrows * ncols);
 
-    /* For regular files "low" in other double tests is something like {4, 4,
-     * 4}; The files which create this test intersection are crafted such a way
-     * that in every dimension "low" is different, thus checking for the
-     * possible mess up in values order.
+    /* For regular files "low" in other double tests is something like {4, 4, 4}
+     * in index coordinate system; The files which create this test intersection
+     * are crafted such a way that in every dimension "low" is different, thus
+     * checking for the possible mess up in values order.
      */
-    int expected_low[3] = {2, 3, 1};
-    int expected_high[3] = {6, 7, 9};
+    int expected_low[3] = {9, 8, 16};
+    int expected_high[3] = {18, 14, 28};
 
-    check_attribute(*subvolume,expected_low, expected_high, 2);
+    check_attribute(*subvolume, expected_low, expected_high, 2);
 
     delete subvolume;
 }

--- a/tests/gtest/datahandle_fence_test.cpp
+++ b/tests/gtest/datahandle_fence_test.cpp
@@ -2,127 +2,18 @@
 #include "gtest/gtest.h"
 #include <iostream>
 
+#include "test_utils.hpp"
+
 #include "cppapi.hpp"
 #include "datahandle.hpp"
-#include "regularsurface.hpp"
-#include "subvolume.hpp"
 
 namespace {
 
-/// Each value in the test files has the positional information encoded in little-endian.
-/// Byte 0: Sample position
-/// Byte 1: CrossLine position
-/// Byte 2: InLine position
-const std::string REGULAR_DATA = "file://regular_8x2_cube.vds";
-const std::string SHIFT_4_DATA = "file://shift_4_8x2_cube.vds";
-const std::string SHIFT_8_BIG_DATA = "file://shift_8_32x3_cube.vds";
-const std::string CREDENTIALS = "";
-
-class DatahandleFenceTest : public ::testing::Test {
-protected:
-    DatahandleFenceTest() : single_datahandle(make_single_datahandle(REGULAR_DATA.c_str(), CREDENTIALS.c_str())),
-                            double_datahandle(make_double_datahandle(
-                                REGULAR_DATA.c_str(),
-                                CREDENTIALS.c_str(),
-                                SHIFT_4_DATA.c_str(),
-                                CREDENTIALS.c_str(),
-                                binary_operator::ADDITION
-                            )),
-
-                            double_reverse_datahandle(make_double_datahandle(
-                                SHIFT_4_DATA.c_str(),
-                                CREDENTIALS.c_str(),
-                                REGULAR_DATA.c_str(),
-                                CREDENTIALS.c_str(),
-                                binary_operator::ADDITION
-                            )),
-
-                            double_different_size(make_double_datahandle(
-                                SHIFT_4_DATA.c_str(),
-                                CREDENTIALS.c_str(),
-                                SHIFT_8_BIG_DATA.c_str(),
-                                CREDENTIALS.c_str(),
-                                binary_operator::ADDITION
-                            )) {}
-
-    void SetUp() override {
-        iline_array = std::vector<int>(32);
-        xline_array = std::vector<int>(32);
-        sample_array = std::vector<int>(36);
-
-        for (int i = 0; i < iline_array.size(); i++) {
-            iline_array[i] = 3 + i * 3;
-            xline_array[i] = 2 + i * 2;
-        }
-
-        for (int i = 0; i < sample_array.size(); i++) {
-            sample_array[i] = 4 + i * 4;
-        }
-    }
-
-public:
-    std::vector<int> iline_array;
-    std::vector<int> xline_array;
-    std::vector<int> sample_array;
-
-    SingleDataHandle single_datahandle;
-    DoubleDataHandle double_datahandle;
-    DoubleDataHandle double_reverse_datahandle;
-    DoubleDataHandle double_different_size;
-
-    static constexpr float fill = -999.25;
-
-    /**
-     * @brief Check result from fence request
-     *
-     * @param response_data Result from request
-     * @param coordinates Provided coordinates (index based)
-     * @param low Low limit on samples axis for expected data as per indicies in
-     * sample_array.
-     * @param high High limit on samples axis for expected data as per indicies
-     * in sample_array. Exclusive
-     * @param factor multiplicative factor (expected value * factor = actual
-     * value). Expected value comes from rules used in file creation
-     * @param fill_flag True if fill value is expected in the whole cube
-     */
-    void check_fence(struct response response_data, std::vector<float> coordinates, int low, int high, float factor, bool fill_flag) {
-        std::size_t nr_of_values = (std::size_t)(response_data.size / sizeof(float));
-        std::size_t nr_of_traces = (std::size_t)(coordinates.size() / 2);
-
-        EXPECT_EQ(nr_of_values, nr_of_traces * (high - low));
-
-        int counter = 0;
-        float* response = (float*)response_data.data;
-        for (int t = 0; t < nr_of_traces; t++) {
-            int ic = coordinates[2 * t];
-            int xc = coordinates[(2 * t) + 1];
-            for (int s = low; s < high; ++s) {
-                float value = response[counter];
-                if (!fill_flag) {
-                    int intValue = int((value / factor) + 0.5f);
-                    int sample = intValue & 0xFF;            // Bits 0-7
-                    int xline = (intValue & 0xFF00) >> 8;    // Bits 8-15
-                    int iline = (intValue & 0xFF0000) >> 16; // Bits 15-23
-
-                    EXPECT_EQ(iline, iline_array[ic]) << "at iline coordinate " << ic << " xline coordinate " << xc << " sample " << s;
-                    EXPECT_EQ(xline, xline_array[xc]) << "at iline coordinate " << ic << " xline coordinate " << xc << " sample " << s;
-
-                    EXPECT_EQ(sample, sample_array[s]) << "at iline coordinate " << ic << " xline coordinate " << xc << " sample " << s;
-                } else {
-                    EXPECT_EQ(value, fill);
-                }
-
-                counter += 1;
-            }
-        }
-    }
-};
-
-TEST_F(DatahandleFenceTest, Fence_INDEX_Single) {
+TEST_F(DatahandleCubeIntersectionTest, Fence_INDEX_Single) {
 
     struct response response_data;
     const std::vector<float> coordinates{0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7};
-    const std::vector<float> check_coordinates{0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7};
+    const std::vector<float> check_coordinates{3, 2, 6, 4, 9, 6, 12, 8, 15, 10, 18, 12, 21, 14, 24, 16};
 
     cppapi::fence(
         single_datahandle,
@@ -134,16 +25,16 @@ TEST_F(DatahandleFenceTest, Fence_INDEX_Single) {
         &response_data
     );
 
-    int low = 0;
-    int high = 32;
+    int low = 4;
+    int high = 128;
     check_fence(response_data, check_coordinates, low, high, 1, false);
 }
 
-TEST_F(DatahandleFenceTest, Fence_INDEX_Double) {
+TEST_F(DatahandleCubeIntersectionTest, Fence_INDEX_Double) {
 
     struct response response_data;
     const std::vector<float> coordinates{0, 0, 1, 1, 2, 2, 3, 3};
-    const std::vector<float> check_coordinates{4, 4, 5, 5, 6, 6, 7, 7};
+    const std::vector<float> check_coordinates{15, 10, 18, 12, 21, 14, 24, 16};
 
     cppapi::fence(
         double_datahandle,
@@ -155,16 +46,16 @@ TEST_F(DatahandleFenceTest, Fence_INDEX_Double) {
         &response_data
     );
 
-    int low = 4;
-    int high = 32;
+    int low = 20;
+    int high = 128;
     check_fence(response_data, check_coordinates, low, high, 2, false);
 }
 
-TEST_F(DatahandleFenceTest, Fence_INDEX_Fill_Single) {
+TEST_F(DatahandleCubeIntersectionTest, Fence_INDEX_Fill_Single) {
 
     struct response response_data;
     const std::vector<float> coordinates{-1, -1, 8, 8};
-    const std::vector<float> check_coordinates{-1, -1, 8, 8};
+    const std::vector<float> check_coordinates{0, 0, 27, 18};
 
     cppapi::fence(
         single_datahandle,
@@ -176,16 +67,16 @@ TEST_F(DatahandleFenceTest, Fence_INDEX_Fill_Single) {
         &response_data
     );
 
-    int low = 0;
-    int high = 32;
+    int low = 4;
+    int high = 128;
     check_fence(response_data, check_coordinates, low, high, 1, true);
 }
 
-TEST_F(DatahandleFenceTest, Fence_INDEX_Fill_Double) {
+TEST_F(DatahandleCubeIntersectionTest, Fence_INDEX_Fill_Double) {
 
     struct response response_data;
     const std::vector<float> coordinates{-1, -1, 4, 4};
-    const std::vector<float> check_coordinates{-1, -1, 4, 4};
+    const std::vector<float> check_coordinates{12, 8, 27, 18};
 
     cppapi::fence(
         double_datahandle,
@@ -197,12 +88,12 @@ TEST_F(DatahandleFenceTest, Fence_INDEX_Fill_Double) {
         &response_data
     );
 
-    int low = 4;
-    int high = 32;
+    int low = 20;
+    int high = 128;
     check_fence(response_data, check_coordinates, low, high, 1, true);
 }
 
-TEST_F(DatahandleFenceTest, Fence_INDEX_out_Of_Bounds_Single) {
+TEST_F(DatahandleCubeIntersectionTest, Fence_INDEX_out_Of_Bounds_Single) {
 
     struct response response_data;
     const std::vector<float> coordinates{8, 8};
@@ -221,7 +112,7 @@ TEST_F(DatahandleFenceTest, Fence_INDEX_out_Of_Bounds_Single) {
                 testing::ThrowsMessage<std::runtime_error>(testing::HasSubstr("Coordinate (8.000000,8.000000) is out of boundaries in dimension 0.")));
 }
 
-TEST_F(DatahandleFenceTest, Fence_INDEX_out_Of_Bounds_Double) {
+TEST_F(DatahandleCubeIntersectionTest, Fence_INDEX_out_Of_Bounds_Double) {
 
     struct response response_data;
     const std::vector<float> coordinates{4, 4};
@@ -242,11 +133,11 @@ TEST_F(DatahandleFenceTest, Fence_INDEX_out_Of_Bounds_Double) {
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-TEST_F(DatahandleFenceTest, Fence_ANNOTATION_Single) {
+TEST_F(DatahandleCubeIntersectionTest, Fence_ANNOTATION_Single) {
 
     struct response response_data;
     const std::vector<float> coordinates{3, 2, 6, 4, 9, 6, 12, 8, 15, 10, 18, 12, 21, 14, 24, 16};
-    const std::vector<float> check_coordinates{0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7};
+    const std::vector<float> check_coordinates{3, 2, 6, 4, 9, 6, 12, 8, 15, 10, 18, 12, 21, 14, 24, 16};
 
     cppapi::fence(
         single_datahandle,
@@ -258,16 +149,16 @@ TEST_F(DatahandleFenceTest, Fence_ANNOTATION_Single) {
         &response_data
     );
 
-    int low = 0;
-    int high = 32;
+    int low = 4;
+    int high = 128;
     check_fence(response_data, check_coordinates, low, high, 1, false);
 }
 
-TEST_F(DatahandleFenceTest, Fence_ANNOTATION_Double) {
+TEST_F(DatahandleCubeIntersectionTest, Fence_ANNOTATION_Double) {
 
     struct response response_data;
     const std::vector<float> coordinates{15, 10, 18, 12, 21, 14, 24, 16};
-    const std::vector<float> check_coordinates{4, 4, 5, 5, 6, 6, 7, 7};
+    const std::vector<float> check_coordinates{15, 10, 18, 12, 21, 14, 24, 16};
 
     cppapi::fence(
         double_datahandle,
@@ -279,16 +170,16 @@ TEST_F(DatahandleFenceTest, Fence_ANNOTATION_Double) {
         &response_data
     );
 
-    int low = 4;
-    int high = 32;
+    int low = 20;
+    int high = 128;
     check_fence(response_data, check_coordinates, low, high, 2, false);
 }
 
-TEST_F(DatahandleFenceTest, Fence_ANNOTATION_Fill_Single) {
+TEST_F(DatahandleCubeIntersectionTest, Fence_ANNOTATION_Fill_Single) {
 
     struct response response_data;
     const std::vector<float> coordinates{0, 0, 27, 18};
-    const std::vector<float> check_coordinates{0, 0, 8, 8};
+    const std::vector<float> check_coordinates{0, 0, 27, 18};
 
     cppapi::fence(
         single_datahandle,
@@ -300,16 +191,16 @@ TEST_F(DatahandleFenceTest, Fence_ANNOTATION_Fill_Single) {
         &response_data
     );
 
-    int low = 0;
-    int high = 32;
+    int low = 4;
+    int high = 128;
     check_fence(response_data, check_coordinates, low, high, 1, true);
 }
 
-TEST_F(DatahandleFenceTest, Fence_ANNOTATION_Fill_Double) {
+TEST_F(DatahandleCubeIntersectionTest, Fence_ANNOTATION_Fill_Double) {
 
     struct response response_data;
     const std::vector<float> coordinates{12, 8, 27, 18};
-    const std::vector<float> check_coordinates{-1, -1, 4, 4};
+    const std::vector<float> check_coordinates{12, 8, 27, 18};
 
     cppapi::fence(
         double_datahandle,
@@ -321,12 +212,12 @@ TEST_F(DatahandleFenceTest, Fence_ANNOTATION_Fill_Double) {
         &response_data
     );
 
-    int low = 4;
-    int high = 32;
+    int low = 20;
+    int high = 128;
     check_fence(response_data, check_coordinates, low, high, 1, true);
 }
 
-TEST_F(DatahandleFenceTest, Fence_ANNOTATION_out_Of_Bounds_Single) {
+TEST_F(DatahandleCubeIntersectionTest, Fence_ANNOTATION_out_Of_Bounds_Single) {
 
     struct response response_data;
     const std::vector<float> coordinates{0, 0};
@@ -345,7 +236,7 @@ TEST_F(DatahandleFenceTest, Fence_ANNOTATION_out_Of_Bounds_Single) {
                 testing::ThrowsMessage<std::runtime_error>(testing::HasSubstr("Coordinate (0.000000,0.000000) is out of boundaries in dimension 0.")));
 }
 
-TEST_F(DatahandleFenceTest, Fence_ANNOTATION_out_Of_Bounds_Double) {
+TEST_F(DatahandleCubeIntersectionTest, Fence_ANNOTATION_out_Of_Bounds_Double) {
 
     struct response response_data;
     const std::vector<float> coordinates{4, 4};
@@ -366,11 +257,11 @@ TEST_F(DatahandleFenceTest, Fence_ANNOTATION_out_Of_Bounds_Double) {
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-TEST_F(DatahandleFenceTest, Fence_CDP_Single) {
+TEST_F(DatahandleCubeIntersectionTest, Fence_CDP_Single) {
 
     struct response response_data;
     const std::vector<float> coordinates{2, 0, 7, 12, 12, 24, 17, 36, 22, 48, 27, 60, 32, 72, 37, 84};
-    const std::vector<float> check_coordinates{0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7};
+    const std::vector<float> check_coordinates{3, 2, 6, 4, 9, 6, 12, 8, 15, 10, 18, 12, 21, 14, 24, 16};
 
     cppapi::fence(
         single_datahandle,
@@ -382,16 +273,16 @@ TEST_F(DatahandleFenceTest, Fence_CDP_Single) {
         &response_data
     );
 
-    int low = 0;
-    int high = 32;
+    int low = 4;
+    int high = 128;
     check_fence(response_data, check_coordinates, low, high, 1, false);
 }
 
-TEST_F(DatahandleFenceTest, Fence_CDP_Double) {
+TEST_F(DatahandleCubeIntersectionTest, Fence_CDP_Double) {
 
     struct response response_data;
     const std::vector<float> coordinates{22, 48, 27, 60, 32, 72, 37, 84};
-    const std::vector<float> check_coordinates{4, 4, 5, 5, 6, 6, 7, 7};
+    const std::vector<float> check_coordinates{15, 10, 18, 12, 21, 14, 24, 16};
 
     cppapi::fence(
         double_datahandle,
@@ -403,16 +294,16 @@ TEST_F(DatahandleFenceTest, Fence_CDP_Double) {
         &response_data
     );
 
-    int low = 4;
-    int high = 32;
+    int low = 20;
+    int high = 128;
     check_fence(response_data, check_coordinates, low, high, 2, false);
 }
 
-TEST_F(DatahandleFenceTest, Fence_CDP_Fill_Single) {
+TEST_F(DatahandleCubeIntersectionTest, Fence_CDP_Fill_Single) {
 
     struct response response_data;
     const std::vector<float> coordinates{-3, -12, 42, 96};
-    const std::vector<float> check_coordinates{-1, -1, 8, 8};
+    const std::vector<float> check_coordinates{0, 0, 27, 18};
 
     cppapi::fence(
         single_datahandle,
@@ -424,16 +315,16 @@ TEST_F(DatahandleFenceTest, Fence_CDP_Fill_Single) {
         &response_data
     );
 
-    int low = 0;
-    int high = 32;
+    int low = 4;
+    int high = 128;
     check_fence(response_data, check_coordinates, low, high, 1, true);
 }
 
-TEST_F(DatahandleFenceTest, Fence_CDP_Fill_Double) {
+TEST_F(DatahandleCubeIntersectionTest, Fence_CDP_Fill_Double) {
 
     struct response response_data;
     const std::vector<float> coordinates{17, 36, 42, 96};
-    const std::vector<float> check_coordinates{-1, -1, 8, 8};
+    const std::vector<float> check_coordinates{12, 8, 27, 18};
 
     cppapi::fence(
         double_datahandle,
@@ -445,12 +336,12 @@ TEST_F(DatahandleFenceTest, Fence_CDP_Fill_Double) {
         &response_data
     );
 
-    int low = 4;
-    int high = 32;
+    int low = 20;
+    int high = 128;
     check_fence(response_data, check_coordinates, low, high, 1, true);
 }
 
-TEST_F(DatahandleFenceTest, Fence_CDP_out_Of_Bounds_Single) {
+TEST_F(DatahandleCubeIntersectionTest, Fence_CDP_out_Of_Bounds_Single) {
 
     struct response response_data;
     const std::vector<float> coordinates{-3, -12};
@@ -469,7 +360,7 @@ TEST_F(DatahandleFenceTest, Fence_CDP_out_Of_Bounds_Single) {
                 testing::ThrowsMessage<std::runtime_error>(testing::HasSubstr("Coordinate (-3.000000,-12.000000) is out of boundaries in dimension 0.")));
 }
 
-TEST_F(DatahandleFenceTest, Fence_CDP_out_Of_Bounds_Double) {
+TEST_F(DatahandleCubeIntersectionTest, Fence_CDP_out_Of_Bounds_Double) {
 
     struct response response_data;
     const std::vector<float> coordinates{17, 36};
@@ -491,11 +382,11 @@ TEST_F(DatahandleFenceTest, Fence_CDP_out_Of_Bounds_Double) {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Miscellaneous tests
 
-TEST_F(DatahandleFenceTest, Fence_INDEX_Reverse_Double) {
+TEST_F(DatahandleCubeIntersectionTest, Fence_INDEX_Reverse_Double) {
 
     struct response response_data;
     const std::vector<float> coordinates{0, 0, 1, 1, 2, 2, 3, 3};
-    const std::vector<float> check_coordinates{4, 4, 5, 5, 6, 6, 7, 7};
+    const std::vector<float> check_coordinates{15, 10, 18, 12, 21, 14, 24, 16};
 
     cppapi::fence(
         double_reverse_datahandle,
@@ -507,16 +398,16 @@ TEST_F(DatahandleFenceTest, Fence_INDEX_Reverse_Double) {
         &response_data
     );
 
-    int low = 4;
-    int high = 32;
+    int low = 20;
+    int high = 128;
     check_fence(response_data, check_coordinates, low, high, 2, false);
 }
 
-TEST_F(DatahandleFenceTest, Fence_INDEX_Different_Size_Double) {
+TEST_F(DatahandleCubeIntersectionTest, Fence_INDEX_Different_Size_Double) {
 
     struct response response_data;
     const std::vector<float> coordinates{0, 0, 1, 1, 2, 2, 3, 3};
-    const std::vector<float> check_coordinates{8, 8, 9, 9, 10, 10, 11, 11};
+    const std::vector<float> check_coordinates{27, 18, 30, 20, 33, 22, 36, 24};
 
     cppapi::fence(
         double_different_size,
@@ -528,19 +419,19 @@ TEST_F(DatahandleFenceTest, Fence_INDEX_Different_Size_Double) {
         &response_data
     );
 
-    int low = 8;
-    int high = 36;
+    int low = 36;
+    int high = 144;
     check_fence(response_data, check_coordinates, low, high, 2, false);
 }
 
-TEST_F(DatahandleFenceTest, Fence_Different_Number_Of_Samples_To_Border_Per_Dimension_Double) {
+TEST_F(DatahandleCubeIntersectionTest, Fence_Different_Number_Of_Samples_To_Border_Per_Dimension_Double) {
 
     struct response response_data;
     struct response response_data_reverse;
     const std::vector<float> coordinates{0, 0, 1, 1, 2, 2, 3, 3};
-    const std::vector<float> check_coordinates{2, 3, 3, 4, 4, 5, 5, 6};
-    int low_sample_index = 1;
-    int high_sample_index = 9;
+    const std::vector<float> check_coordinates{9, 8, 12, 10, 15, 12, 18, 14};
+    int low_sample = 8;
+    int high_sample = 36;
 
     const std::string INNER_CUBE = "file://inner_4x2_cube.vds";
 
@@ -562,7 +453,7 @@ TEST_F(DatahandleFenceTest, Fence_Different_Number_Of_Samples_To_Border_Per_Dime
         &response_data
     );
 
-    check_fence(response_data, check_coordinates, low_sample_index, high_sample_index, 2, false);
+    check_fence(response_data, check_coordinates, low_sample, high_sample, 2, false);
 
     DoubleDataHandle double_overlap_handle_reverse = make_double_datahandle(
         INNER_CUBE.c_str(),
@@ -582,7 +473,7 @@ TEST_F(DatahandleFenceTest, Fence_Different_Number_Of_Samples_To_Border_Per_Dime
         &response_data_reverse
     );
 
-    check_fence(response_data_reverse, check_coordinates, low_sample_index, high_sample_index, 2, false);
+    check_fence(response_data_reverse, check_coordinates, low_sample, high_sample, 2, false);
 }
 
 } // namespace

--- a/tests/gtest/datahandle_slice_test.cpp
+++ b/tests/gtest/datahandle_slice_test.cpp
@@ -2,211 +2,128 @@
 #include "gtest/gtest.h"
 #include <iostream>
 
+#include "test_utils.hpp"
+
 #include "cppapi.hpp"
 #include "datahandle.hpp"
-#include "regularsurface.hpp"
-#include "subvolume.hpp"
 
 namespace {
 
-/// Each value in the test files has the positional information encoded in little-endian.
-/// Byte 0: Sample position
-/// Byte 1: CrossLine position
-/// Byte 2: InLine position
-const std::string REGULAR_DATA = "file://regular_8x2_cube.vds";
-const std::string SHIFT_4_DATA = "file://shift_4_8x2_cube.vds";
-const std::string SHIFT_8_BIG_DATA = "file://shift_8_32x3_cube.vds";
-const std::string CREDENTIALS = "";
+TEST_F(DatahandleCubeIntersectionTest, Slice_Axis_I_Single) {
 
-class DatahandleSliceTest : public ::testing::Test {
-protected:
-    DatahandleSliceTest() : single_datahandle(make_single_datahandle(REGULAR_DATA.c_str(), CREDENTIALS.c_str())),
-                            double_datahandle(make_double_datahandle(
-                                REGULAR_DATA.c_str(),
-                                CREDENTIALS.c_str(),
-                                SHIFT_4_DATA.c_str(),
-                                CREDENTIALS.c_str(),
-                                binary_operator::ADDITION
-                            )),
-
-                            double_reverse_datahandle(make_double_datahandle(
-                                SHIFT_4_DATA.c_str(),
-                                CREDENTIALS.c_str(),
-                                REGULAR_DATA.c_str(),
-                                CREDENTIALS.c_str(),
-                                binary_operator::ADDITION
-                            )),
-
-                            double_different_size(make_double_datahandle(
-                                SHIFT_4_DATA.c_str(),
-                                CREDENTIALS.c_str(),
-                                SHIFT_8_BIG_DATA.c_str(),
-                                CREDENTIALS.c_str(),
-                                binary_operator::ADDITION
-                            )) {}
-
-    void SetUp() override {
-        iline_array = std::vector<int>(32);
-        xline_array = std::vector<int>(32);
-        sample_array = std::vector<int>(36);
-
-        for (int i = 0; i < iline_array.size(); i++) {
-            iline_array[i] = 3 + i * 3;
-            xline_array[i] = 2 + i * 2;
-        }
-
-        for (int i = 0; i < sample_array.size(); i++) {
-            sample_array[i] = 4 + i * 4;
-        }
-    }
-
-public:
-    std::vector<int> iline_array;
-    std::vector<int> xline_array;
-    std::vector<int> sample_array;
-
-    std::vector<Bound> slice_bounds;
-
-    SingleDataHandle single_datahandle;
-    DoubleDataHandle double_datahandle;
-    DoubleDataHandle double_reverse_datahandle;
-    DoubleDataHandle double_different_size;
-
-    /**
-     * @brief Check response slice towards expected slice
-     *
-     * @param response_data Data from request
-     * @param low Low limit on axis for expected data. Array contains
-     * 3 values corresponding to indicies in iline_array, xline_array,
-     * sample_array.
-     * @param high High limit on axis for expected data. Exclusive
-     * @param factor multiplicative factor (expected value * factor = actual
-     * value). Expected value comes from rules used in file creation
-     */
-    void check_slice(struct response response_data, int low[], int high[], float factor) {
-        std::size_t nr_of_values = (std::size_t)(response_data.size / sizeof(float));
-
-        EXPECT_EQ(nr_of_values, (high[0] - low[0]) * (high[1] - low[1]) * (high[2] - low[2]));
-
-        int counter = 0;
-        auto response_samples = (float*)response_data.data;
-        for (int il = low[0]; il < high[0]; ++il) {
-            for (int xl = low[1]; xl < high[1]; ++xl) {
-                for (int s = low[2]; s < high[2]; s++) {
-                    int value = std::lround(response_samples[counter] / factor);
-                    int sample = value & 0xFF;
-                    int xline = value & 0xFF00;
-                    int iline = value & 0xFF0000;
-                    iline = iline >> 16;
-                    xline = xline >> 8;
-
-                    EXPECT_EQ(iline, iline_array[il]) << "at iline " << il << " xline " << xl << " sample " << s;
-                    EXPECT_EQ(xline, xline_array[xl]) << "at iline " << il << " xline " << xl << " sample " << s;
-                    EXPECT_EQ(sample, sample_array[s]) << "at iline " << il << " xline " << xl << " sample " << s;
-                    counter += 1;
-                }
-            }
-        }
-    }
-};
-
-TEST_F(DatahandleSliceTest, Slice_Axis_I_Single) {
+    int line_index = 2;
+    int line_annotation = 9;
 
     struct response response_data;
     cppapi::slice(
         single_datahandle,
         Direction(axis_name::I),
-        2,
+        line_index,
         slice_bounds,
         &response_data
     );
 
-    int low[3] = {2, 0, 0};
-    int high[3] = {3, 8, 32};
+    int low[3] = {line_annotation, 2, 4};
+    int high[3] = {line_annotation, 16, 128};
     check_slice(response_data, low, high, 1);
 }
 
-TEST_F(DatahandleSliceTest, Slice_Axis_I_Double) {
+TEST_F(DatahandleCubeIntersectionTest, Slice_Axis_I_Double) {
+
+    int line_index = 2;
+    int line_annotation = 21;
 
     struct response response_data;
     cppapi::slice(
         double_datahandle,
         Direction(axis_name::I),
-        2,
+        line_index,
         slice_bounds,
         &response_data
     );
 
-    int low[3] = {6, 4, 4};
-    int high[3] = {7, 8, 32};
+    int low[3] = {line_annotation, 10, 20};
+    int high[3] = {line_annotation, 16, 128};
     check_slice(response_data, low, high, 2);
 }
 
-TEST_F(DatahandleSliceTest, Slice_Axis_J_Single) {
+TEST_F(DatahandleCubeIntersectionTest, Slice_Axis_J_Single) {
+
+    int line_index = 2;
+    int line_annotation = 6;
 
     struct response response_data;
     cppapi::slice(
         single_datahandle,
         Direction(axis_name::J),
-        2,
+        line_index,
         slice_bounds,
         &response_data
     );
 
-    int low[3] = {0, 2, 0};
-    int high[3] = {8, 3, 32};
+    int low[3] = {3, line_annotation, 4};
+    int high[3] = {24, line_annotation, 128};
     check_slice(response_data, low, high, 1);
 }
 
-TEST_F(DatahandleSliceTest, Slice_Axis_J_Double) {
+TEST_F(DatahandleCubeIntersectionTest, Slice_Axis_J_Double) {
+
+    int line_index = 2;
+    int line_annotation = 14;
 
     struct response response_data;
     cppapi::slice(
         double_datahandle,
         Direction(axis_name::J),
-        2,
+        line_index,
         slice_bounds,
         &response_data
     );
 
-    int low[3] = {4, 6, 4};
-    int high[3] = {8, 7, 32};
+    int low[3] = {15, line_annotation, 20};
+    int high[3] = {24, line_annotation, 128};
     check_slice(response_data, low, high, 2);
 }
 
-TEST_F(DatahandleSliceTest, Slice_Axis_K_Single) {
+TEST_F(DatahandleCubeIntersectionTest, Slice_Axis_K_Single) {
+
+    int line_index = 2;
+    int line_annotation = 12;
 
     struct response response_data;
     cppapi::slice(
         single_datahandle,
         Direction(axis_name::K),
-        2,
+        line_index,
         slice_bounds,
         &response_data
     );
 
-    int low[3] = {0, 0, 2};
-    int high[3] = {8, 8, 3};
+    int low[3] = {3, 2, line_annotation};
+    int high[3] = {24, 16, line_annotation};
     check_slice(response_data, low, high, 1);
 }
 
-TEST_F(DatahandleSliceTest, Slice_Axis_K_Double) {
+TEST_F(DatahandleCubeIntersectionTest, Slice_Axis_K_Double) {
+
+    int line_index = 2;
+    int line_annotation = 28;
 
     struct response response_data;
     cppapi::slice(
         double_datahandle,
         Direction(axis_name::K),
-        2,
+        line_index,
         slice_bounds,
         &response_data
     );
 
-    int low[3] = {4, 4, 6};
-    int high[3] = {8, 8, 7};
+    int low[3] = {15, 10, line_annotation};
+    int high[3] = {24, 16, line_annotation};
     check_slice(response_data, low, high, 2);
 }
 
-TEST_F(DatahandleSliceTest, Slice_Axis_INLINE_Single) {
+TEST_F(DatahandleCubeIntersectionTest, Slice_Axis_INLINE_Single) {
 
     struct response response_data;
     cppapi::slice(
@@ -217,12 +134,12 @@ TEST_F(DatahandleSliceTest, Slice_Axis_INLINE_Single) {
         &response_data
     );
 
-    int low[3] = {6, 0, 0};
-    int high[3] = {7, 8, 32};
+    int low[3] = {21, 2, 4};
+    int high[3] = {21, 16, 128};
     check_slice(response_data, low, high, 1);
 }
 
-TEST_F(DatahandleSliceTest, Slice_Axis_INLINE_Double) {
+TEST_F(DatahandleCubeIntersectionTest, Slice_Axis_INLINE_Double) {
 
     struct response response_data;
     cppapi::slice(
@@ -233,12 +150,12 @@ TEST_F(DatahandleSliceTest, Slice_Axis_INLINE_Double) {
         &response_data
     );
 
-    int low[3] = {6, 4, 4};
-    int high[3] = {7, 8, 32};
+    int low[3] = {21, 10, 20};
+    int high[3] = {21, 16, 128};
     check_slice(response_data, low, high, 2);
 }
 
-TEST_F(DatahandleSliceTest, Slice_Axis_CROSSLINE_Single) {
+TEST_F(DatahandleCubeIntersectionTest, Slice_Axis_CROSSLINE_Single) {
 
     struct response response_data;
     cppapi::slice(
@@ -249,12 +166,12 @@ TEST_F(DatahandleSliceTest, Slice_Axis_CROSSLINE_Single) {
         &response_data
     );
 
-    int low[3] = {0, 6, 0};
-    int high[3] = {8, 7, 32};
+    int low[3] = {3, 14, 4};
+    int high[3] = {24, 14, 128};
     check_slice(response_data, low, high, 1);
 }
 
-TEST_F(DatahandleSliceTest, Slice_Axis_CROSSLINE_Double) {
+TEST_F(DatahandleCubeIntersectionTest, Slice_Axis_CROSSLINE_Double) {
 
     struct response response_data;
     cppapi::slice(
@@ -265,12 +182,12 @@ TEST_F(DatahandleSliceTest, Slice_Axis_CROSSLINE_Double) {
         &response_data
     );
 
-    int low[3] = {4, 6, 4};
-    int high[3] = {8, 7, 32};
+    int low[3] = {15, 14, 20};
+    int high[3] = {24, 14, 128};
     check_slice(response_data, low, high, 2);
 }
 
-TEST_F(DatahandleSliceTest, Slice_Axis_SAMPLE_Single) {
+TEST_F(DatahandleCubeIntersectionTest, Slice_Axis_SAMPLE_Single) {
 
     struct response response_data;
     cppapi::slice(
@@ -281,12 +198,12 @@ TEST_F(DatahandleSliceTest, Slice_Axis_SAMPLE_Single) {
         &response_data
     );
 
-    int low[3] = {0, 0, 9};
-    int high[3] = {8, 8, 10};
+    int low[3] = {3, 2, 40};
+    int high[3] = {24, 16, 40};
     check_slice(response_data, low, high, 1);
 }
 
-TEST_F(DatahandleSliceTest, Slice_Axis_SAMPLE_Double) {
+TEST_F(DatahandleCubeIntersectionTest, Slice_Axis_SAMPLE_Double) {
 
     struct response response_data;
     cppapi::slice(
@@ -297,12 +214,12 @@ TEST_F(DatahandleSliceTest, Slice_Axis_SAMPLE_Double) {
         &response_data
     );
 
-    int low[3] = {4, 4, 9};
-    int high[3] = {8, 8, 10};
+    int low[3] = {15, 10, 40};
+    int high[3] = {24, 16, 40};
     check_slice(response_data, low, high, 2);
 }
 
-TEST_F(DatahandleSliceTest, Slice_Axis_TIME_Single) {
+TEST_F(DatahandleCubeIntersectionTest, Slice_Axis_TIME_Single) {
 
     struct response response_data;
     cppapi::slice(
@@ -313,12 +230,12 @@ TEST_F(DatahandleSliceTest, Slice_Axis_TIME_Single) {
         &response_data
     );
 
-    int low[3] = {0, 0, 9};
-    int high[3] = {8, 8, 10};
+    int low[3] = {3, 2, 40};
+    int high[3] = {24, 16, 40};
     check_slice(response_data, low, high, 1);
 }
 
-TEST_F(DatahandleSliceTest, Slice_Axis_TIME_Double) {
+TEST_F(DatahandleCubeIntersectionTest, Slice_Axis_TIME_Double) {
 
     struct response response_data;
     cppapi::slice(
@@ -329,12 +246,12 @@ TEST_F(DatahandleSliceTest, Slice_Axis_TIME_Double) {
         &response_data
     );
 
-    int low[3] = {4, 4, 9};
-    int high[3] = {8, 8, 10};
+    int low[3] = {15, 10, 40};
+    int high[3] = {24, 16, 40};
     check_slice(response_data, low, high, 2);
 }
 
-TEST_F(DatahandleSliceTest, Slice_Axis_DEPTH_Single) {
+TEST_F(DatahandleCubeIntersectionTest, Slice_Axis_DEPTH_Single) {
 
     struct response response_data;
 
@@ -350,7 +267,7 @@ TEST_F(DatahandleSliceTest, Slice_Axis_DEPTH_Single) {
                 testing::ThrowsMessage<std::runtime_error>(testing::HasSubstr("Cannot fetch depth slice for VDS file with vertical axis unit: ms")));
 }
 
-TEST_F(DatahandleSliceTest, Slice_Axis_DEPTH_Double) {
+TEST_F(DatahandleCubeIntersectionTest, Slice_Axis_DEPTH_Double) {
 
     struct response response_data;
 
@@ -366,7 +283,7 @@ TEST_F(DatahandleSliceTest, Slice_Axis_DEPTH_Double) {
                 testing::ThrowsMessage<std::runtime_error>(testing::HasSubstr("Cannot fetch depth slice for VDS file with vertical axis unit: ms")));
 }
 
-TEST_F(DatahandleSliceTest, Slice_Axis_TIME_Invalid_Single) {
+TEST_F(DatahandleCubeIntersectionTest, Slice_Axis_TIME_Invalid_Single) {
 
     Direction const direction(axis_name::TIME);
     struct response response_data;
@@ -405,7 +322,7 @@ TEST_F(DatahandleSliceTest, Slice_Axis_TIME_Invalid_Single) {
                 testing::ThrowsMessage<std::runtime_error>(testing::HasSubstr("Invalid lineno: 21, valid range: [4.00:128.00:4.00]")));
 }
 
-TEST_F(DatahandleSliceTest, Slice_Axis_TIME_Invalid_Double) {
+TEST_F(DatahandleCubeIntersectionTest, Slice_Axis_TIME_Invalid_Double) {
 
     Direction const direction(axis_name::TIME);
     struct response response_data;
@@ -444,7 +361,7 @@ TEST_F(DatahandleSliceTest, Slice_Axis_TIME_Invalid_Double) {
                 testing::ThrowsMessage<std::runtime_error>(testing::HasSubstr("Invalid lineno: 21, valid range: [20.00:128.00:4.00]")));
 }
 
-TEST_F(DatahandleSliceTest, Slice_Axis_TIME_Reverse_Double) {
+TEST_F(DatahandleCubeIntersectionTest, Slice_Axis_TIME_Reverse_Double) {
 
     struct response response_data;
     cppapi::slice(
@@ -455,12 +372,12 @@ TEST_F(DatahandleSliceTest, Slice_Axis_TIME_Reverse_Double) {
         &response_data
     );
 
-    int low[3] = {4, 4, 9};
-    int high[3] = {8, 8, 10};
+    int low[3] = {15, 10, 40};
+    int high[3] = {24, 16, 40};
     check_slice(response_data, low, high, 2);
 }
 
-TEST_F(DatahandleSliceTest, Slice_Different_Size_Double) {
+TEST_F(DatahandleCubeIntersectionTest, Slice_Different_Size_Double) {
 
     struct response response_data;
     cppapi::slice(
@@ -471,12 +388,12 @@ TEST_F(DatahandleSliceTest, Slice_Different_Size_Double) {
         &response_data
     );
 
-    int low[3] = {9, 8, 8};
-    int high[3] = {10, 12, 36};
+    int low[3] = {30, 18, 36};
+    int high[3] = {30, 24, 144};
     check_slice(response_data, low, high, 2);
 }
 
-TEST_F(DatahandleSliceTest, Slice_Different_Number_Of_Samples_To_Border_Per_Dimension) {
+TEST_F(DatahandleCubeIntersectionTest, Slice_Different_Number_Of_Samples_To_Border_Per_Dimension) {
     const std::string INNER_CUBE = "file://inner_4x2_cube.vds";
 
     DoubleDataHandle datahandle = make_double_datahandle(
@@ -496,13 +413,13 @@ TEST_F(DatahandleSliceTest, Slice_Different_Number_Of_Samples_To_Border_Per_Dime
         &response_data
     );
 
-    int low[3] = {2, 6, 1};
-    int high[3] = {6, 7, 9};
+    int low[3] = {9, 14, 8};
+    int high[3] = {18, 14, 36};
 
     check_slice(response_data, low, high, 2);
 }
 
-TEST_F(DatahandleSliceTest, Slice_Minimum_Single) {
+TEST_F(DatahandleCubeIntersectionTest, Slice_Minimum_Single) {
 
     const std::string MINIMUM_CUBE = "file://10_min_dimensions.vds";
 
@@ -530,7 +447,7 @@ TEST_F(DatahandleSliceTest, Slice_Minimum_Single) {
     }
 }
 
-TEST_F(DatahandleSliceTest, Slice_Minimum_Double) {
+TEST_F(DatahandleCubeIntersectionTest, Slice_Minimum_Double) {
 
     const std::string SHIFT_6_DATA = "file://shift_6_8x2_cube.vds";
 

--- a/tests/gtest/test_utils.cpp
+++ b/tests/gtest/test_utils.cpp
@@ -1,0 +1,18 @@
+#include "test_utils.hpp"
+
+void DatahandleCubeIntersectionTest::check_value(
+    int value, int expected_iline, int expected_xline, int expected_sample
+) {
+    int sample = value & 0xFF;            // Bits 0-7
+    int xline = (value & 0xFF00) >> 8;    // Bits 8-15
+    int iline = (value & 0xFF0000) >> 16; // Bits 15-23
+
+    std::string error_message =
+        "at iline " + std::to_string(expected_iline) +
+        " xline " + std::to_string(expected_xline) +
+        " sample " + std::to_string(expected_sample);
+    EXPECT_EQ(iline, expected_iline) << error_message;
+    EXPECT_EQ(xline, expected_xline) << error_message;
+    EXPECT_EQ(sample, expected_sample) << error_message;
+}
+

--- a/tests/gtest/test_utils.cpp
+++ b/tests/gtest/test_utils.cpp
@@ -1,5 +1,7 @@
 #include "test_utils.hpp"
 
+#include "subvolume.hpp"
+
 void DatahandleCubeIntersectionTest::check_value(
     int value, int expected_iline, int expected_xline, int expected_sample
 ) {
@@ -16,3 +18,145 @@ void DatahandleCubeIntersectionTest::check_value(
     EXPECT_EQ(sample, expected_sample) << error_message;
 }
 
+void DatahandleCubeIntersectionTest::check_slice(
+    struct response response_data,
+    int low_annotation[],
+    int high_annotation[],
+    float factor
+) {
+    std::size_t nr_of_values = (std::size_t)(response_data.size / sizeof(float));
+
+    int low_index[3] = {
+        low_annotation[0] / ILINE_STEP,
+        low_annotation[1] / XLINE_STEP,
+        low_annotation[2] / SAMPLE_STEP
+    };
+
+    int high_index[3] = {
+        high_annotation[0] / ILINE_STEP + 1,
+        high_annotation[1] / XLINE_STEP + 1,
+        high_annotation[2] / SAMPLE_STEP + 1
+    };
+
+    EXPECT_EQ(nr_of_values, (high_index[0] - low_index[0]) * (high_index[1] - low_index[1]) * (high_index[2] - low_index[2]));
+
+    int counter = 0;
+    auto response_samples = (float*)response_data.data;
+    for (int il = low_annotation[0]; il <= high_annotation[0]; il += ILINE_STEP) {
+        for (int xl = low_annotation[1]; xl <= high_annotation[1]; xl += XLINE_STEP) {
+            for (int s = low_annotation[2]; s <= high_annotation[2]; s += SAMPLE_STEP) {
+                int value = std::lround(response_samples[counter] / factor);
+                check_value(value, il, xl, s);
+                counter += 1;
+            }
+        }
+    }
+}
+
+void DatahandleCubeIntersectionTest::check_fence(
+    struct response response_data,
+    std::vector<float> annotated_coordinates,
+    int lowest_sample,
+    int highest_sample,
+    float factor,
+    bool fill_flag
+) {
+    std::size_t nr_of_values = (std::size_t)(response_data.size / sizeof(float));
+    std::size_t nr_of_traces = (std::size_t)(annotated_coordinates.size() / 2);
+
+    int lowest_sample_index = lowest_sample / SAMPLE_STEP;
+    int highest_sample_index = highest_sample / SAMPLE_STEP + 1;
+
+    EXPECT_EQ(nr_of_values, nr_of_traces * (highest_sample_index - lowest_sample_index));
+
+    int counter = 0;
+    float* response = (float*)response_data.data;
+
+    for (int t = 0; t < nr_of_traces; t++) {
+        for (int s = lowest_sample; s <= highest_sample; s += SAMPLE_STEP) {
+            float value = response[counter];
+            if (!fill_flag) {
+                int intValue = int((value / factor) + 0.5f);
+                check_value(intValue, annotated_coordinates[2 * t], annotated_coordinates[(2 * t) + 1], s);
+            } else {
+                EXPECT_EQ(value, fill);
+            }
+
+            counter += 1;
+        }
+    }
+}
+
+void DatahandleCubeIntersectionTest::check_attribute(
+    SurfaceBoundedSubVolume& subvolume,
+    int requested_low_annotation[],
+    int requested_high_annotation[],
+    int expected_low_annotation[],
+    int expected_high_annotation[],
+    float factor
+) {
+
+    // check assumes that margin is stable for the whole grid (requested samples
+    // are at least 2 samples from the border)
+    auto margin = 2;
+
+    int requested_low_index[3] = {
+        requested_low_annotation[0] / ILINE_STEP,
+        requested_low_annotation[1] / XLINE_STEP,
+        requested_low_annotation[2] / SAMPLE_STEP - margin
+    };
+
+    int requested_high_index[3] = {
+        requested_high_annotation[0] / ILINE_STEP + 1,
+        requested_high_annotation[1] / XLINE_STEP + 1,
+        requested_high_annotation[2] / SAMPLE_STEP + 1 + margin
+    };
+
+    int expected_low_index[3] = {
+        expected_low_annotation[0] / ILINE_STEP,
+        expected_low_annotation[1] / XLINE_STEP,
+        expected_low_annotation[2] / SAMPLE_STEP - margin
+    };
+
+    int expected_high_index[3] = {
+        expected_high_annotation[0] / ILINE_STEP + 1,
+        expected_high_annotation[1] / XLINE_STEP + 1,
+        expected_high_annotation[2] / SAMPLE_STEP + 1 + margin
+    };
+
+    std::size_t nr_of_values = subvolume.nsamples(
+        0, (requested_high_index[0] - requested_low_index[0]) * (requested_high_index[1] - requested_low_index[1])
+    );
+
+    EXPECT_EQ(
+        nr_of_values,
+        (expected_high_index[0] - expected_low_index[0]) *
+            (expected_high_index[1] - expected_low_index[1]) *
+            (expected_high_index[2] - expected_low_index[2])
+    );
+
+    int counter = 0;
+    for (int il = requested_low_index[0]; il < requested_high_index[0]; ++il) {
+        for (int xl = requested_low_index[1]; xl < requested_high_index[1]; ++xl) {
+            RawSegment rs = subvolume.vertical_segment(counter);
+            counter += 1;
+
+            if (il < expected_low_index[0] || il >= expected_high_index[0] ||
+                xl < expected_low_index[1] || xl >= expected_high_index[1]) {
+                EXPECT_EQ(rs.size(), 0);
+                continue;
+            }
+            int s = expected_low_index[2];
+            for (auto it = rs.begin(); it != rs.end(); ++it) {
+                int value = int(*it / factor + 0.5f);
+                check_value(value, il * ILINE_STEP, xl * XLINE_STEP, s * SAMPLE_STEP);
+                s += 1;
+            }
+            EXPECT_EQ(s, expected_high_index[2]);
+        }
+    }
+}
+
+void DatahandleCubeIntersectionTest::check_attribute(SurfaceBoundedSubVolume& subvolume, int low[], int high[], float factor) {
+    return this->check_attribute(subvolume, low, high, low, high, factor);
+}

--- a/tests/gtest/test_utils.hpp
+++ b/tests/gtest/test_utils.hpp
@@ -53,5 +53,15 @@ public:
     DoubleDataHandle double_reverse_datahandle;
     DoubleDataHandle double_different_size;
 
+    /**
+     * @brief Checks that retrieved value and expected iline, xline and sample match as:
+     *
+     * Each value in the test files has the positional information encoded in little-endian.
+     * Byte 0: Sample position
+     * Byte 1: CrossLine position
+     * Byte 2: InLine position
+     */
+    void check_value(int value, int expected_iline, int expected_xline, int expected_sample);
+
 };
 #endif // TEST_UTILS_H

--- a/tests/gtest/test_utils.hpp
+++ b/tests/gtest/test_utils.hpp
@@ -63,5 +63,75 @@ public:
      */
     void check_value(int value, int expected_iline, int expected_xline, int expected_sample);
 
+    /**
+     * @brief Check response slice towards expected slice
+     *
+     * @param response_data Data from request
+     * @param low Low limit on axis for expected data. Array contains
+     * 3 values corresponding to inline/xline/sample annotation coordinate. Inclusive
+     * @param high High limit on axis for expected data. Array contains
+     * 3 values corresponding to inline/xline/sample annotation coordinate. Inclusive
+     * @param factor multiplicative factor (expected value * factor = actual
+     * value). Expected value comes from rules used in file creation
+     */
+    void check_slice(struct response response_data, int low_annotation[], int high_annotation[], float factor);
+
+    /**
+     * @brief Check result from fence request
+     *
+     * @param response_data Result from request
+     * @param annotated_coordinates Provided coordinates (in annotation
+     * coordinate system)
+     * @param lowest_sample Low limit on samples axis for expected data as a
+     * sample annotation coordinate. Inclusive
+     * @param highest_sample High limit on samples axis for expected data as a
+     * sample annotation coordinate. Inclusive
+     * @param factor multiplicative factor (expected value * factor = actual
+     * value). Expected value comes from rules used in file creation
+     * @param fill_flag True if fill value is expected in the whole cube
+     */
+    void check_fence(
+        struct response response_data,
+        std::vector<float> annotated_coordinates,
+        int lowest_sample,
+        int highest_sample,
+        float factor,
+        bool fill_flag
+    );
+
+    /**
+     * @brief Check attribute values against expected values
+     *
+     * @param subvolume
+     * @param requested_low Low limit on axis for requested data. Array contains
+     * 3 values corresponding to inline/xline/sample annotation coordinate.
+     * Inclusive
+     * @param requested_high High limit on axis for requested data. Inclusive
+     * @param expected_low Low limit on axis for expected returned data. Array
+     * contains 3 values corresponding to inline/xline/sample annotation
+     * coordinate. Default margin would be applied automatically. Inclusive
+     * @param expected_high High limit on axis for expected returned data.
+     * Inclusive
+     * @param factor multiplicative factor (expected value * factor = actual
+     * value). Expected value comes from rules used in file creation
+     */
+    void check_attribute(
+        SurfaceBoundedSubVolume& subvolume, int requested_low_annotation[], int requested_high_annotation[],
+        int expected_low_annotation[], int expected_high_annotation[], float factor
+    );
+
+    /**
+     * @brief Check attribute values against expected values
+     *
+     * @param subvolume
+     * @param expected_low Low limit on axis for expected returned data. Array
+     * contains 3 values corresponding to inline/xline/sample annotation
+     * coordinate. Default margin would be applied automatically. Inclusive
+     * @param expected_high High limit on axis for expected returned data.
+     * Inclusive
+     * @param factor multiplicative factor (expected value * factor = actual
+     * value). Expected value comes from rules used in file creation
+     */
+    void check_attribute(SurfaceBoundedSubVolume& subvolume, int low[], int high[], float factor);
 };
 #endif // TEST_UTILS_H

--- a/tests/gtest/test_utils.hpp
+++ b/tests/gtest/test_utils.hpp
@@ -1,0 +1,57 @@
+#ifndef TEST_UTILS_H
+#define TEST_UTILS_H
+
+#include "cppapi.hpp"
+#include "ctypes.h"
+#include <iostream>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+const std::string CREDENTIALS = "";
+static constexpr float fill = -999.25;
+
+class DatahandleCubeIntersectionTest : public ::testing::Test {
+protected:
+    const std::string REGULAR_DATA = "file://regular_8x2_cube.vds";
+    const std::string SHIFT_4_DATA = "file://shift_4_8x2_cube.vds";
+    const std::string SHIFT_8_32_DATA = "file://shift_8_32x3_cube.vds";
+
+    const int ILINE_STEP = 3;
+    const int XLINE_STEP = 2;
+    const int SAMPLE_STEP = 4;
+
+    DatahandleCubeIntersectionTest()
+        : single_datahandle(make_single_datahandle(REGULAR_DATA.c_str(), CREDENTIALS.c_str())),
+          double_datahandle(make_double_datahandle(
+              REGULAR_DATA.c_str(),
+              CREDENTIALS.c_str(),
+              SHIFT_4_DATA.c_str(),
+              CREDENTIALS.c_str(),
+              binary_operator::ADDITION
+          )),
+          double_reverse_datahandle(make_double_datahandle(
+              SHIFT_4_DATA.c_str(),
+              CREDENTIALS.c_str(),
+              REGULAR_DATA.c_str(),
+              CREDENTIALS.c_str(),
+              binary_operator::ADDITION
+          )),
+          double_different_size(make_double_datahandle(
+              SHIFT_4_DATA.c_str(),
+              CREDENTIALS.c_str(),
+              SHIFT_8_32_DATA.c_str(),
+              CREDENTIALS.c_str(),
+              binary_operator::ADDITION
+          )) {}
+
+public:
+    std::vector<Bound> slice_bounds;
+
+    SingleDataHandle single_datahandle;
+    DoubleDataHandle double_datahandle;
+    DoubleDataHandle double_reverse_datahandle;
+    DoubleDataHandle double_different_size;
+
+};
+#endif // TEST_UTILS_H


### PR DESCRIPTION
Changes the way slice/fence/attributes gtests perform verifications and make all 3 to use the same class.
(metadata tests also can be unified with them, in theory, but it is separate enough issue I didn't feel the compelling need to do)