### PR TITLE
Fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
     cooldown:
       default-days: 7
 
-  - package-ecosystem: "go"
+  - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "quarterly"


### PR DESCRIPTION
It turns out that the correct ecosystem name for Go is `gomod` instead of `go`. The PR should resolve [this failing job](https://github.com/equinor/oneseismic-api/runs/90247398980).