### PR TITLE
Allow blocking requests based on ip/user-agent

### DIFF
--- a/api/middleware/request_blocker.go
+++ b/api/middleware/request_blocker.go
@@ -1,0 +1,33 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+func RequestBlocker(blockedIPs []string, blockedUserAgents []string) gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		msg := "request cannot be processed. Please contact system admin to resolve the issue"
+
+		clientIP := ctx.ClientIP()
+		for _, blockedIP := range blockedIPs {
+			blockedIP = strings.TrimSpace(blockedIP)
+			if blockedIP == clientIP {
+				ctx.AbortWithStatusJSON(http.StatusForbidden, &ErrorResponse{Error: msg})
+				return
+			}
+		}
+
+		userAgent := ctx.Request.UserAgent()
+		for _, blockedAgent := range blockedUserAgents {
+			blockedAgent = strings.TrimSpace(blockedAgent)
+			if strings.Contains(userAgent, blockedAgent) {
+				ctx.AbortWithStatusJSON(http.StatusForbidden, &ErrorResponse{Error: msg})
+				return
+			}
+		}
+		ctx.Next()
+	}
+}

--- a/cmd/query/main_test.go
+++ b/cmd/query/main_test.go
@@ -1171,6 +1171,42 @@ func TestLogHasNoSas(t *testing.T) {
 	}
 }
 
+func TestRequestBlocked(t *testing.T) {
+	testcases := []endpointTest{
+		sliceTest{
+			baseTest{
+				name:           "Blocked IP test",
+				method:         http.MethodPost,
+				expectedStatus: http.StatusForbidden,
+				expectedError:  "request cannot be processed. Please contact system admin to resolve the issue",
+				headers:        map[string]string{"X-Forwarded-For": "66.66.66.66"},
+			},
+			testSliceRequest{
+				Vds:       []string{well_known},
+				Direction: "crossline",
+				Lineno:    10,
+				Sas:       []string{"n/a"},
+			},
+		},
+
+		metadataTest{
+			baseTest{
+				name:           "Blocked User Agent test",
+				method:         http.MethodGet,
+				expectedStatus: http.StatusForbidden,
+				expectedError:  "request cannot be processed. Please contact system admin to resolve the issue",
+				headers:        map[string]string{"User-Agent": "test"},
+			},
+			testMetadataRequest{
+				Vds: []string{"unknown"},
+				Sas: []string{"n/a"},
+			},
+		},
+	}
+
+	testErrorHTTPResponse(t, testcases)
+}
+
 func testErrorHTTPResponse(t *testing.T, testcases []endpointTest) {
 	for _, testcase := range testcases {
 		w := setupTest(t, testcase)

--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -42,6 +42,8 @@ spec:
             VDSSLICE_METRICS: "true"
             VDSSLICE_METRICS_PORT: "8081"
             VDSSLICE_TRUSTED_PROXIES: ""
+            VDSSLICE_BLOCKED_IPS: ""
+            VDSSLICE_BLOCKED_USER_AGENTS: ""
           secretRefs:
             azureKeyVaults:
               - name: S067-RadixKeyvault
@@ -64,6 +66,8 @@ spec:
             VDSSLICE_METRICS: "false"
             VDSSLICE_METRICS_PORT: "8081"
             VDSSLICE_TRUSTED_PROXIES: ""
+            VDSSLICE_BLOCKED_IPS: ""
+            VDSSLICE_BLOCKED_USER_AGENTS: ""
           secretRefs:
             azureKeyVaults:
               - name: S067-RadixKeyvault
@@ -94,6 +98,8 @@ spec:
             VDSSLICE_METRICS: "false"
             VDSSLICE_METRICS_PORT: "8081"
             VDSSLICE_TRUSTED_PROXIES: ""
+            VDSSLICE_BLOCKED_IPS: ""
+            VDSSLICE_BLOCKED_USER_AGENTS: ""
           secretRefs:
             azureKeyVaults:
               - name: S067-RadixKeyvault

--- a/radixconfig_playground.yaml
+++ b/radixconfig_playground.yaml
@@ -31,6 +31,8 @@ spec:
             VDSSLICE_METRICS: "true"
             VDSSLICE_METRICS_PORT: "8081"
             VDSSLICE_TRUSTED_PROXIES: ""
+            VDSSLICE_BLOCKED_IPS: ""
+            VDSSLICE_BLOCKED_USER_AGENTS: ""
           secretRefs:
             azureKeyVaults:
               - name: S067-RadixKeyvault


### PR DESCRIPTION
We would like to prevent some requests, like slack back-linking, from spoiling our statistics.
It might not really be a solution, but lets see what it leads to.