### PR TITLE
Monitor openvds with snyk

### DIFF
--- a/.github/workflows/snyk.yaml
+++ b/.github/workflows/snyk.yaml
@@ -5,6 +5,8 @@ on:
   workflow_dispatch:
 
 jobs:
+  # The following secrets are required:
+  # SNYK_TOKEN : token to run and upload data to snyk
   snyk_test:
     name: Snyk test
     runs-on: ubuntu-latest
@@ -40,3 +42,34 @@ jobs:
         args:
          --file=Dockerfile
          --severity-threshold=high
+
+  openvds_snyk_monitor:
+    name: openvds snyk test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Load openvds image
+      uses: "./.github/actions/load_openvds_image"
+
+    - name: Set tag name for openvds snyk monitor
+      run: |
+        tag=$(echo "${{ github.repository }}/openvds-source-${{ github.ref_name }}" \
+         | tr '[:upper:]' '[:lower:]')
+        echo "OPENVDS_SNYK_PROJECT_TAG=$tag" >> "$GITHUB_ENV"
+
+    - name: Build docker image
+      run: |
+        docker build \
+        -f Dockerfile \
+        --build-arg OPENVDS_IMAGE=${{ env.OPENVDS_IMAGE_TAG }} \
+        --target openvds_snyk_monitor \
+        --tag $OPENVDS_SNYK_PROJECT_TAG \
+        .
+
+    - name: Run Snyk to check openvds for vulnerabilities
+      run: |
+        docker run \
+        --env SNYK_TOKEN=${{ secrets.SNYK_TOKEN }} \
+        --env SNYK_PROJECT_TAG=${{ env.OPENVDS_SNYK_PROJECT_TAG }} \
+        ${{ env.OPENVDS_SNYK_PROJECT_TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,15 @@ RUN cmake -S . \
 RUN cmake --build build --config ${BUILD_TYPE} --target install -j 8 --verbose
 
 
+FROM $OPENVDS_IMAGE as openvds_snyk_monitor
+WORKDIR /
+RUN apk --no-cache add curl
+RUN curl --compressed https://downloads.snyk.io/cli/stable/snyk-alpine -o snyk
+RUN chmod +x ./snyk
+WORKDIR /open-vds
+ENTRYPOINT /snyk monitor --unmanaged --remote-repo-url=${SNYK_PROJECT_TAG}
+
+
 FROM $OPENVDS_IMAGE as builder
 WORKDIR /src
 COPY go.mod go.sum ./


### PR DESCRIPTION
What we discussed - we do not monitor openvds and we probably should, to not miss some critical issue.

I am not sure if these would somehow be repeated by snyk every couple of days (or similar), or if we would want to run the workflow on schedule.
```
  schedule:
    - cron: "05 05 * * MON"
```
We could see how it goes after some time.