### PR TITLE
Use new openssl in open-vds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,18 @@ RUN apk --no-cache add \
     util-linux-dev \
     perl \
     libuv-dev \
-    zlib-dev
+    zlib-dev \
+    openssl-dev
 
 ARG OPENVDS_VERSION=3.4.1
 WORKDIR /
 RUN git clone --depth 1 --branch ${OPENVDS_VERSION} https://community.opengroup.org/osdu/platform/domain-data-mgmt-services/seismic/open-vds.git
 WORKDIR /open-vds
 
+# for performance reasons open-vds should be build and run with new openssl
+# libssl is installed on alpine by default and would be used during runtime
+
+# it is unclear if curl version makes a difference and which one is better
 ARG BUILD_TYPE=Release
 RUN cmake -S . \
     -B build \
@@ -35,7 +40,9 @@ RUN cmake -S . \
     -DDISABLE_AZURE_PRESIGNED_IOMANAGER=ON \
     -DDISABLE_CURL_IOMANAGER=ON \
     -DBUILD_UV=OFF \
-    -DBUILD_ZLIB=OFF
+    -DBUILD_ZLIB=OFF \
+    -DBUILD_OPENSSL=OFF \
+    -DBUILD_CURL=ON
 
 RUN cmake --build build --config ${BUILD_TYPE} --target install -j 8 --verbose
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,9 @@ RUN apk --no-cache add \
     cmake \
     boost-dev \
     util-linux-dev \
-    perl
+    perl \
+    libuv-dev \
+    zlib-dev
 
 ARG OPENVDS_VERSION=3.4.1
 WORKDIR /
@@ -25,11 +27,15 @@ RUN cmake -S . \
     -DBUILD_EXAMPLES=OFF \
     -DBUILD_TESTS=OFF \
     -DBUILD_DOCS=OFF \
-    -DDISABLE_AWS_IOMANAGER=ON \
+    -DDISABLE_STRICT_WARNINGS=OFF \
     -DDISABLE_AZURESDKFORCPP_IOMANAGER=OFF \
+    -DDISABLE_AWS_IOMANAGER=ON \
     -DDISABLE_GCP_IOMANAGER=ON \
-    -DDISABLE_DMS_IOMANAGER=OFF \
-    -DDISABLE_STRICT_WARNINGS=OFF
+    -DDISABLE_DMS_IOMANAGER=ON \
+    -DDISABLE_AZURE_PRESIGNED_IOMANAGER=ON \
+    -DDISABLE_CURL_IOMANAGER=ON \
+    -DBUILD_UV=OFF \
+    -DBUILD_ZLIB=OFF
 
 RUN cmake --build build --config ${BUILD_TYPE} --target install -j 8 --verbose
 

--- a/tests/performance/script-random-inlineslice-wait.js
+++ b/tests/performance/script-random-inlineslice-wait.js
@@ -1,0 +1,33 @@
+import { sendSetupMetadataRequest } from "./helpers/metadata-helpers.js";
+import { sendRandomSliceRequest } from "./helpers/slice-helpers.js";
+import {
+  createSummary,
+  thresholds,
+  summaryTrendStats,
+} from "./helpers/report-helpers.js";
+import { sleep } from "k6";
+
+export const options = {
+  scenarios: {
+    randomInlineSliceWait: {
+      executor: "constant-vus",
+      vus: 1,
+      duration: "20m",
+    },
+  },
+  thresholds: thresholds(),
+  summaryTrendStats: summaryTrendStats(),
+};
+
+export function setup() {
+  return sendSetupMetadataRequest();
+}
+
+export default function (metadata) {
+  sendRandomSliceRequest(metadata, "Inline");
+  sleep(150);
+}
+
+export function handleSummary(data) {
+  return createSummary(data);
+}


### PR DESCRIPTION
Looks like the reason for slowness I've been investigating is openssl version.

Test results on slice retrieval for 500_300_2000 file with 2.5 minutes wait time between requests (which is closer to standard user pattern than hammering requests) :

Before:
`   ✓ request_time_Manual_execution...: avg=1.79s     min=1.67s    med=1.77s    max=1.92s    p(95)=1.92s    p(99)=1.92s    count=8`
After:
`   ✓ request_time_Manual_execution...: avg=1.07s    min=912.93ms med=1.06s    max=1.41s    p(95)=1.31s    p(99)=1.39s    count=8`